### PR TITLE
Remove Codecov secrets from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,5 @@ jobs:
       if: runner.os == 'Linux' && (matrix.cpp_compiler == 'clang++' || matrix.cpp_compiler == 'g++')
       uses: codecov/codecov-action@v5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         files: ${{ github.workspace }}/docs/coverage/coverage.info
         fail_ci_if_error: true


### PR DESCRIPTION
Code removes reference to CODECOV_TOKEN from GitHub Actions CI workflow.

Closes #23 