### PR TITLE
Update Array class to better match std::array API and behaviour

### DIFF
--- a/include/dsa/array.h
+++ b/include/dsa/array.h
@@ -417,7 +417,7 @@ namespace dsa
          *
          * @param[in] other container to exchange content with
          */
-        constexpr void swap(Array<T, N>& other) noexcept
+        constexpr void swap(Array<T, N>& other) noexcept(std::is_nothrow_swappable_v<T>)
         {
             if (*this != other)
             {
@@ -513,7 +513,7 @@ namespace dsa
      * @param[in] rhs container to swap content
      */
     template<typename T, std::size_t N>
-    void swap(Array<T, N>& lhs, Array<T, N>& rhs) noexcept
+    void swap(Array<T, N>& lhs, Array<T, N>& rhs) noexcept(noexcept(lhs.swap(rhs)))
     {
         lhs.swap(rhs);
     }
@@ -588,7 +588,8 @@ namespace dsa
      * @retval false if input containers are not equal
      */
     template<typename T, std::size_t N>
-    [[nodiscard]] constexpr auto operator==(const Array<T, N>& lhs, const Array<T, N>& rhs) -> bool
+    [[nodiscard]] constexpr auto operator==(const Array<T, N>& lhs, const Array<T, N>& rhs)
+        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> bool
     {
         auto lhs_iter = lhs.cbegin();
         auto rhs_iter = rhs.cbegin();
@@ -622,7 +623,7 @@ namespace dsa
      */
     template<typename T, std::size_t N>
     [[nodiscard]] constexpr auto operator<=>(const Array<T, N>& lhs, const Array<T, N>& rhs)
-        -> std::compare_three_way_result_t<T>
+        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> std::compare_three_way_result_t<T>
     {
         auto lhs_iter = lhs.cbegin();
         auto rhs_iter = rhs.cbegin();

--- a/include/dsa/array.h
+++ b/include/dsa/array.h
@@ -610,34 +610,36 @@ namespace dsa
     /**
      * @brief The relational operator compares two Array objects
      *
+     * Depending on type T, function returns one of following objects:
+     * std::strong_ordering::less / equal / greater
+     * std::weak_ordering::less / equivalent / greater
+     * std::partial_ordering::less / equivalent / greater / unordered
+     * It is best to compare results with 0 to determine if lhs is <, >, or == to rhs
+     *
      * @param[in] lhs input container
      * @param[in] rhs input container
-     * @retval -1 if the content of \p lhs is lexicographically lesser than the content of \p rhs
-     * @retval  0 if the content of \p lhs and \p rhs is equal
-     * @retval +1 if the content of \p lhs is lexicographically greater than the content of \p rhs
+     * @return three way comparison result type
      */
     template<typename T, std::size_t N>
     [[nodiscard]] auto operator<=>(const Array<T, N>& lhs, const Array<T, N>& rhs)
+        -> std::compare_three_way_result_t<T>
     {
         auto lhs_iter = lhs.cbegin();
         auto rhs_iter = rhs.cbegin();
 
         for (size_t i = 0; i < N; i++)
         {
-            if (*lhs_iter < *rhs_iter)
+            auto cmp = *lhs_iter <=> *rhs_iter;
+            if (cmp != 0)
             {
-                return std::strong_ordering::less;
-            }
-            if (*lhs_iter > *rhs_iter)
-            {
-                return std::strong_ordering::greater;
+                return cmp;
             }
 
             lhs_iter++;
             rhs_iter++;
         }
 
-        return std::strong_ordering::equivalent;
+        return std::compare_three_way_result_t<T>::equivalent;
     }
 }
 

--- a/include/dsa/array.h
+++ b/include/dsa/array.h
@@ -15,6 +15,8 @@
 #include <cstddef>
 #include <iostream>
 #include <iterator>
+#include <type_traits>
+#include <utility>
 
 namespace dsa
 {
@@ -24,8 +26,6 @@ namespace dsa
      *
      * @tparam T type of data stored in container
      * @tparam N number of elements in container
-     *
-     * @todo add non-member to_array()
      */
     template<typename T, std::size_t N>
     struct Array
@@ -516,6 +516,74 @@ namespace dsa
     void swap(Array<T, N>& array1, Array<T, N>& array2) noexcept
     {
         array1.swap(array2);
+    }
+
+    /**
+     * @brief Helper function counts C-style array elements at compile time
+     * @tparam T data type stored in containers
+     * @tparam N number of elements in containers
+     * @tparam I compile-time index sequence used to expand array elements
+     * @param[in] array C-style array
+     * @param[in] items sequence of array indexes
+     * @return Array container of size N
+     */
+    template<typename T, std::size_t N, std::size_t... I>
+    // Intentional use of C-style array: the array bound must be part of the type
+    // to enable compile-time size deduction
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+    constexpr auto to_array_helper(T(&array)[N], std::index_sequence<I...> /* seq */) -> dsa::Array<std::remove_cv_t<T>, N>
+    {
+        return { {array[I]...} };
+    }
+
+    /**
+     * @brief Helper function counts C-style array elements at compile time
+     * @tparam T data type stored in containers
+     * @tparam N number of elements in containers
+     * @tparam I compile-time index sequence used to expand array elements
+     * @param[in] array C-style array
+     * @param[in] items sequence of array indexes
+     * @return Array container of size N
+     */
+    template<typename T, std::size_t N, std::size_t... I>
+    // Intentional use of C-style array: the array bound must be part of the type
+    // to enable compile-time size deduction
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-rvalue-reference-param-not-moved)
+    constexpr auto to_array_helper(T(&& array)[N], std::index_sequence<I...> /* seq */) -> dsa::Array<std::remove_cv_t<T>, N>
+    {
+        return { {std::move(array[I])...} };
+    }
+
+    /**
+     * @brief Creates Array from one dimensional C-style array using copy semantics
+     * @tparam T data type stored in containers
+     * @tparam N number of elements in containers
+     * @param[in] array C-style array
+     * @return Array container
+     */
+    template<typename T, std::size_t N>
+    // Intentional use of C-style array: the array bound must be part of the type
+    // to enable compile-time size deduction
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+    constexpr auto to_array(T(&array)[N]) -> Array<std::remove_cv_t<T>, N>
+    {
+        return to_array_helper(array, std::make_index_sequence<N>{});
+    }
+
+    /**
+     * @brief Creates Array from one dimensional C-style array using move semantics
+     * @tparam T data type stored in containers
+     * @tparam N number of elements in containers
+     * @param[in] array C-style array
+     * @return Array container
+     */
+    template<typename T, std::size_t N>
+    // Intentional use of C-style array: the array bound must be part of the type
+    // to enable compile-time size deduction
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+    constexpr auto to_array(T(&& array)[N]) -> Array<std::remove_cv_t<T>, N>
+    {
+        return to_array_helper(std::move(array), std::make_index_sequence<N>{});
     }
 
     /**

--- a/include/dsa/array.h
+++ b/include/dsa/array.h
@@ -509,13 +509,13 @@ namespace dsa
      *
      * @tparam T data type stored in containers
      * @tparam N number of elements in containers
-     * @param[in] array1 container to swap content
-     * @param[in] array2 container to swap content
+     * @param[in] lhs container to swap content
+     * @param[in] rhs container to swap content
      */
     template<typename T, std::size_t N>
-    void swap(Array<T, N>& array1, Array<T, N>& array2) noexcept
+    void swap(Array<T, N>& lhs, Array<T, N>& rhs) noexcept
     {
-        array1.swap(array2);
+        lhs.swap(rhs);
     }
 
     /**
@@ -582,26 +582,26 @@ namespace dsa
     /**
      * @brief The relational operator compares two Array objects
      *
-     * @param[in] array1 input container
-     * @param[in] array2 input container
-     * @retval true if containers are equal
-     * @retval false if containers are not equal
+     * @param[in] lhs input container
+     * @param[in] rhs input container
+     * @retval true if input containers are equal
+     * @retval false if input containers are not equal
      */
     template<typename T, std::size_t N>
-    [[nodiscard]] auto operator==(const Array<T, N>& array1, const Array<T, N>& array2) -> bool
+    [[nodiscard]] auto operator==(const Array<T, N>& lhs, const Array<T, N>& rhs) -> bool
     {
-        auto array1_iter = array1.cbegin();
-        auto array2_iter = array2.cbegin();
+        auto lhs_iter = lhs.cbegin();
+        auto rhs_iter = rhs.cbegin();
 
         for (size_t i = 0; i < N; i++)
         {
-            if (*array1_iter != *array2_iter)
+            if (*lhs_iter != *rhs_iter)
             {
                 return false;
             }
 
-            array1_iter++;
-            array2_iter++;
+            lhs_iter++;
+            rhs_iter++;
         }
 
         return true;
@@ -610,31 +610,31 @@ namespace dsa
     /**
      * @brief The relational operator compares two Array objects
      *
-     * @param[in] array1 input container
-     * @param[in] array2 input container
-     * @retval -1 if the content of \p array1 is lexicographically lesser than the content of \p array2
-     * @retval  0 if the content of \p array1 and \p array2 is equal
-     * @retval +1 if the content of \p array1 is lexicographically greater than the content of \p array2
+     * @param[in] lhs input container
+     * @param[in] rhs input container
+     * @retval -1 if the content of \p lhs is lexicographically lesser than the content of \p rhs
+     * @retval  0 if the content of \p lhs and \p rhs is equal
+     * @retval +1 if the content of \p lhs is lexicographically greater than the content of \p rhs
      */
     template<typename T, std::size_t N>
-    [[nodiscard]] auto operator<=>(const Array<T, N>& array1, const Array<T, N>& array2)
+    [[nodiscard]] auto operator<=>(const Array<T, N>& lhs, const Array<T, N>& rhs)
     {
-        auto array1_iter = array1.cbegin();
-        auto array2_iter = array2.cbegin();
+        auto lhs_iter = lhs.cbegin();
+        auto rhs_iter = rhs.cbegin();
 
         for (size_t i = 0; i < N; i++)
         {
-            if (*array1_iter < *array2_iter)
+            if (*lhs_iter < *rhs_iter)
             {
                 return std::strong_ordering::less;
             }
-            if (*array1_iter > *array2_iter)
+            if (*lhs_iter > *rhs_iter)
             {
                 return std::strong_ordering::greater;
             }
 
-            array1_iter++;
-            array2_iter++;
+            lhs_iter++;
+            rhs_iter++;
         }
 
         return std::strong_ordering::equivalent;

--- a/include/dsa/array.h
+++ b/include/dsa/array.h
@@ -12,6 +12,7 @@
 #ifndef ARRAY_H
 #define ARRAY_H
 
+#include <cstddef>
 #include <iostream>
 #include <iterator>
 
@@ -42,6 +43,13 @@ namespace dsa
          * @tparam T size type
          */
         using size_type = std::size_t;
+
+        /**
+         * @brief Alias for pointer difference type
+         *
+         * Used by STL to define distance between two pointers
+         */
+        using difference_type = std::ptrdiff_t;
 
         /**
          * @brief Alias for pointer to data type used in class

--- a/include/dsa/array.h
+++ b/include/dsa/array.h
@@ -526,6 +526,7 @@ namespace dsa
      * @return Array container
      */
     template<typename T, std::size_t N>
+        requires(!std::is_array_v<T>)
     // Intentional use of C-style array: the array bound must be part of the type
     // to enable compile-time size deduction
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
@@ -546,6 +547,7 @@ namespace dsa
      * @return Array container
      */
     template<typename T, std::size_t N>
+        requires(!std::is_array_v<T> && !std::is_const_v<T>)
     // Intentional use of C-style array: the array bound must be part of the type
     // to enable compile-time size deduction
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-rvalue-reference-param-not-moved)

--- a/include/dsa/array.h
+++ b/include/dsa/array.h
@@ -588,7 +588,7 @@ namespace dsa
      * @retval false if input containers are not equal
      */
     template<typename T, std::size_t N>
-    [[nodiscard]] auto operator==(const Array<T, N>& lhs, const Array<T, N>& rhs) -> bool
+    [[nodiscard]] constexpr auto operator==(const Array<T, N>& lhs, const Array<T, N>& rhs) -> bool
     {
         auto lhs_iter = lhs.cbegin();
         auto rhs_iter = rhs.cbegin();
@@ -621,7 +621,7 @@ namespace dsa
      * @return three way comparison result type
      */
     template<typename T, std::size_t N>
-    [[nodiscard]] auto operator<=>(const Array<T, N>& lhs, const Array<T, N>& rhs)
+    [[nodiscard]] constexpr auto operator<=>(const Array<T, N>& lhs, const Array<T, N>& rhs)
         -> std::compare_three_way_result_t<T>
     {
         auto lhs_iter = lhs.cbegin();

--- a/include/dsa/array.h
+++ b/include/dsa/array.h
@@ -519,42 +519,6 @@ namespace dsa
     }
 
     /**
-     * @brief Helper function counts C-style array elements at compile time
-     * @tparam T data type stored in containers
-     * @tparam N number of elements in containers
-     * @tparam I compile-time index sequence used to expand array elements
-     * @param[in] array C-style array
-     * @param[in] items sequence of array indexes
-     * @return Array container of size N
-     */
-    template<typename T, std::size_t N, std::size_t... I>
-    // Intentional use of C-style array: the array bound must be part of the type
-    // to enable compile-time size deduction
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-    constexpr auto to_array_helper(T(&array)[N], std::index_sequence<I...> /* seq */) -> dsa::Array<std::remove_cv_t<T>, N>
-    {
-        return { {array[I]...} };
-    }
-
-    /**
-     * @brief Helper function counts C-style array elements at compile time
-     * @tparam T data type stored in containers
-     * @tparam N number of elements in containers
-     * @tparam I compile-time index sequence used to expand array elements
-     * @param[in] array C-style array
-     * @param[in] items sequence of array indexes
-     * @return Array container of size N
-     */
-    template<typename T, std::size_t N, std::size_t... I>
-    // Intentional use of C-style array: the array bound must be part of the type
-    // to enable compile-time size deduction
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-rvalue-reference-param-not-moved)
-    constexpr auto to_array_helper(T(&& array)[N], std::index_sequence<I...> /* seq */) -> dsa::Array<std::remove_cv_t<T>, N>
-    {
-        return { {std::move(array[I])...} };
-    }
-
-    /**
      * @brief Creates Array from one dimensional C-style array using copy semantics
      * @tparam T data type stored in containers
      * @tparam N number of elements in containers
@@ -567,7 +531,11 @@ namespace dsa
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     constexpr auto to_array(T(&array)[N]) -> Array<std::remove_cv_t<T>, N>
     {
-        return to_array_helper(array, std::make_index_sequence<N>{});
+        return[&]<std::size_t... I>(std::index_sequence<I...>)
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+            return dsa::Array<std::remove_cv_t<T>, N>{array[I]...};
+        }(std::make_index_sequence<N>{});
     }
 
     /**
@@ -580,10 +548,14 @@ namespace dsa
     template<typename T, std::size_t N>
     // Intentional use of C-style array: the array bound must be part of the type
     // to enable compile-time size deduction
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-rvalue-reference-param-not-moved)
     constexpr auto to_array(T(&& array)[N]) -> Array<std::remove_cv_t<T>, N>
     {
-        return to_array_helper(std::move(array), std::make_index_sequence<N>{});
+        return[&]<std::size_t... I>(std::index_sequence<I...>)
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+            return dsa::Array<std::remove_cv_t<T>, N>{std::move(array[I])...};
+        }(std::make_index_sequence<N>{});
     }
 
     /**

--- a/include/dsa/array.h
+++ b/include/dsa/array.h
@@ -444,7 +444,7 @@ namespace dsa
      * @return T& reference to Ith element of array container
      */
     template<std::size_t I, typename T, std::size_t N>
-    constexpr auto get(Array<T, N>& array) noexcept -> T&
+    [[nodiscard]] constexpr auto get(Array<T, N>& array) noexcept -> T&
     {
         static_assert(I < N, "Index out of range in dsa::Array::get");
         return array[I];
@@ -460,7 +460,7 @@ namespace dsa
      * @return const T& reference to Ith element of array container
      */
     template<std::size_t I, typename T, std::size_t N>
-    constexpr auto get(const Array<T, N>& array) noexcept -> const T&
+    [[nodiscard]] constexpr auto get(const Array<T, N>& array) noexcept -> const T&
     {
         static_assert(I < N, "Index out of range in dsa::Array::get");
         return array[I];
@@ -482,7 +482,7 @@ namespace dsa
      */
     template<std::size_t I, typename T, std::size_t N>
     // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
-    constexpr auto get(Array<T, N>&& array) noexcept -> T&&
+    [[nodiscard]] constexpr auto get(Array<T, N>&& array) noexcept -> T&&
     {
         static_assert(I < N, "Index out of range in dsa::Array::get");
         return std::move(array[I]);
@@ -498,7 +498,7 @@ namespace dsa
      * @return const T&& reference to Ith element of array container
      */
     template<std::size_t I, typename T, std::size_t N>
-    constexpr auto get(const Array<T, N>&& array) noexcept -> const T&&
+    [[nodiscard]] constexpr auto get(const Array<T, N>&& array) noexcept -> const T&&
     {
         static_assert(I < N, "Index out of range in dsa::Array::get");
         return std::move(array[I]);
@@ -530,7 +530,7 @@ namespace dsa
     // Intentional use of C-style array: the array bound must be part of the type
     // to enable compile-time size deduction
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-    constexpr auto to_array(T(&array)[N]) -> Array<std::remove_cv_t<T>, N>
+    [[nodiscard]] constexpr auto to_array(T(&array)[N]) -> Array<std::remove_cv_t<T>, N>
     {
         return[&]<std::size_t... I>(std::index_sequence<I...>)
         {
@@ -551,7 +551,7 @@ namespace dsa
     // Intentional use of C-style array: the array bound must be part of the type
     // to enable compile-time size deduction
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-rvalue-reference-param-not-moved)
-    constexpr auto to_array(T(&& array)[N]) -> Array<std::remove_cv_t<T>, N>
+    [[nodiscard]] constexpr auto to_array(T(&& array)[N]) -> Array<std::remove_cv_t<T>, N>
     {
         return[&]<std::size_t... I>(std::index_sequence<I...>)
         {
@@ -588,7 +588,7 @@ namespace dsa
      * @retval false if containers are not equal
      */
     template<typename T, std::size_t N>
-    auto operator==(const Array<T, N>& array1, const Array<T, N>& array2) -> bool
+    [[nodiscard]] auto operator==(const Array<T, N>& array1, const Array<T, N>& array2) -> bool
     {
         auto array1_iter = array1.cbegin();
         auto array2_iter = array2.cbegin();
@@ -617,7 +617,7 @@ namespace dsa
      * @retval +1 if the content of \p array1 is lexicographically greater than the content of \p array2
      */
     template<typename T, std::size_t N>
-    auto operator<=>(const Array<T, N>& array1, const Array<T, N>& array2)
+    [[nodiscard]] auto operator<=>(const Array<T, N>& array1, const Array<T, N>& array2)
     {
         auto array1_iter = array1.cbegin();
         auto array2_iter = array2.cbegin();

--- a/tests/array/array_operators_test.cpp
+++ b/tests/array/array_operators_test.cpp
@@ -13,6 +13,7 @@
 #include "dsa/array.h"
 
 #include <array>
+#include <compare>
 #include <exception>
 #include <iostream>
 

--- a/tests/array/array_operators_test.cpp
+++ b/tests/array/array_operators_test.cpp
@@ -13,9 +13,12 @@
 #include "dsa/array.h"
 
 #include <array>
+#include <cassert>
 #include <compare>
 #include <exception>
 #include <iostream>
+#include <limits>
+#include <type_traits>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -75,6 +78,19 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Array1 <=> Array3 ==", (Array1 <=> Array3) == std::weak_ordering::equivalent, true);
         tests::compare("Array1 <=> Array3 <=", (Array1 <=> Array3) != std::weak_ordering::greater, true);
 
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::Array<int, 3>>, std::strong_ordering>,
+            "Int array should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::Array<double, 3>>, std::partial_ordering>,
+            "Double array should support strong ordering");
+
+        // test partial ordering
+        const dsa::Array<double, 3> Array4{ 1.0, 2.0, 3.0 };
+        const dsa::Array<double, 3> Array5{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() };
+        assert((Array4 <=> Array5) == std::partial_ordering::unordered);
+        tests::compare("Array4 <=> Array5 weak ordering", (Array1 <=> Array3) != std::weak_ordering::less, true);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -127,6 +143,23 @@ int main() // NOLINT(modernize-use-trailing-return-type)
             (Array1 <=> Array3) == std::weak_ordering::equivalent, (std_Array1 <=> std_Array3) == std::weak_ordering::equivalent);
         tests::compare("Array1 <=> Array3 vs std <= ",
             (Array1 <=> Array3) != std::weak_ordering::greater, (std_Array1 <=> std_Array3) != std::weak_ordering::greater);
+
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::array<int, 3>>, std::strong_ordering>,
+            "Int array should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::array<double, 3>>, std::partial_ordering>,
+            "Double array should support strong ordering");
+
+        // test partial ordering
+        const std::array<double, 3> std_Array4{ 1.0, 2.0, 3.0 };
+        const std::array<double, 3> std_Array5{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() };
+        assert((std_Array4 <=> std_Array5) == std::partial_ordering::unordered);
+        assert((Array4 <=> Array5) == (std_Array4 <=> std_Array5));
+        tests::compare("std_Array4 <=> std_Array5 weak ordering",
+            (std_Array4 <=> std_Array5) == std::partial_ordering::unordered, true);
+        tests::compare("(Array4 <=> Array5) == (std_Array4 <=> std_Array5)",
+            (Array4 <=> Array5) == (std_Array4 <=> std_Array5), true);
 
 
         tests::print_stats();

--- a/tests/array/array_ranges_test.cpp
+++ b/tests/array/array_ranges_test.cpp
@@ -21,9 +21,7 @@
 #include <list>
 #include <numeric>
 #include <ranges>
-#include <tuple>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
@@ -183,7 +181,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const int sum = std::accumulate(array3.begin(), array3.end(), 0);
         tests::compare("Array3 sum", sum, 80);
         std::list<int> expected3;
-        std::ranges::for_each(array3, [&](int item) {expected3.push_back(item); });
+        std::ranges::for_each(array3, [&](int item) { expected3.push_back(item); });
         tests::compare("Array3 for_each() equal()",
             std::ranges::equal(expected3, std::list{ 30, 10, 40 }), true);
 

--- a/tests/array/array_test.cpp
+++ b/tests/array/array_test.cpp
@@ -21,6 +21,7 @@
 #include <iterator>
 #include <stdexcept>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
@@ -427,6 +428,36 @@ int main() // NOLINT(modernize-use-trailing-return-type)
             }();
         static_assert(array20[0] == 100);
 
+        // Test to_array
+        // Intentional use of C-style array
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        const int temp21[] = { 1, 2, 3, 4 };
+        const dsa::Array<int, 4> array21 = dsa::to_array(temp21);
+        const std::initializer_list<int> expected21{ 1, 2, 3, 4 };
+        tests::compare("Array21", array21, expected21);
+
+        // Intentional use of C-style array
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        const std::string temp22[] = { "A", "B", "C" };
+        auto array22 = dsa::to_array(temp22);
+        const std::initializer_list<std::string> expected22{ "A", "B", "C" };
+        tests::compare("Array22", array22, expected22);
+
+        auto array23 = dsa::to_array<std::string>({ std::string{"A"}, std::string{"B"}, std::string{"C"} });
+        const std::initializer_list<std::string> expected23{ "A", "B", "C" };
+        tests::compare("Array23", array23, expected23);
+
+        // Intentional use of C-style arrays
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        auto array24 = dsa::to_array<std::string>({ std::string{"A"}, std::string{"B"}, std::string{"C"} });
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        std::string array25[] = { "X", "Y", "Z" };
+        array24 = dsa::to_array(std::move(array25));
+        const std::initializer_list<std::string> expected24{ "X", "Y", "Z" };
+        const std::initializer_list<std::string> expected25{ "", "", "" };
+        tests::compare("Array24", array24, expected24);
+        tests::compare("Array25", dsa::to_array(array25), expected25);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -602,6 +633,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
                 return std_tmp;
             }();
         static_assert(std_array20[0] == 100);
+
+        // Test to_array
+        const std::array<int, 4> std_array21 = std::to_array(temp21);
+        tests::compare("Array21 vs std", array21, std_array21);
+
+        auto std_array22 = std::to_array(temp22);
+        tests::compare("Array22 vs std", array22, std_array22);
+
+        auto std_array23 = std::to_array<std::string>({ std::string{"A"}, std::string{"B"}, std::string{"C"} });
+        tests::compare("Array23 vs std", array23, std_array23);
 
 
         tests::print_stats();

--- a/tests/array/array_test.cpp
+++ b/tests/array/array_test.cpp
@@ -12,7 +12,6 @@
 #include "common.h"
 #include "dsa/array.h"
 
-#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <exception>
@@ -20,6 +19,7 @@
 #include <iostream>
 #include <iterator>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/tests/array/array_test.cpp
+++ b/tests/array/array_test.cpp
@@ -42,6 +42,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const dsa::Array<int, 3> array2 = { 0, 10, 20 };
         tests::compare("Array2", array2, { 0, 10, 20 });
 
+        dsa::Array<int, 3> array2b = { 0, 10, 20 };
+        array2b = array1;
+        tests::compare("Array2b = Array1", array2b, { 0, 1, 2 });
+
         // Test element access
         dsa::Array<int, 3> array3{ 10, 20, 30 };
         tests::compare("Array3 front()", array3.front(), 10);
@@ -467,6 +471,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         const std::array<int, 3> std_array2 = { 0, 10, 20 };
         tests::compare("Array2 vs std", array2, std_array2);
+
+        std::array<int, 3> std_array2b = { 0, 10, 20 };
+        std_array2b = std_array1;
+        tests::compare("Array2b = Array1", array2b, std_array2b);
 
         // Test element access
         std::array<int, 3> std_array3{ 10, 20, 30 };

--- a/tests/common.h
+++ b/tests/common.h
@@ -19,17 +19,24 @@
 #include "dsa/stack.h"
 #include "dsa/vector.h"
 
-#include <concepts>
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <exception>
 #include <forward_list>
 #include <initializer_list>
 #include <iomanip>
+#include <ios>
 #include <iostream>
+#include <iterator>
 #include <list>
 #include <optional>
 #include <queue>
 #include <ranges>
 #include <source_location>
 #include <stack>
+#include <string>
+#include <vector>
 
  /**
   * @brief Namespace with test results


### PR DESCRIPTION
Update `dsa::Array` implementation to better match std::array API and behaviour.

Closes #35

## Checklist
- [x] add non-member to_array() function with internal lambda to prevent pollution of namespace with helper function
- [x] fix `operator<=>` to handle strong, weak and partial ordering
- [x] add `constexpr` keyword to use container during compilation
- [x] arguments of `swap`, `operator==` and `operator<=>` were renamed to lhs/rhs to match convention
- [x] add `[[nodiscard]]` to detect operations that whose result should be handled
- [x] verified functions declarations and definitions
- [x] update tests to match features provided by updated implementation
