### PR TITLE
Exclude test directory from code coverage reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,6 +16,9 @@ parsers:
       method: true
       macro: true
 
+ignore:
+  - "tests/**"
+
 coverage:
   precision: 2
   range:


### PR DESCRIPTION
Updated CI workflow remove `tests/` folder from code coverage reports.

Closes #22 