### PR TITLE
Update ForwardList class to better match std::forward_list API and behaviour

### DIFF
--- a/dsa.natvis
+++ b/dsa.natvis
@@ -35,8 +35,8 @@
 		<Expand>
 			<LinkedListItems>
 				<Size>m_size</Size>
-				<HeadPointer>m_head._Mypair._Myval2->m_next._Mypair._Myval2</HeadPointer>
-				<NextPointer>m_next._Mypair._Myval2</NextPointer>
+				<HeadPointer>m_head->m_next</HeadPointer>
+				<NextPointer>m_next</NextPointer>
 				<ValueNode>(*this)</ValueNode>
 			</LinkedListItems>
 		</Expand>
@@ -45,10 +45,6 @@
 	
 	<Type Name="dsa::ForwardList&lt;*&gt;::Node">
 		<DisplayString>{m_value}</DisplayString>
-		<Expand>
-			<Item Name="Value">m_value</Item>
-			<Item Name="NextPtr">m_next._Mypair._Myval2</Item>
-		</Expand>
 	</Type>
 	
 	

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -981,6 +981,31 @@ namespace dsa
         }
 
         /**
+         * @brief Function allocate and construct ForwardList node
+         *
+         * @param[in] value element of type T to be inserted
+         * @param[in] next_ptr pointer to next Node
+         * @return pointer to created Node
+         */
+        auto construct_node(T&& value, NodeBase* next_ptr = nullptr) -> Node*
+        {
+            Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
+            try
+            {
+                node_alloc_traits::construct(node_alloc, newNode, Node(std::move(value)));
+            }
+            catch (...)
+            {
+                node_alloc_traits::deallocate(node_alloc, newNode, 1);
+                throw;
+            }
+
+            newNode->m_next = next_ptr;
+
+            return newNode;
+        }
+
+        /**
          * @brief Function destroys and deallocates memory used by Node
          *
          * @param[in] node_to_destroy pointer to Node to delete

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -969,6 +969,17 @@ namespace dsa
         auto unique() -> size_type;
 
         /**
+         * @brief Function removes consecutive duplicated elements
+         * @details Only the first occurrence of given element in each group is preserved
+         *
+         * @tparam BinaryPred
+         * @param[in] predicate binary predicate which returns \p true if the element should be treated as equal
+         * @return size_type number of elements removed
+         */
+        template<typename BinaryPred>
+        auto unique(BinaryPred predicate) -> size_type;
+
+        /**
          * @brief Function sorts the elements and preserves the order of equivalent elements
          *
          * @details elements are compared using \p operator<
@@ -2040,6 +2051,13 @@ namespace dsa
     template<typename T>
     auto ForwardList<T>::unique() -> size_type
     {
+        return unique(std::equal_to<>());
+    }
+
+    template<typename T>
+    template<typename BinaryPred>
+    auto ForwardList<T>::unique(BinaryPred predicate) -> size_type
+    {
         NodeBase* temp{ m_head };
         NodeBase* prev{};
         NodeBase* next{};
@@ -2058,7 +2076,7 @@ namespace dsa
                 Node* node_temp = dynamic_cast<Node*>(temp);
                 if (node_next && node_temp)
                 {
-                    if (node_next->value() == node_temp->value())
+                    if (predicate(node_next->value(), node_temp->value()))
                     {
                         NodeBase* to_remove = next;
                         prev->m_next = to_remove->m_next;

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -37,7 +37,6 @@ namespace dsa
      *
      * @tparam T type of data stored in ForwardList Node
      *
-     * @todo add operator<=>
      * @todo add non-member specialized swap function
      * @todo add non-member specialized erase function
      * @todo add non-member specialized erase_if function
@@ -2055,31 +2054,32 @@ namespace dsa
      * @brief The relational operator compares two ForwardList objects
      *
      * @tparam T type of data stored in ForwardList
-     * @param[in] list1 input container
-     * @param[in] list2 input container
+     * @param[in] lhs input container
+     * @param[in] rhs input container
      * @retval true if containers are equal
      * @retval false if containers are not equal
      */
     template<typename T>
-    auto operator==(const ForwardList<T>& list1, const ForwardList<T>& list2) -> bool
+    [[nodiscard]] auto operator==(const ForwardList<T>& lhs, const ForwardList<T>& rhs)
+        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> bool
     {
-        if (list1.size() != list2.size())
+        if (lhs.size() != rhs.size())
         {
             return false;
         }
 
-        auto list1_iter = list1.cbegin();
-        auto list2_iter = list2.cbegin();
+        auto lhs_iter = lhs.cbegin();
+        auto rhs_iter = rhs.cbegin();
 
-        while (list1_iter != list1.cend())
+        while (lhs_iter != lhs.cend())
         {
-            if (*list1_iter != *list2_iter)
+            if (*lhs_iter != *rhs_iter)
             {
                 return false;
             }
 
-            list1_iter++;
-            list2_iter++;
+            lhs_iter++;
+            rhs_iter++;
         }
 
         return true;
@@ -2088,100 +2088,38 @@ namespace dsa
     /**
      * @brief The relational operator compares two ForwardList objects
      *
-     * @tparam T type of data stored in ForwardList
-     * @param[in] list1 input container
-     * @param[in] list2 input container
-     * @retval true if containers are not equal
-     * @retval false if containers are equal
-     */
-    template<typename T>
-    auto operator!=(const ForwardList<T>& list1, const ForwardList<T>& list2) -> bool
-    {
-        return !(operator==(list1, list2));
-    }
-
-    /**
-     * @brief The relational operator compares two ForwardList objects
+     * Depending on type T, function returns one of following objects:
+     * std::strong_ordering::less / equal / greater
+     * std::weak_ordering::less / equivalent / greater
+     * std::partial_ordering::less / equivalent / greater / unordered
+     * It is best to compare results with 0 to determine if lhs is <, >, or == to rhs
      *
-     * @tparam T type of data stored in ForwardList
-     * @param[in] list1 input container
-     * @param[in] list2 input container
-     * @retval true if the content of \p list1 are lexicographically
-     *         less than the content of \p list2
-     * @retval false otherwise
+     * @param[in] lhs input container
+     * @param[in] rhs input container
+     * @return three way comparison result type
      */
     template<typename T>
-    auto operator<(const ForwardList<T>& list1, const ForwardList<T>& list2) -> bool
+    [[nodiscard]] auto operator<=>(const ForwardList<T>& lhs, const ForwardList<T>& rhs)
+        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> std::compare_three_way_result_t<T>
     {
-        auto list1_iter = list1.cbegin();
-        auto list2_iter = list2.cbegin();
+        auto lhs_iter = lhs.cbegin();
+        auto rhs_iter = rhs.cbegin();
 
-        while (list1_iter != list1.cend() && list2_iter != list2.cend())
+        while (lhs_iter != lhs.cend() && rhs_iter != rhs.cend())
         {
-            if (*list1_iter > *list2_iter)
+            auto cmp = *lhs_iter <=> *rhs_iter;
+            if (cmp != 0)
             {
-                return false;
-            }
-            if (*list1_iter < *list2_iter)
-            {
-                return true;
+                return cmp;
             }
 
-            list1_iter++;
-            list2_iter++;
+            lhs_iter++;
+            rhs_iter++;
         }
 
         // first n elements are equal
         // check sizes
-        return list1.size() < list2.size();
-    }
-
-    /**
-     * @brief The relational operator compares two ForwardList objects
-     *
-     * @tparam T type of data stored in ForwardList
-     * @param[in] list1 input container
-     * @param[in] list2 input container
-     * @retval true if the content of \p list1 are lexicographically
-     *         greater than the content of \p list2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator>(const ForwardList<T>& list1, const ForwardList<T>& list2) -> bool
-    {
-        return operator<(list2, list1);
-    }
-
-    /**
-     * @brief The relational operator compares two ForwardList objects
-     *
-     * @tparam T type of data stored in ForwardList
-     * @param[in] list1 input container
-     * @param[in] list2 input container
-     * @retval true if the content of \p list1 are lexicographically
-     *         less or equal than the content of \p list2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator<=(const ForwardList<T>& list1, const ForwardList<T>& list2) -> bool
-    {
-        return !(operator>(list1, list2));
-    }
-
-    /**
-     * @brief The relational operator compares two ForwardList objects
-     *
-     * @tparam T type of data stored in ForwardList
-     * @param[in] list1 input container
-     * @param[in] list2 input container
-     * @retval true if the content of \p list1 are lexicographically
-     *         greater or equal than the content of \p list2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator>=(const ForwardList<T>& list1, const ForwardList<T>& list2) -> bool
-    {
-        return !(operator<(list1, list2));
+        return lhs.size() <=> rhs.size();
     }
 }
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -37,7 +37,6 @@ namespace dsa
      *
      * @tparam T type of data stored in ForwardList Node
      *
-     * @todo add non-member specialized swap function
      * @todo add non-member specialized erase function
      * @todo add non-member specialized erase_if function
      * @todo remove public functions / operators not supported by std::forward_list
@@ -727,7 +726,7 @@ namespace dsa
          *
          * @param[in,out] other object to swap content with
          */
-        void swap(ForwardList<T>& other) noexcept;
+        void swap(ForwardList<T>& other) noexcept(std::is_nothrow_swappable_v<T>);
 
         /**
          * @brief Function combines two sorted ForwardLists into one sorted ForwardList
@@ -1617,7 +1616,7 @@ namespace dsa
     }
 
     template<typename T>
-    void ForwardList<T>::swap(ForwardList<T>& other) noexcept
+    void ForwardList<T>::swap(ForwardList<T>& other) noexcept(std::is_nothrow_swappable_v<T>)
     {
         std::swap(m_head->m_next, other.m_head->m_next);
         std::swap(m_size, other.m_size);
@@ -2120,6 +2119,19 @@ namespace dsa
         // first n elements are equal
         // check sizes
         return lhs.size() <=> rhs.size();
+    }
+
+    /**
+     * @brief Exchanges content of two ForwardList containers
+     *
+     * @tparam T data type stored in containers
+     * @param[in] lhs container to swap content
+     * @param[in] rhs container to swap content
+     */
+    template<typename T>
+    void swap(ForwardList<T>& lhs, ForwardList<T>& rhs) noexcept(noexcept(lhs.swap(rhs)))
+    {
+        lhs.swap(rhs);
     }
 }
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1467,20 +1467,10 @@ namespace dsa
     {
         const iterator current{ pos.m_current_node };
 
-        Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
-        try
-        {
-            node_alloc_traits::construct(node_alloc, newNode, std::forward<Args>(args)...);
-            newNode->m_next = current.m_current_node->m_next;
-        }
-        catch (...)
-        {
-            node_alloc_traits::deallocate(node_alloc, newNode, 1);
-            throw;
-        }
-
+        Node* newNode{ construct_node(current.m_current_node->m_next, std::forward<Args>(args)...) };
         current.m_current_node->m_next = newNode;
         ++m_size;
+
         return iterator(newNode);
     }
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1039,28 +1039,6 @@ namespace dsa
         void destroy_node(NodeBase* node_to_destroy);
 
         /**
-         * @brief Function inserts new Node after specified ForwardList iterator
-         *
-         * @param[in] pos iterator to insert element after
-         * @param[in] value element of type T to be inserted
-         * @return pointer to next element
-         * @retval iterator to iterator inserted after \pos
-         * @retval nullptr if invalid iterator
-         */
-        auto insert_element_after(iterator& pos, const_reference value) -> iterator;
-
-        /**
-         * @brief Function inserts new Node after specified ForwardList iterator
-         *
-         * @param[in] pos iterator to insert element after
-         * @param[in] value element of type T to be inserted
-         * @return pointer to next element
-         * @retval iterator to iterator inserted after \pos
-         * @retval nullptr if invalid iterator
-         */
-        auto insert_element_after(iterator& pos, T&& value) -> iterator;
-
-        /**
          * @brief Function checks ForwardList contains iterator
          *
          * @param[in] pos iterator to check
@@ -2122,26 +2100,6 @@ namespace dsa
             node_alloc_traits::destroy(node_alloc, node_dyn);
             node_alloc_traits::deallocate(node_alloc, node_dyn, 1);
         }
-    }
-
-    template<typename T>
-    auto ForwardList<T>::insert_element_after(iterator& pos, const_reference value) -> iterator
-    {
-        NodeBase* temp{ pos.m_current_node };
-        Node* newNode = construct_node(value, temp->m_next);
-        temp->m_next = newNode;
-        m_size++;
-        return iterator(newNode);
-    }
-
-    template<typename T>
-    auto ForwardList<T>::insert_element_after(iterator& pos, T&& value) -> iterator
-    {
-        NodeBase* temp{ pos.m_current_node };
-        Node* newNode = construct_node(std::move(value), temp->m_next);
-        temp->m_next = newNode;
-        m_size++;
-        return iterator(newNode);
     }
 
     template<typename T>

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1549,35 +1549,13 @@ namespace dsa
     template<typename T>
     void ForwardList<T>::push_front(const_reference value)
     {
-        Node* newNode = construct_node(value);
-        if (!m_head->m_next)
-        {
-            m_head->m_next = newNode;
-        }
-        else
-        {
-            newNode->m_next = m_head->m_next;
-            m_head->m_next = newNode;
-        }
-
-        m_size++;
+        emplace_after(before_begin(), value);
     }
 
     template<typename T>
     void ForwardList<T>::push_front(T&& value)
     {
-        Node* newNode = construct_node(std::move(value));
-        if (!m_head->m_next)
-        {
-            m_head->m_next = newNode;
-        }
-        else
-        {
-            newNode->m_next = m_head->m_next;
-            m_head->m_next = newNode;
-        }
-
-        m_size++;
+        emplace_after(before_begin(), std::move(value));
     }
 
     template<typename T>

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -495,6 +495,17 @@ namespace dsa
         void assign(size_type count, const_reference value);
 
         /**
+         * @brief Function assign elements from range [ \p first , \p last ) to ForwardList object
+         *
+         * @tparam InputIt
+         * @param[in] first element defining range of elements to insert
+         * @param[in] last element definig range of elements to insert
+         */
+        template<typename InputIt>
+            requires std::input_iterator<InputIt>
+        void assign(InputIt first, InputIt last);
+
+        /**
          * @brief Function assign values to the ForwardList
          *
          * @param[in] init_list values to replace ForwardList with
@@ -1200,6 +1211,21 @@ namespace dsa
         for (size_type i = 0; i < count; i++)
         {
             iter = insert_after(iter, value);
+        }
+    }
+
+    template<typename T>
+    template<typename InputIt>
+        requires std::input_iterator<InputIt>
+    void ForwardList<T>::assign(InputIt first, InputIt last)
+    {
+        clear();
+
+        auto iter = before_begin();
+        while (first != last)
+        {
+            iter = insert_after(iter, *first);
+            first++;
         }
     }
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -895,6 +895,7 @@ namespace dsa
         {
             if (m_head == nullptr)
             {
+                // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
                 m_head = new NodeBase;
             }
         }

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -735,8 +735,23 @@ namespace dsa
          * @brief Function adds new Node at the beginning of ForwardList
          *
          * @param[in] value element of type T
+         *
+         * @note no iterators or references are invalidated,
+         *       if construction of new element fails or an exception is thrown for any reason
+         *       state of the object does not change and this function has no effect
          */
         void push_front(const_reference value);
+
+        /**
+         * @brief Function adds new Node at the beginning of ForwardList
+         *
+         * @param[in] value element of type T
+         *
+         * @note no iterators or references are invalidated,
+         *       if construction of new element fails or an exception is thrown for any reason
+         *       state of the object does not change and this function has no effect
+         */
+        void push_front(T&& value);
 
         /**
          * @brief Inserts a new element to the beginning of the container
@@ -1584,6 +1599,23 @@ namespace dsa
     void ForwardList<T>::push_front(const_reference value)
     {
         Node* newNode = construct_node(value);
+        if (!m_head->m_next)
+        {
+            m_head->m_next = newNode;
+        }
+        else
+        {
+            newNode->m_next = m_head->m_next;
+            m_head->m_next = newNode;
+        }
+
+        m_size++;
+    }
+
+    template<typename T>
+    void ForwardList<T>::push_front(T&& value)
+    {
+        Node* newNode = construct_node(std::move(value));
         if (!m_head->m_next)
         {
             m_head->m_next = newNode;

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -364,6 +364,13 @@ namespace dsa
         using size_type = std::size_t;
 
         /**
+         * @brief Alias for pointer difference type used in class
+         *
+         * @tparam T pointer size type
+         */
+        using difference_type = std::ptrdiff_t;
+
+        /**
          * @brief Alias for pointer to data type used in class
          *
          * @tparam T* pointer to data type

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1367,7 +1367,7 @@ namespace dsa
     template<typename T>
     void ForwardList<T>::clear()
     {
-        if (m_head && m_head->m_next)
+        if (m_head)
         {
             NodeBase* temp{ m_head->m_next };
             while (temp)
@@ -1830,11 +1830,7 @@ namespace dsa
                     }
                 }
 
-                if (prev)
-                {
-                    prev = prev->m_next;
-                }
-
+                prev = prev->m_next;
                 temp = temp->m_next;
             }
         }
@@ -2061,8 +2057,7 @@ namespace dsa
     template<typename T>
     void ForwardList<T>::destroy_node(NodeBase* node_to_destroy)
     {
-        Node* node_dyn = dynamic_cast<Node*>(node_to_destroy);
-        if (node_dyn)
+        if (Node* node_dyn = dynamic_cast<Node*>(node_to_destroy))
         {
             node_alloc_traits::destroy(node_alloc, node_dyn);
             node_alloc_traits::deallocate(node_alloc, node_dyn, 1);
@@ -2109,15 +2104,12 @@ namespace dsa
 
             NodeBase* to_move{ temp_next->m_next };
 
-            if (to_move)
-            {
-                temp_next->m_next = to_move->m_next;
-                to_move->m_next = temp_prev->m_next;
-                temp_prev->m_next = to_move;
+            temp_next->m_next = to_move->m_next;
+            to_move->m_next = temp_prev->m_next;
+            temp_prev->m_next = to_move;
 
-                m_size += 1;
-                other.m_size -= 1;
-            }
+            m_size += 1;
+            other.m_size -= 1;
         }
     }
 
@@ -2143,21 +2135,15 @@ namespace dsa
             NodeBase* last_to_move{ temp_next };
             for (size_type i = 0; i < dist; i++)
             {
-                if (last_to_move)
-                {
-                    last_to_move = last_to_move->m_next;
-                }
+                last_to_move = last_to_move->m_next;
             }
 
-            if (temp_next)
-            {
-                temp_next->m_next = last_to_move->m_next;
-                last_to_move->m_next = temp_prev->m_next;
-                temp_prev->m_next = first_to_move;
+            temp_next->m_next = last_to_move->m_next;
+            last_to_move->m_next = temp_prev->m_next;
+            temp_prev->m_next = first_to_move;
 
-                m_size += dist;
-                other.m_size -= dist;
-            }
+            m_size += dist;
+            other.m_size -= dist;
         }
     }
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -900,55 +900,6 @@ namespace dsa
         }
 
         /**
-         * @brief Function returns pointer to specific Node of ForwardList
-         *
-         * @param[in] index index of element
-         * @return Node*
-         * @retval Node* if index is valid
-         * @retval nullptr if invalid index
-         */
-        [[nodiscard]] auto get(size_type index) const -> Node*
-        {
-            if (index > m_size)
-            {
-                return nullptr;
-            }
-
-            Node* temp = dynamic_cast<Node*>(m_head->m_next);
-            for (size_type i = 0; i < index; i++)
-            {
-                temp = dynamic_cast<Node*>(temp->m_next);
-                if (temp == nullptr)
-                {
-                    break;
-                }
-            }
-
-            return temp;
-        }
-
-        /**
-         * @brief Function sets value of specified Node of ForwardList
-         *
-         * @param[in] index index of element to be modified
-         * @param[in] value to overwrite Node at index
-         * @return operation status
-         * @retval true if value of Node was overwritten
-         * @retval false if invalid index
-         */
-        auto set(size_type index, T value) -> bool
-        {
-            Node* temp = get(index);
-            if (temp)
-            {
-                temp->m_value = value;
-                return true;
-            }
-
-            return false;
-        }
-
-        /**
          * @brief Function returns ForwardList size
          *
          * @return size_type number of elements in container

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -13,6 +13,7 @@
 #define FORWARD_LIST_H
 
 #include <cstddef>
+#include <functional>
 #include <initializer_list>
 #include <iostream>
 #include <iterator>
@@ -852,6 +853,20 @@ namespace dsa
         void sort();
 
         /**
+         * @brief Function sorts the elements and preserves the order of equivalent elements
+         *
+         * @details elements are compared using \p comp
+         *
+         * @tparam Compare
+         * @param[in] comp comparison function object, returns \p true if the first argument is less than second
+         *
+         * @note no iterators or references are invalidated,
+         *       if an exception is thrown, the order of elements is unspecified
+         */
+        template<typename Compare>
+        void sort(Compare comp);
+
+        /**
          * @brief push elements of another ForwardList to base container back
          *
          * @param[in] other ForwardList to read elements from
@@ -1136,9 +1151,11 @@ namespace dsa
          *          Sorting is stable and inplace
          *
          * @param[in,out] source list to sort
-         * @return NodeBase* of sorted list
+         * @param[in] comp comparison function object
+         * @return NodeBase* of sorted list using \p comp
          */
-        auto merge_sort(NodeBase* source) -> NodeBase*;
+        template<typename Compare>
+        auto merge_sort(NodeBase* source, Compare comp) -> NodeBase*;
 
         /**
          * @brief Helper function for merge_sort to merge two sub-lists
@@ -1146,9 +1163,11 @@ namespace dsa
          *
          * @param[in,out] left first input sub-list
          * @param[in,out] right second input sub-list
-         * @return NodeBase* containing sorted elements from both input lists
+         * @param[in] comp comparison function object
+         * @return NodeBase* containing elements from both input lists sorted using \p comp
          */
-        auto merge(NodeBase* left, NodeBase* right) -> NodeBase*;
+        template<typename Compare>
+        auto merge(NodeBase* left, NodeBase* right, Compare comp) -> NodeBase*;
 
         NodeBase* m_head{};
         size_type m_size{};
@@ -1895,9 +1914,10 @@ namespace dsa
     }
 
     template<typename T>
+    template<typename Compare>
     // Intentional recursive call for sorting nodes in top-down algorithm implementation
     // NOLINTNEXTLINE(misc-no-recursion)
-    auto ForwardList<T>::merge_sort(NodeBase* source) -> NodeBase*
+    auto ForwardList<T>::merge_sort(NodeBase* source, Compare comp) -> NodeBase*
     {
         // Stop condition, one element list is already sorted
         if (source == nullptr || source->m_next == nullptr)
@@ -1923,18 +1943,19 @@ namespace dsa
         slow->m_next = nullptr;
 
         // Recursively sort both sub-lists
-        left = merge_sort(left);
-        right = merge_sort(right);
+        left = merge_sort(left, comp);
+        right = merge_sort(right, comp);
 
         // Merge sorted sublists
-        NodeBase* result{ merge(left, right) };
+        NodeBase* result{ merge(left, right, comp) };
         return result;
     }
 
     template<typename T>
+    template<typename Compare>
     // Intentional recursive call for merging nodes in top-down merge_sort algorithm implementation
     // NOLINTNEXTLINE(misc-no-recursion)
-    auto ForwardList<T>::merge(NodeBase* left, NodeBase* right) -> NodeBase*
+    auto ForwardList<T>::merge(NodeBase* left, NodeBase* right, Compare comp) -> NodeBase*
     {
         // Stop condition, empty element list is already sorted
         if (left == nullptr)
@@ -1952,15 +1973,16 @@ namespace dsa
         if (node_left && node_right)
         {
             // Recursively merge nodes
-            if (node_left->m_value <= node_right->m_value)
+            //if (node_left->m_value <= node_right->m_value)
+            if (comp(node_left->m_value, node_right->m_value))
             {
                 result = left;
-                result->m_next = merge(left->m_next, right);
+                result->m_next = merge(left->m_next, right, comp);
             }
             else
             {
                 result = right;
-                result->m_next = merge(left, right->m_next);
+                result->m_next = merge(left, right->m_next, comp);
             }
         }
 
@@ -1970,7 +1992,14 @@ namespace dsa
     template<typename T>
     void ForwardList<T>::sort()
     {
-        m_head->m_next = merge_sort(m_head->m_next);
+        m_head->m_next = merge_sort(m_head->m_next, std::less<>());
+    }
+
+    template<typename T>
+    template<typename Compare>
+    void ForwardList<T>::sort(Compare comp)
+    {
+        m_head->m_next = merge_sort(m_head->m_next, comp);
     }
 
     /**

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -37,8 +37,6 @@ namespace dsa
      *
      * @tparam T type of data stored in ForwardList Node
      *
-     * @todo add non-member specialized erase function
-     * @todo add non-member specialized erase_if function
      * @todo remove public functions / operators not supported by std::forward_list
      */
     template<typename T>
@@ -2132,6 +2130,36 @@ namespace dsa
     void swap(ForwardList<T>& lhs, ForwardList<T>& rhs) noexcept(noexcept(lhs.swap(rhs)))
     {
         lhs.swap(rhs);
+    }
+
+    /**
+     * @brief Function erases from container all elements that are equal to \p value
+     *
+     * @tparam T data type stored in containers
+     * @tparam U data type of \p value
+     * @param[in,out] container object to remove erase elements from
+     * @param[in] value value to remove from \p container
+     * @return size_type number of elements removed
+     */
+    template<typename T, typename U>
+    auto erase(ForwardList<T>& container, const U& value) -> ForwardList<T>::size_type
+    {
+        return erase_if(container, [&value](U node_val) { return node_val == value; });
+    }
+
+    /**
+     * @brief Function erases from container all elements that satisfy the predicate \p pred
+     *
+     * @tparam T data type stored in containers
+     * @tparam Pred predicate to check if element should be erased
+     * @param[in,out] container container object to remove erase elements from
+     * @param[in] pred predicate which returns \p true if the element should be erased
+     * @return size_type number of elements removed
+     */
+    template<typename T, typename Pred>
+    auto erase_if(ForwardList<T>& container, Pred pred) -> ForwardList<T>::size_type
+    {
+        return container.remove_if(pred);
     }
 }
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1016,20 +1016,13 @@ namespace dsa
         /**
          * @brief Function allocate and construct ForwardList node
          *
-         * @param[in] value element of type T to be inserted
+         * @tparam ...Args
          * @param[in] next_ptr pointer to next Node
+         * @param[in] value element of type T to be inserted
          * @return pointer to created Node
          */
-        [[nodiscard]] auto construct_node(const_reference value, NodeBase* next_ptr = nullptr) -> Node*;
-
-        /**
-         * @brief Function allocate and construct ForwardList node
-         *
-         * @param[in] value element of type T to be inserted
-         * @param[in] next_ptr pointer to next Node
-         * @return pointer to created Node
-         */
-        [[nodiscard]] auto construct_node(T&& value, NodeBase* next_ptr = nullptr) -> Node*;
+        template<typename... Args>
+        auto construct_node(NodeBase* next_ptr, Args&&... args) -> Node*;
 
         /**
          * @brief Function destroys and deallocates memory used by Node
@@ -1650,15 +1643,8 @@ namespace dsa
 
         if (m_size != 0)
         {
-            Node* temp_head = construct_node(T{});
-            if (!temp_head)
-            {
-                // if temporary node could not be allocated
-                // do not modify object state
-                return;
-            }
-
-            NodeBase* temp_tail = temp_head;
+            Node* temp_head{ construct_node(nullptr, T{}) };
+            NodeBase* temp_tail{ temp_head };
 
             NodeBase* to_move{};
             NodeBase* to_return{};
@@ -2063,36 +2049,20 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::construct_node(const_reference value, NodeBase* next_ptr) -> Node*
+    template<typename... Args>
+    auto ForwardList<T>::construct_node(NodeBase* next_ptr, Args&&... args) -> Node*
     {
         Node* newNode{};
         try
         {
             newNode = node_alloc_traits::allocate(node_alloc, 1);
-            node_alloc_traits::construct(node_alloc, newNode, Node(value));
+            node_alloc_traits::construct(node_alloc, newNode, std::forward<Args>(args)...);
             newNode->m_next = next_ptr;
         }
         catch (...)
         {
             node_alloc_traits::deallocate(node_alloc, newNode, 1);
-        }
-
-        return newNode;
-    }
-
-    template<typename T>
-    auto ForwardList<T>::construct_node(T&& value, NodeBase* next_ptr) -> Node*
-    {
-        Node* newNode{};
-        try
-        {
-            newNode = node_alloc_traits::allocate(node_alloc, 1);
-            node_alloc_traits::construct(node_alloc, newNode, Node(std::move(value)));
-            newNode->m_next = next_ptr;
-        }
-        catch (...)
-        {
-            node_alloc_traits::deallocate(node_alloc, newNode, 1);
+            throw;
         }
 
         return newNode;

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -799,6 +799,10 @@ namespace dsa
          *
          * @param[in,out] other container to take elements from
          * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void merge(ForwardList<T>& other);
 
@@ -807,10 +811,42 @@ namespace dsa
          *
          * @param[in,out] other container to take elements from
          * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
-         // transfers ownership of nodes, moving entire container is not necessary
-         // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
         void merge(ForwardList<T>&& other);
+
+        /**
+         * @brief Function combines two sorted ForwardLists into one sorted ForwardList
+         *
+         * @param[in,out] other container to take elements from
+         * @param[in] comp comparison function object
+         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
+         */
+        template<typename Compare>
+        void merge(ForwardList<T>& other, Compare comp);
+
+        /**
+         * @brief Function combines two sorted ForwardLists into one sorted ForwardList
+         *
+         * @param[in,out] other container to take elements from
+         * @param[in] comp comparison function object
+         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
+         */
+        template<typename Compare>
+        // transfers ownership of nodes, moving entire container is not necessary
+        // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+        void merge(ForwardList<T>&& other, Compare comp);
 
         /**
          * @brief Function moves elements from other ForwardList object
@@ -1718,9 +1754,23 @@ namespace dsa
     }
 
     template<typename T>
+    void ForwardList<T>::merge(ForwardList<T>&& other)
+    {
+        merge(std::move(other), std::less<>());
+    }
+
+    template<typename T>
+    template<typename Compare>
+    void ForwardList<T>::merge(ForwardList<T>& other, Compare comp)
+    {
+        merge(std::move(other), comp);
+    }
+
+    template<typename T>
+    template<typename Compare>
     // transfers ownership of nodes, moving entire container is not necessary
     // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
-    void ForwardList<T>::merge(ForwardList<T>&& other)
+    void ForwardList<T>::merge(ForwardList<T>&& other, Compare comp)
     {
         if (&other != this)
         {
@@ -1739,7 +1789,7 @@ namespace dsa
 
                     if (node_this && node_other)
                     {
-                        if (node_this->value() <= node_other->value())
+                        if (comp(node_this->value(), node_other->value()))
                         {
                             to_move = m_head->m_next;
                             to_return = to_move->m_next;

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -131,7 +131,7 @@ namespace dsa
              *
              * @return T& reference to value stored in Node
              */
-            auto value() -> T&
+            [[nodiscard]] auto value() -> T&
             {
                 return m_value;
             }
@@ -544,7 +544,7 @@ namespace dsa
          *
          * @return reference to data stored in ForwardList first Node
          */
-        auto front() -> reference;
+        [[nodiscard]] auto front() -> reference;
 
         /**
          * @brief Function returns const reference value stored in ForwardList first Node
@@ -558,7 +558,7 @@ namespace dsa
          *
          * @return iterator iterator just before ForwardList first Node
          */
-        auto before_begin() noexcept -> iterator;
+        [[nodiscard]] auto before_begin() noexcept -> iterator;
 
         /**
          * @brief Function returns const_iterator just before ForwardList first Node
@@ -579,14 +579,14 @@ namespace dsa
          *
          * @return iterator iterator to ForwardList first Node
          */
-        auto begin() noexcept -> iterator;
+        [[nodiscard]] auto begin() noexcept -> iterator;
 
         /**
          * @brief Function returns const pointer to ForwardList first Node
          *
          * @return const_iterator const iterator to ForwardList first Node
          */
-        auto begin() const noexcept -> const_iterator;
+        [[nodiscard]] auto begin() const noexcept -> const_iterator;
 
         /**
          * @brief Function returns const pointer to ForwardList first Node
@@ -600,14 +600,14 @@ namespace dsa
          *
          * @return iterator iterator to ForwardList last Node
          */
-        auto end() noexcept -> iterator;
+        [[nodiscard]] auto end() noexcept -> iterator;
 
         /**
          * @brief Function returns pointer to ForwardList last Node
          *
          * @return const_iterator const iterator to ForwardList last Node
          */
-        auto end() const noexcept -> const_iterator;
+        [[nodiscard]] auto end() const noexcept -> const_iterator;
 
         /**
          * @brief Function returns pointer to ForwardList last Node
@@ -1033,7 +1033,7 @@ namespace dsa
          *
          * @return iterator to Node before last one
          */
-        auto find_iter_before_last() -> iterator
+        [[nodiscard]] auto find_iter_before_last() -> iterator
         {
             NodeBase* temp{ m_head->m_next };
             while (temp && temp->m_next && temp->m_next->m_next)
@@ -1075,7 +1075,7 @@ namespace dsa
          * @param[in] next_ptr pointer to next Node
          * @return pointer to created Node
          */
-        auto construct_node(const_reference value, NodeBase* next_ptr = nullptr) -> Node*
+        [[nodiscard]] auto construct_node(const_reference value, NodeBase* next_ptr = nullptr) -> Node*
         {
             Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
             try
@@ -1100,7 +1100,7 @@ namespace dsa
          * @param[in] next_ptr pointer to next Node
          * @return pointer to created Node
          */
-        auto construct_node(T&& value, NodeBase* next_ptr = nullptr) -> Node*
+        [[nodiscard]] auto construct_node(T&& value, NodeBase* next_ptr = nullptr) -> Node*
         {
             Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
             try
@@ -1177,7 +1177,7 @@ namespace dsa
          * @return true if \p pos belong to ForwardList
          * @return false if otherwise
          */
-        auto if_valid_iterator(const const_iterator& pos) -> bool
+        [[nodiscard]] auto if_valid_iterator(const const_iterator& pos) -> bool
         {
             bool valid_iterator{};
             for (auto it = cbefore_begin(); it != cend(); ++it)
@@ -1199,7 +1199,7 @@ namespace dsa
          * @param[in] last const_iterator pointing to last (inclusive) element
          * @return size_type number of elements between input elements
          */
-        auto distance(const_iterator first, const const_iterator& last) -> size_type;
+        [[nodiscard]] auto distance(const_iterator first, const const_iterator& last) -> size_type;
 
         /**
          * @brief Function moves elements from other ForwardList object

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -674,6 +674,20 @@ namespace dsa
          * @brief Function inserts new Node after specified ForwardList const_iterator
          *
          * @param[in] pos const_iterator to insert element after
+         * @param[in] first element defining range of elements to insert
+         * @param[in] last element definig range of elements to insert
+         * @return pointer to ForwardList element
+         * @retval iterator pointer to last inserted element
+         * @retval pos if no element was inserted
+         */
+        template<typename InputIt>
+            requires std::input_iterator<InputIt>
+        auto insert_after(const const_iterator& pos, InputIt first, InputIt last) -> iterator;
+
+        /**
+         * @brief Function inserts new Node after specified ForwardList const_iterator
+         *
+         * @param[in] pos const_iterator to insert element after
          * @param[in] init_list initializer_list with elements to insert after \p pos
          * @return pointer to the last inserted element
          * @retval iterator to last inserted element
@@ -1466,6 +1480,27 @@ namespace dsa
         for (size_type i = 0; i < count; i++)
         {
             iter = insert_element_after(iter, value);
+        }
+
+        return iter;
+    }
+
+    template<typename T>
+    template<typename InputIt>
+        requires std::input_iterator<InputIt>
+    auto ForwardList<T>::insert_after(const const_iterator& pos, InputIt first, InputIt last)
+        -> typename ForwardList<T>::iterator
+    {
+        if (!if_valid_iterator(pos))
+        {
+            return nullptr;
+        }
+
+        iterator iter{ pos.m_current_node };
+        while (first != last)
+        {
+            iter = insert_after(iter, *first);
+            first++;
         }
 
         return iter;

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -648,6 +648,17 @@ namespace dsa
         auto insert_after(const const_iterator& pos, const_reference value) -> iterator;
 
         /**
+         * @brief Function inserts new Node after specified ForwardList iterator
+         *
+         * @param[in] pos const_iterator to insert element after
+         * @param[in] value element of type T to be inserted after \p pos
+         * @return pointer to ForwardList element
+         * @retval iterator to inserted \p value
+         * @retval pos if no element was inserted
+         */
+        auto insert_after(const const_iterator& pos, T&& value) -> iterator;
+
+        /**
          * @brief Function inserts new Node after specified ForwardList const_iterator
          *
          * @param[in] pos const_iterator to insert element after
@@ -1425,6 +1436,21 @@ namespace dsa
         -> typename ForwardList<T>::iterator
     {
         return insert_after(pos, 1, value);
+    }
+
+    template<typename T>
+    auto ForwardList<T>::insert_after(const const_iterator& pos, T&& value)
+        -> typename ForwardList<T>::iterator
+    {
+        if (!if_valid_iterator(pos))
+        {
+            return nullptr;
+        }
+
+        iterator iter{ pos.m_current_node };
+        iter = insert_element_after(iter, std::move(value));
+
+        return iter;
     }
 
     template<typename T>

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -117,6 +117,16 @@ namespace dsa
             {}
 
             /**
+             * @brief Construct a new Node object with initial value using move semantics
+             * @details \p value will be taken by constructed object
+             *
+             * @param[in] value to store in Node object
+             */
+            Node(T&& value)
+                : m_value{ std::move(value) }
+            {}
+
+            /**
              * @brief Function returns value stored in Node object
              *
              * @return T& reference to value stored in Node

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -443,6 +443,17 @@ namespace dsa
         ForwardList(size_type count, const T& value);
 
         /**
+         * @brief Construct a new ForwardList object using elements from range [ \p first , \p last )
+         *
+         * @tparam InputIt
+         * @param[in] first element defining range of elements to insert
+         * @param[in] last element definig range of elements to insert
+         */
+        template<typename InputIt>
+            requires std::input_iterator<InputIt>
+        ForwardList(InputIt first, InputIt last);
+
+        /**
          * @brief Construct a new ForwardList object using initializer list
          *
          * @param[in] init_list initializer list of values of type T
@@ -1120,6 +1131,16 @@ namespace dsa
         {
             push_front(value);
         }
+    }
+
+    template<typename T>
+    template<typename InputIt>
+        requires std::input_iterator<InputIt>
+    ForwardList<T>::ForwardList(InputIt first, InputIt last)
+    {
+        init_node();
+
+        assign(first, last);
     }
 
     template<typename T>

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -307,11 +307,11 @@ namespace dsa
              * @retval valid ForwardListIterator if index is valid
              * @retval nullptr if index is invalid
              */
-            auto operator[](size_t index) -> ForwardListIterator
+            auto operator[](size_type index) -> ForwardListIterator
             {
                 NodeBase* temp{ m_current_node };
 
-                for (size_t i = 0; i < index; i++)
+                for (size_type i = 0; i < index; i++)
                 {
                     if (temp->m_next)
                     {
@@ -440,7 +440,7 @@ namespace dsa
          *
          * @param[in] count element count
          */
-        ForwardList(size_t count);
+        ForwardList(size_type count);
 
         /**
          * @brief Construct a new ForwardList object of size \p count,
@@ -449,7 +449,7 @@ namespace dsa
          * @param[in] count element count
          * @param[in] value value for all nodes
          */
-        ForwardList(size_t count, const T& value);
+        ForwardList(size_type count, const T& value);
 
         /**
          * @brief Construct a new ForwardList object using initializer list
@@ -501,7 +501,7 @@ namespace dsa
          * @param[in] count new size of the container
          * @param[in] value value to initialize elements of the container with
          */
-        void assign(size_t count, const_reference value);
+        void assign(size_type count, const_reference value);
 
         /**
          * @brief Function assign values to the ForwardList
@@ -605,9 +605,9 @@ namespace dsa
         /**
          * @brief Function returns maximum number of elements container can hold
          *
-         * @return size_t maximum number of elements
+         * @return size_type maximum number of elements
          */
-        [[nodiscard]] auto max_size() const noexcept -> size_t;
+        [[nodiscard]] auto max_size() const noexcept -> size_type;
 
         /**
          * @brief Function removes all elements of ForwardList
@@ -635,7 +635,7 @@ namespace dsa
          * @retval iterator pointer to last inserted element
          * @retval pos if no element was inserted
          */
-        auto insert_after(const const_iterator& pos, size_t count, const_reference value) -> iterator;
+        auto insert_after(const const_iterator& pos, size_type count, const_reference value) -> iterator;
 
         /**
          * @brief Function inserts new Node after specified ForwardList const_iterator
@@ -715,7 +715,7 @@ namespace dsa
          *
          * @param[in] count new size of container
          */
-        void resize(size_t count);
+        void resize(size_type count);
 
         /**
          * @brief Function resize ForwardList to specified number of elements
@@ -723,7 +723,7 @@ namespace dsa
          * @param[in] count count new size of container
          * @param[in] value value to initialize new elements
          */
-        void resize(size_t count, const_reference value);
+        void resize(size_type count, const_reference value);
 
         /**
          * @brief Function swaps content of two ForwardList objects
@@ -874,7 +874,7 @@ namespace dsa
          * @retval Node* if index is valid
          * @retval nullptr if invalid index
          */
-        [[nodiscard]] auto get(size_t index) const -> Node*
+        [[nodiscard]] auto get(size_type index) const -> Node*
         {
             if (index > m_size)
             {
@@ -882,7 +882,7 @@ namespace dsa
             }
 
             Node* temp = dynamic_cast<Node*>(m_head->m_next);
-            for (size_t i = 0; i < index; i++)
+            for (size_type i = 0; i < index; i++)
             {
                 temp = dynamic_cast<Node*>(temp->m_next);
                 if (temp == nullptr)
@@ -903,7 +903,7 @@ namespace dsa
          * @retval true if value of Node was overwritten
          * @retval false if invalid index
          */
-        auto set(size_t index, T value) -> bool
+        auto set(size_type index, T value) -> bool
         {
             Node* temp = get(index);
             if (temp)
@@ -918,9 +918,9 @@ namespace dsa
         /**
          * @brief Function returns ForwardList size
          *
-         * @return size_t number of elements in container
+         * @return size_type number of elements in container
          */
-        [[nodiscard]] auto size() const -> size_t
+        [[nodiscard]] auto size() const -> size_type
         {
             return m_size;
         }
@@ -1078,9 +1078,9 @@ namespace dsa
          * @tparam T type of input objects
          * @param[in] first const_iterator pointing first element
          * @param[in] last const_iterator pointing to last (inclusive) element
-         * @return size_t number of elements between input elements
+         * @return size_type number of elements between input elements
          */
-        auto distance(const_iterator first, const const_iterator& last) -> size_t;
+        auto distance(const_iterator first, const const_iterator& last) -> size_type;
 
         /**
          * @brief Function moves elements from other ForwardList object
@@ -1109,7 +1109,7 @@ namespace dsa
             const const_iterator& first, const const_iterator& last);
 
         NodeBase* m_head{};
-        size_t m_size{};
+        size_type m_size{};
 
         /**
          * @brief Allocator for memory management
@@ -1139,17 +1139,17 @@ namespace dsa
     }
 
     template<typename T>
-    ForwardList<T>::ForwardList(size_t count)
+    ForwardList<T>::ForwardList(size_type count)
         : ForwardList(count, T{})
     {
     }
 
     template<typename T>
-    ForwardList<T>::ForwardList(size_t count, const T& value)
+    ForwardList<T>::ForwardList(size_type count, const T& value)
     {
         init_node();
 
-        for (size_t i = 0; i < count; i++)
+        for (size_type i = 0; i < count; i++)
         {
             push_front(value);
         }
@@ -1233,7 +1233,7 @@ namespace dsa
     }
 
     template<typename T>
-    void ForwardList<T>::assign(size_t count, const_reference value)
+    void ForwardList<T>::assign(size_type count, const_reference value)
     {
         while (m_head->m_next)
         {
@@ -1241,7 +1241,7 @@ namespace dsa
         }
 
         auto iter = before_begin();
-        for (size_t i = 0; i < count; i++)
+        for (size_type i = 0; i < count; i++)
         {
             iter = insert_after(iter, value);
         }
@@ -1342,9 +1342,9 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::max_size() const noexcept -> size_t
+    auto ForwardList<T>::max_size() const noexcept -> size_type
     {
-        return std::numeric_limits<size_t>::max();
+        return std::numeric_limits<size_type>::max();
     }
 
     template<typename T>
@@ -1373,7 +1373,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::insert_after(const const_iterator& pos, size_t count, const_reference value)
+    auto ForwardList<T>::insert_after(const const_iterator& pos, size_type count, const_reference value)
         -> typename ForwardList<T>::iterator
     {
         if (!if_valid_iterator(pos))
@@ -1382,7 +1382,7 @@ namespace dsa
         }
 
         iterator iter{ pos.m_current_node };
-        for (size_t i = 0; i < count; i++)
+        for (size_type i = 0; i < count; i++)
         {
             iter = insert_element_after(iter, value);
         }
@@ -1455,8 +1455,8 @@ namespace dsa
         }
 
         const iterator iter(first.m_current_node);
-        const size_t dist = distance(first, last);
-        for (size_t i = 0; i < dist - 1; i++)
+        const size_type dist = distance(first, last);
+        for (size_type i = 0; i < dist - 1; i++)
         {
             erase_element_after(iter);
         }
@@ -1512,13 +1512,13 @@ namespace dsa
     }
 
     template<typename T>
-    void ForwardList<T>::resize(size_t count)
+    void ForwardList<T>::resize(size_type count)
     {
         resize(count, T{});
     }
 
     template<typename T>
-    void ForwardList<T>::resize(size_t count, const_reference value)
+    void ForwardList<T>::resize(size_type count, const_reference value)
     {
         init_node();
 
@@ -1530,7 +1530,7 @@ namespace dsa
         if (m_size > count)
         {
             auto iter = begin();
-            for (size_t i = 0; i < count - 1; i++)
+            for (size_type i = 0; i < count - 1; i++)
             {
                 ++iter;
             }
@@ -1635,9 +1635,9 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::distance(const_iterator first, const const_iterator& last) -> size_t
+    auto ForwardList<T>::distance(const_iterator first, const const_iterator& last) -> size_type
     {
-        size_t dist{};
+        size_type dist{};
         while (first != last)
         {
             ++first;
@@ -1679,7 +1679,7 @@ namespace dsa
     {
         if (&other != this && other.m_size > 0)
         {
-            const size_t dist = distance(first, last) - 1;
+            const size_type dist = distance(first, last) - 1;
 
             if (first == last || dist == 0)
             {
@@ -1691,7 +1691,7 @@ namespace dsa
 
             NodeBase* first_to_move{ temp_next->m_next };
             NodeBase* last_to_move{ temp_next };
-            for (size_t i = 0; i < dist; i++)
+            for (size_type i = 0; i < dist; i++)
             {
                 if (last_to_move)
                 {
@@ -1789,7 +1789,7 @@ namespace dsa
         NodeBase* prev{};
         NodeBase* next{};
 
-        for (size_t i = 0; i < m_size; i++)
+        for (size_type i = 0; i < m_size; i++)
         {
             next = temp->m_next;
             temp->m_next = prev;

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -736,7 +736,7 @@ namespace dsa
          *
          * @param[in] value element of type T
          */
-        void push_front(T value);
+        void push_front(const_reference value);
 
         /**
          * @brief Inserts a new element to the beginning of the container
@@ -1581,7 +1581,7 @@ namespace dsa
     }
 
     template<typename T>
-    void ForwardList<T>::push_front(T value)
+    void ForwardList<T>::push_front(const_reference value)
     {
         Node* newNode = construct_node(value);
         if (!m_head->m_next)

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1021,18 +1021,36 @@ namespace dsa
         }
 
         /**
-        * @brief Function inserts new Node after specified ForwardList iterator
-        *
-        * @param[in] pos iterator to insert element after
-        * @param[in] value element of type T to be inserted
-        * @return pointer to next element
-        * @retval iterator to iterator inserted after \pos
-        * @retval nullptr if invalid iterator
-        */
+         * @brief Function inserts new Node after specified ForwardList iterator
+         *
+         * @param[in] pos iterator to insert element after
+         * @param[in] value element of type T to be inserted
+         * @return pointer to next element
+         * @retval iterator to iterator inserted after \pos
+         * @retval nullptr if invalid iterator
+         */
         auto insert_element_after(iterator& pos, const_reference value) -> iterator
         {
             NodeBase* temp{ pos.m_current_node };
             Node* newNode = construct_node(value, temp->m_next);
+            temp->m_next = newNode;
+            m_size++;
+            return iterator(newNode);
+        }
+
+        /**
+         * @brief Function inserts new Node after specified ForwardList iterator
+         *
+         * @param[in] pos iterator to insert element after
+         * @param[in] value element of type T to be inserted
+         * @return pointer to next element
+         * @retval iterator to iterator inserted after \pos
+         * @retval nullptr if invalid iterator
+         */
+        auto insert_element_after(iterator& pos, T&& value) -> iterator
+        {
+            NodeBase* temp{ pos.m_current_node };
+            Node* newNode = construct_node(std::move(value), temp->m_next);
             temp->m_next = newNode;
             m_size++;
             return iterator(newNode);

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -850,62 +850,86 @@ namespace dsa
 
         /**
          * @brief Function moves elements from other ForwardList object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator after which content of other container will be inserted
          * @param[in,out] other container to take elements from
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice_after(const const_iterator& pos, ForwardList<T>& other);
 
         /**
          * @brief Function moves elements from other ForwardList object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator after which content of other container will be inserted
          * @param[in,out] other container to take elements from
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice_after(const_iterator pos, ForwardList<T>&& other);
 
         /**
          * @brief Function moves elements from other ForwardList object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator after which content of other container will be inserted
          * @param[in,out] other container to take elements from
          * @param[in] iter const_iterator after which elements of \p other will be taken
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice_after(const const_iterator& pos, ForwardList<T>& other, const const_iterator& iter);
 
         /**
          * @brief Function moves elements from other ForwardList object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator after which content of other container will be inserted
          * @param[in,out] other container to take elements from
          * @param[in] iter const_iterator after which elements of \p other will be taken
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice_after(const_iterator pos, ForwardList<T>&& other, const_iterator iter);
 
         /**
          * @brief Function moves elements from other ForwardList object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator after which content of other container will be inserted
          * @param[in,out] other container to take elements from
          * @param[in] first const_iterator after which elements of \p other will be taken
          * @param[in] last const_iterator until which elements of \p other will be taken
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice_after(const const_iterator& pos, ForwardList<T>& other,
             const const_iterator& first, const const_iterator& last);
 
         /**
          * @brief Function moves elements from other ForwardList object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator after which content of other container will be inserted
          * @param[in,out] other container to take elements from
          * @param[in] first const_iterator after which elements of \p other will be taken
          * @param[in] last const_iterator until which elements of \p other will be taken
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice_after(const_iterator pos, ForwardList<T>&& other, const_iterator first, const_iterator last);
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1428,7 +1428,7 @@ namespace dsa
         }
 
         iterator iter{ pos.m_current_node };
-        iter = insert_element_after(iter, std::move(value));
+        iter = emplace_after(iter, std::move(value));
 
         return iter;
     }
@@ -1445,7 +1445,7 @@ namespace dsa
         iterator iter{ pos.m_current_node };
         for (size_type i = 0; i < count; i++)
         {
-            iter = insert_element_after(iter, value);
+            iter = emplace_after(iter, value);
         }
 
         return iter;
@@ -1484,7 +1484,7 @@ namespace dsa
         iterator iter{ pos.m_current_node };
         for (const auto val : init_list)
         {
-            iter = insert_element_after(iter, val);
+            iter = emplace_after(iter, val);
         }
 
         return iter;

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -36,8 +36,6 @@ namespace dsa
      *
      * @tparam T type of data stored in ForwardList Node
      *
-     * @todo add emplace_after
-     * @todo add emplace_front
      * @todo add remove
      * @todo add remove_if
      * @todo add sort
@@ -637,6 +635,21 @@ namespace dsa
         auto insert_after(const const_iterator& pos, std::initializer_list<T> init_list) -> iterator;
 
         /**
+         * @brief Insert new element into the container after \p pos
+         *
+         * @tparam ...Args
+         * @param[in] pos iterator before which new element will be inserted
+         * @param[in] ...args args arguments to forward to the constructor of the element
+         * @return iterator pointing to the emplaced element
+         *
+         * @note no iterators or references are invalidated,
+         *       if construction of new element fails or an exception is thrown for any reason
+         *       state of the object does not change and this function has no effect
+         */
+        template<typename... Args>
+        auto emplace_after(const_iterator pos, Args&&... args) -> iterator;
+
+        /**
         * @brief Function erases Node after specified ForwardList const_iterator
         *
         * @param[in] pos const_iterator after which element will be erased
@@ -663,6 +676,20 @@ namespace dsa
          * @param[in] value element of type T
          */
         void push_front(T value);
+
+        /**
+         * @brief Inserts a new element to the beginning of the container
+         *
+         * @tparam ...Args
+         * @param[in] ...args arguments to forward to the constructor of the element
+         * @return reference to emplaced element
+         *
+         * @note no iterators or references are invalidated,
+         *       if construction of new element fails or an exception is thrown for any reason
+         *       state of the object does not change and this function has no effect
+         */
+        template<typename... Args>
+        auto emplace_front(Args&&... args) -> reference;
 
         /**
          * @brief Function removes first Node of ForwardList
@@ -1368,6 +1395,29 @@ namespace dsa
     }
 
     template<typename T>
+    template<typename... Args>
+    auto ForwardList<T>::emplace_after(const_iterator pos, Args&&... args) -> iterator
+    {
+        const iterator current{ pos.m_current_node };
+
+        Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
+        try
+        {
+            node_alloc_traits::construct(node_alloc, newNode, std::forward<Args>(args)...);
+            newNode->m_next = current.m_current_node->m_next;
+        }
+        catch (...)
+        {
+            node_alloc_traits::deallocate(node_alloc, newNode, 1);
+            throw;
+        }
+
+        current.m_current_node->m_next = newNode;
+        ++m_size;
+        return iterator(newNode);
+    }
+
+    template<typename T>
     auto ForwardList<T>::erase_after(const const_iterator& pos) -> typename ForwardList<T>::iterator
     {
         if (!if_valid_iterator(pos))
@@ -1415,6 +1465,14 @@ namespace dsa
         }
 
         m_size++;
+    }
+
+    template<typename T>
+    template<typename... Args>
+    auto ForwardList<T>::emplace_front(Args&&... args) -> reference
+    {
+        emplace_after(before_begin(), std::forward<Args>(args)...);
+        return front();
     }
 
     template<typename T>

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -112,10 +112,9 @@ namespace dsa
              *
              * @param[in] value to store in Node object
              */
-            Node(T value)
+            Node(const T& value)
                 : m_value{ value }
-            {
-            }
+            {}
 
             /**
              * @brief Function returns value stored in Node object

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -36,7 +36,6 @@ namespace dsa
      *
      * @tparam T type of data stored in ForwardList Node
      *
-     * @todo add get_allocator
      * @todo add emplace_after
      * @todo add emplace_front
      * @todo add remove
@@ -376,6 +375,11 @@ namespace dsa
         using value_type = T;
 
         /**
+         * @brief Alias for memory allocator
+         */
+        using allocator_type = std::allocator<value_type>;
+
+        /**
          * @brief Alias for pointer to data type used in class
          *
          * @tparam T* pointer to data type
@@ -493,6 +497,13 @@ namespace dsa
          * @param[in] init_list values to replace ForwardList with
          */
         void assign(const std::initializer_list<T>& init_list);
+
+        /**
+         * @brief Get the allocator object
+         *
+         * @return allocator_type type of memory allocator
+         */
+        [[nodiscard]] constexpr auto get_allocator() const -> allocator_type;
 
         /**
          * @brief Function returns reference to value stored in ForwardList first Node
@@ -1021,6 +1032,11 @@ namespace dsa
 
         NodeBase* m_head{};
         size_t m_size{};
+
+        /**
+         * @brief Allocator for memory management
+         */
+        allocator_type m_allocator{};
     };
 
     template<typename T>
@@ -1151,6 +1167,12 @@ namespace dsa
         {
             iter = insert_after(iter, item);
         }
+    }
+
+    template<typename T>
+    [[nodiscard]] constexpr auto ForwardList<T>::get_allocator() const -> allocator_type
+    {
+        return m_allocator;
     }
 
     template<typename T>

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -109,7 +109,7 @@ namespace dsa
             /**
              * @brief Pointer to next node
              */
-            std::unique_ptr<NodeBase> m_next{};
+            NodeBase* m_next{};
         };
 
         /**
@@ -251,7 +251,7 @@ namespace dsa
             {
                 if (m_current_node)
                 {
-                    m_current_node = m_current_node->m_next.get();
+                    m_current_node = m_current_node->m_next;
                 }
 
                 return *this;
@@ -311,7 +311,7 @@ namespace dsa
                 {
                     if (temp->m_next)
                     {
-                        temp = temp->m_next.get();
+                        temp = temp->m_next;
                     }
                     else
                     {
@@ -829,10 +829,10 @@ namespace dsa
                 return nullptr;
             }
 
-            Node* temp = dynamic_cast<Node*>(m_head->m_next.get());
+            Node* temp = dynamic_cast<Node*>(m_head->m_next);
             for (size_t i = 0; i < index; i++)
             {
-                temp = dynamic_cast<Node*>(temp->m_next.get());
+                temp = dynamic_cast<Node*>(temp->m_next);
                 if (temp == nullptr)
                 {
                     break;
@@ -895,7 +895,7 @@ namespace dsa
         {
             if (m_head == nullptr)
             {
-                m_head = std::make_unique<NodeBase>();
+                m_head = new NodeBase;
             }
         }
 
@@ -906,10 +906,10 @@ namespace dsa
          */
         auto find_iter_before_last() -> iterator
         {
-            NodeBase* temp{ m_head->m_next.get() };
+            NodeBase* temp{ m_head->m_next };
             while (temp && temp->m_next && temp->m_next->m_next)
             {
-                temp = temp->m_next.get();
+                temp = temp->m_next;
             }
 
             auto iter = iterator(temp);
@@ -930,13 +930,13 @@ namespace dsa
         auto erase_element_after(iterator pos) -> iterator
         {
             NodeBase* temp{ pos.m_current_node };
-            NodeBase* to_remove{ temp->m_next.get() };
+            NodeBase* to_remove{ temp->m_next };
 
-            temp->m_next = std::move(to_remove->m_next);
-
+            temp->m_next = to_remove->m_next;
+            delete to_remove;
 
             m_size--;
-            return iterator(temp->m_next.get());
+            return iterator(temp->m_next);
         }
 
         /**
@@ -950,12 +950,14 @@ namespace dsa
         */
         auto insert_element_after(iterator& pos, const_reference value) -> iterator
         {
-            auto newNode = std::make_unique<Node>(value);
-            newNode->m_next = std::move(pos.m_current_node->m_next);
-            pos.m_current_node->m_next = std::move(newNode);
+            NodeBase* temp{ pos.m_current_node };
 
+            Node* newNode = new Node(value);
+            newNode->m_next = temp->m_next;
+
+            temp->m_next = newNode;
             m_size++;
-            return iterator(pos.m_current_node->m_next.get());
+            return iterator(newNode);
         }
 
         /**
@@ -1016,7 +1018,7 @@ namespace dsa
         void transfer(const const_iterator& pos, ForwardList<T>&& other,
             const const_iterator& first, const const_iterator& last);
 
-        std::unique_ptr<NodeBase> m_head{};
+        NodeBase* m_head{};
         size_t m_size{};
     };
 
@@ -1103,7 +1105,7 @@ namespace dsa
             clear();
             init_node();
 
-            m_head->m_next = std::move(other.m_head->m_next);
+            m_head->m_next = other.m_head->m_next;
             m_size = other.m_size;
 
             other.m_head->m_next = nullptr;
@@ -1117,6 +1119,7 @@ namespace dsa
     ForwardList<T>::~ForwardList()
     {
         clear();
+        delete m_head;
     }
 
     template<typename T>
@@ -1164,13 +1167,13 @@ namespace dsa
     template<typename T>
     auto ForwardList<T>::before_begin() noexcept -> typename ForwardList<T>::iterator
     {
-        return iterator(m_head.get());
+        return iterator(m_head);
     }
 
     template<typename T>
     auto ForwardList<T>::before_begin() const noexcept -> typename ForwardList<T>::const_iterator
     {
-        return const_iterator(m_head.get());
+        return const_iterator(m_head);
     }
 
     template<typename T>
@@ -1182,13 +1185,13 @@ namespace dsa
     template<typename T>
     auto ForwardList<T>::begin() noexcept -> typename ForwardList<T>::iterator
     {
-        return iterator(m_head->m_next.get());
+        return iterator(m_head->m_next);
     }
 
     template<typename T>
     auto ForwardList<T>::begin() const noexcept -> typename ForwardList<T>::const_iterator
     {
-        return const_iterator(m_head->m_next.get());
+        return const_iterator(m_head->m_next);
     }
 
     template<typename T>
@@ -1233,11 +1236,12 @@ namespace dsa
     {
         if (m_head && m_head->m_next)
         {
-            NodeBase* temp{ m_head->m_next.get() };
+            NodeBase* temp{ m_head->m_next };
             while (temp)
             {
-                m_head->m_next = std::move(temp->m_next);
-                temp = m_head->m_next.get();
+                m_head->m_next = temp->m_next;
+                delete temp;
+                temp = m_head->m_next;
             }
 
             m_size = 0;
@@ -1318,21 +1322,21 @@ namespace dsa
             erase_element_after(iter);
         }
 
-        return first.m_current_node->m_next.get();
+        return first.m_current_node->m_next;
     }
 
     template<typename T>
     void ForwardList<T>::push_front(T value)
     {
-        auto newNode = std::make_unique<Node>(value);
+        Node* newNode = new Node(value);
         if (!m_head->m_next)
         {
-            m_head->m_next = std::move(newNode);
+            m_head->m_next = newNode;
         }
         else
         {
-            newNode->m_next = std::move(m_head->m_next);
-            m_head->m_next = std::move(newNode);
+            newNode->m_next = m_head->m_next;
+            m_head->m_next = newNode;
         }
 
         m_size++;
@@ -1346,15 +1350,16 @@ namespace dsa
             return;
         }
 
-        NodeBase* temp{ m_head->m_next.get() };
+        NodeBase* temp{ m_head->m_next };
         if (m_size == 1)
         {
             m_head->m_next = nullptr;
         }
         else
         {
-            m_head->m_next = std::move(temp->m_next);
+            m_head->m_next = temp->m_next;
         }
+        delete temp;
 
         m_size--;
     }
@@ -1426,41 +1431,51 @@ namespace dsa
         {
             if (m_size != 0)
             {
-                auto temp_head = std::make_unique<Node>(0);
-                NodeBase* temp_tail = temp_head.get();
+                NodeBase* temp_head = new NodeBase;
+                NodeBase* temp_tail = temp_head;
 
-                std::unique_ptr<NodeBase> to_move{};
-                std::unique_ptr<NodeBase> to_return{};
+                NodeBase* to_move{};
+                NodeBase* to_return{};
 
                 while (m_head->m_next && other.m_head->m_next)
                 {
-                    Node* node_this = dynamic_cast<Node*>(m_head->m_next.get());
-                    Node* node_other = dynamic_cast<Node*>(other.m_head->m_next.get());
+                    Node* node_this = dynamic_cast<Node*>(m_head->m_next);
+                    Node* node_other = dynamic_cast<Node*>(other.m_head->m_next);
 
                     if (node_this && node_other)
                     {
                         if (node_this->value() <= node_other->value())
                         {
-                            to_move = std::move(m_head->m_next);
-                            to_return = std::move(to_move->m_next);
-                            temp_tail->m_next = std::move(to_move);
-                            m_head->m_next = std::move(to_return);
+                            to_move = m_head->m_next;
+                            to_return = to_move->m_next;
+                            temp_tail->m_next = to_move;
+                            m_head->m_next = to_return;
                         }
                         else
                         {
-                            to_move = std::move(other.m_head->m_next);
-                            to_return = std::move(to_move->m_next);
-                            temp_tail->m_next = std::move(to_move);
-                            other.m_head->m_next = std::move(to_return);
+                            to_move = other.m_head->m_next;
+                            to_return = to_move->m_next;
+                            temp_tail->m_next = to_move;
+                            other.m_head->m_next = to_return;
                         }
 
-                        temp_tail = temp_tail->m_next.get();
+                        temp_tail = temp_tail->m_next;
                     }
                 }
-                temp_tail->m_next =
-                    (m_head->m_next == nullptr) ? std::move(other.m_head->m_next) : std::move(m_head->m_next);
 
-                m_head->m_next = std::move(temp_head->m_next);
+                if (m_head->m_next == nullptr)
+                {
+                    temp_tail->m_next = other.m_head->m_next;
+                    other.m_head->m_next = nullptr;
+                }
+                else
+                {
+                    temp_tail->m_next = m_head->m_next;
+                    m_head->m_next = nullptr;
+                }
+
+                m_head->m_next = temp_head->m_next;
+                delete temp_head;
 
                 m_size += other.m_size;
                 other.m_size = 0;
@@ -1495,13 +1510,13 @@ namespace dsa
             NodeBase* temp_prev{ pos.m_current_node };  // to append to
             NodeBase* temp_next{ iter.m_current_node }; // does not move
 
-            std::unique_ptr<NodeBase> to_move{ std::move(temp_next->m_next) };
+            NodeBase* to_move{ temp_next->m_next };
 
             if (to_move)
             {
-                temp_next->m_next = std::move(to_move->m_next);
-                to_move->m_next = std::move(temp_prev->m_next);
-                temp_prev->m_next = std::move(to_move);
+                temp_next->m_next = to_move->m_next;
+                to_move->m_next = temp_prev->m_next;
+                temp_prev->m_next = to_move;
 
                 m_size += 1;
                 other.m_size -= 1;
@@ -1525,24 +1540,23 @@ namespace dsa
             }
 
             NodeBase* temp_prev{ pos.m_current_node };     // to append to
-            std::unique_ptr<NodeBase> to_append_to{ std::move(pos.m_current_node->m_next) };
             NodeBase* temp_next{ first.m_current_node };   // does not move
 
+            NodeBase* first_to_move{ temp_next->m_next };
             NodeBase* last_to_move{ temp_next };
             for (size_t i = 0; i < dist; i++)
             {
                 if (last_to_move)
                 {
-                    last_to_move = last_to_move->m_next.get();
+                    last_to_move = last_to_move->m_next;
                 }
             }
 
             if (temp_next)
             {
-                std::unique_ptr<NodeBase> to_move{ std::move(temp_next->m_next) };
-                temp_next->m_next = std::move(last_to_move->m_next);
-                last_to_move->m_next = std::move(to_append_to);
-                temp_prev->m_next = std::move(to_move);
+                temp_next->m_next = last_to_move->m_next;
+                last_to_move->m_next = temp_prev->m_next;
+                temp_prev->m_next = first_to_move;
 
                 m_size += dist;
                 other.m_size -= dist;
@@ -1590,42 +1604,51 @@ namespace dsa
     template<typename T>
     void ForwardList<T>::remove(const_reference value)
     {
-        NodeBase* temp{ m_head.get() };
+        NodeBase* temp{ m_head };
         NodeBase* next{};
 
         while (temp)
         {
-            next = temp->m_next.get();
+            next = temp->m_next;
 
             if (Node* node = dynamic_cast<Node*>(next))
             {
                 if (node->value() == value)
                 {
-                    NodeBase* to_remove = std::move(temp->m_next.get());
-                    temp->m_next = std::move(to_remove->m_next);
+                    NodeBase* to_remove = temp->m_next;
+                    temp->m_next = to_remove->m_next;
+                    delete to_remove;
 
                     m_size--;
                     continue;
                 }
             }
 
-            temp = std::move(temp->m_next.get());
+            temp = temp->m_next;
         }
     }
 
     template<typename T>
     void ForwardList<T>::reverse()
     {
-        std::unique_ptr<NodeBase> temp = std::move(m_head->m_next);
-        std::unique_ptr<NodeBase> prev{};
+        NodeBase* temp{ m_head->m_next };
+
+        auto iter = find_iter_before_last();
+        NodeBase* last{ iter.m_current_node->m_next };
+
+        m_head->m_next = last;
+        last = temp;
+
+        NodeBase* prev{};
+        NodeBase* next{};
 
         for (size_t i = 0; i < m_size; i++)
         {
-            std::unique_ptr<NodeBase> next = std::move(temp->m_next);
-            temp->m_next = std::move(prev);
+            next = temp->m_next;
+            temp->m_next = prev;
 
-            prev = std::move(temp);
-            temp = std::move(next);
+            prev = temp;
+            temp = next;
         }
 
         m_head->m_next = std::move(prev);
@@ -1634,7 +1657,7 @@ namespace dsa
     template<typename T>
     void ForwardList<T>::unique()
     {
-        NodeBase* temp{ m_head.get() };
+        NodeBase* temp{ m_head };
         NodeBase* prev{};
         NodeBase* next{};
         while (temp)
@@ -1643,7 +1666,7 @@ namespace dsa
 
             while (prev)
             {
-                next = prev->m_next.get();
+                next = prev->m_next;
 
                 Node* node_next = dynamic_cast<Node*>(next);
                 Node* node_temp = dynamic_cast<Node*>(temp);
@@ -1651,8 +1674,9 @@ namespace dsa
                 {
                     if (node_next->value() == node_temp->value())
                     {
-                        NodeBase* to_remove = std::move(next);
-                        prev->m_next = std::move(to_remove->m_next);
+                        NodeBase* to_remove = next;
+                        prev->m_next = to_remove->m_next;
+                        delete to_remove;
 
                         m_size--;
                         continue;
@@ -1661,10 +1685,10 @@ namespace dsa
 
                 if (prev)
                 {
-                    prev = prev->m_next.get();
+                    prev = prev->m_next;
                 }
 
-                temp = temp->m_next.get();
+                temp = temp->m_next;
             }
         }
     }

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -375,28 +375,28 @@ namespace dsa
          *
          * @tparam T* pointer to data type
          */
-        using pointer = T*;
+        using pointer = value_type*;
 
         /**
          * @brief Alias for const pointer to data type used in class
          *
          * @tparam T* pointer to data type
          */
-        using const_pointer = const T*;
+        using const_pointer = const value_type*;
 
         /**
          * @brief Alias for reference to data type used in class
          *
          * @tparam T& reference to data type
          */
-        using reference = T&;
+        using reference = value_type&;
 
         /**
          * @brief Alias for const reference to data type used in class
          *
          * @tparam T& const reference to data type
          */
-        using const_reference = const T&;
+        using const_reference = const value_type&;
 
         /**
          * @brief Alias for const iterator to data type used in class

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -36,7 +36,6 @@ namespace dsa
      *
      * @tparam T type of data stored in ForwardList Node
      *
-     * @todo add sort
      * @todo add operator<=>
      * @todo add non-member specialized swap function
      * @todo add non-member specialized erase function
@@ -843,6 +842,16 @@ namespace dsa
         void unique();
 
         /**
+         * @brief Function sorts the elements and preserves the order of equivalent elements
+         *
+         * @details elements are compared using \p operator<
+         *
+         * @note no iterators or references are invalidated,
+         *       if an exception is thrown, the order of elements is unspecified
+         */
+        void sort();
+
+        /**
          * @brief push elements of another ForwardList to base container back
          *
          * @param[in] other ForwardList to read elements from
@@ -1120,6 +1129,26 @@ namespace dsa
          // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
         void transfer(const const_iterator& pos, ForwardList<T>&& other,
             const const_iterator& first, const const_iterator& last);
+
+        /**
+         * @brief Function sorts nodes using merge sort algorithm
+         * @details Sorting is implemented using recursive (top-down) algorithm
+         *          Sorting is stable and inplace
+         *
+         * @param[in,out] source list to sort
+         * @return NodeBase* of sorted list
+         */
+        auto merge_sort(NodeBase* source) -> NodeBase*;
+
+        /**
+         * @brief Helper function for merge_sort to merge two sub-lists
+         * @details Merging of sorted sub-lists is performed recursively
+         *
+         * @param[in,out] left first input sub-list
+         * @param[in,out] right second input sub-list
+         * @return NodeBase* containing sorted elements from both input lists
+         */
+        auto merge(NodeBase* left, NodeBase* right) -> NodeBase*;
 
         NodeBase* m_head{};
         size_type m_size{};
@@ -1863,6 +1892,85 @@ namespace dsa
                 temp = temp->m_next;
             }
         }
+    }
+
+    template<typename T>
+    // Intentional recursive call for sorting nodes in top-down algorithm implementation
+    // NOLINTNEXTLINE(misc-no-recursion)
+    auto ForwardList<T>::merge_sort(NodeBase* source) -> NodeBase*
+    {
+        // Stop condition, one element list is already sorted
+        if (source == nullptr || source->m_next == nullptr)
+        {
+            return source;
+        }
+
+        // Divide list into equal-sized sublists consisting of first and second half of the list
+        NodeBase* left{ source };
+        NodeBase* right{};
+
+        // Use slow and fast pointer to find half of list
+        NodeBase* slow{ source };
+        NodeBase* fast{ source->m_next };
+        while (fast && fast->m_next)
+        {
+            slow = slow->m_next;
+            fast = fast->m_next->m_next;
+        }
+
+        // Split input list into two halfs
+        right = slow->m_next;
+        slow->m_next = nullptr;
+
+        // Recursively sort both sub-lists
+        left = merge_sort(left);
+        right = merge_sort(right);
+
+        // Merge sorted sublists
+        NodeBase* result{ merge(left, right) };
+        return result;
+    }
+
+    template<typename T>
+    // Intentional recursive call for merging nodes in top-down merge_sort algorithm implementation
+    // NOLINTNEXTLINE(misc-no-recursion)
+    auto ForwardList<T>::merge(NodeBase* left, NodeBase* right) -> NodeBase*
+    {
+        // Stop condition, empty element list is already sorted
+        if (left == nullptr)
+        {
+            return right;
+        }
+        if (right == nullptr)
+        {
+            return left;
+        }
+
+        NodeBase* result{};
+        Node* node_left = dynamic_cast<Node*>(left);
+        Node* node_right = dynamic_cast<Node*>(right);
+        if (node_left && node_right)
+        {
+            // Recursively merge nodes
+            if (node_left->m_value <= node_right->m_value)
+            {
+                result = left;
+                result->m_next = merge(left->m_next, right);
+            }
+            else
+            {
+                result = right;
+                result->m_next = merge(left, right->m_next);
+            }
+        }
+
+        return result;
+    }
+
+    template<typename T>
+    void ForwardList<T>::sort()
+    {
+        m_head->m_next = merge_sort(m_head->m_next);
     }
 
     /**

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -201,6 +201,13 @@ namespace dsa
             using value_type = T;
 
             /**
+             * @brief Alias for size type used in class
+             *
+             * @tparam T size type
+             */
+            using size_type = std::size_t;
+
+            /**
              * @brief Alias for pointer to data type used by iterator
              *
              * @tparam T* pointer to data type
@@ -376,6 +383,13 @@ namespace dsa
          * @brief Alias for memory allocator
          */
         using allocator_type = std::allocator<value_type>;
+
+        /**
+         * @brief Alias for size type used in class
+         *
+         * @tparam T size type
+         */
+        using size_type = std::size_t;
 
         /**
          * @brief Alias for pointer to data type used in class

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1643,63 +1643,72 @@ namespace dsa
     // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
     void ForwardList<T>::merge(ForwardList<T>&& other, Compare comp)
     {
-        if (&other != this)
+        if (&other == this)
         {
-            if (m_size != 0)
+            return;
+        }
+
+        if (m_size != 0)
+        {
+            Node* temp_head = construct_node(T{});
+            if (!temp_head)
             {
-                Node* temp_head = construct_node(0);
-                NodeBase* temp_tail = temp_head;
+                // if temporary node could not be allocated
+                // do not modify object state
+                return;
+            }
 
-                NodeBase* to_move{};
-                NodeBase* to_return{};
+            NodeBase* temp_tail = temp_head;
 
-                while (m_head->m_next && other.m_head->m_next)
+            NodeBase* to_move{};
+            NodeBase* to_return{};
+
+            while (m_head->m_next && other.m_head->m_next)
+            {
+                Node* node_this = dynamic_cast<Node*>(m_head->m_next);
+                Node* node_other = dynamic_cast<Node*>(other.m_head->m_next);
+
+                if (node_this && node_other)
                 {
-                    Node* node_this = dynamic_cast<Node*>(m_head->m_next);
-                    Node* node_other = dynamic_cast<Node*>(other.m_head->m_next);
-
-                    if (node_this && node_other)
+                    if (comp(node_this->value(), node_other->value()))
                     {
-                        if (comp(node_this->value(), node_other->value()))
-                        {
-                            to_move = m_head->m_next;
-                            to_return = to_move->m_next;
-                            temp_tail->m_next = to_move;
-                            m_head->m_next = to_return;
-                        }
-                        else
-                        {
-                            to_move = other.m_head->m_next;
-                            to_return = to_move->m_next;
-                            temp_tail->m_next = to_move;
-                            other.m_head->m_next = to_return;
-                        }
-
-                        temp_tail = temp_tail->m_next;
+                        to_move = m_head->m_next;
+                        to_return = to_move->m_next;
+                        temp_tail->m_next = to_move;
+                        m_head->m_next = to_return;
                     }
-                }
+                    else
+                    {
+                        to_move = other.m_head->m_next;
+                        to_return = to_move->m_next;
+                        temp_tail->m_next = to_move;
+                        other.m_head->m_next = to_return;
+                    }
 
-                if (m_head->m_next == nullptr)
-                {
-                    temp_tail->m_next = other.m_head->m_next;
-                    other.m_head->m_next = nullptr;
+                    temp_tail = temp_tail->m_next;
                 }
-                else
-                {
-                    temp_tail->m_next = m_head->m_next;
-                    m_head->m_next = nullptr;
-                }
+            }
 
-                m_head->m_next = temp_head->m_next;
-                destroy_node(temp_head);
-
-                m_size += other.m_size;
-                other.m_size = 0;
+            if (m_head->m_next == nullptr)
+            {
+                temp_tail->m_next = other.m_head->m_next;
+                other.m_head->m_next = nullptr;
             }
             else
             {
-                swap(other);
+                temp_tail->m_next = m_head->m_next;
+                m_head->m_next = nullptr;
             }
+
+            m_head->m_next = temp_head->m_next;
+            destroy_node(temp_head);
+
+            m_size += other.m_size;
+            other.m_size = 0;
+        }
+        else
+        {
+            swap(other);
         }
     }
 
@@ -2056,18 +2065,17 @@ namespace dsa
     template<typename T>
     auto ForwardList<T>::construct_node(const_reference value, NodeBase* next_ptr) -> Node*
     {
-        Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
+        Node* newNode{};
         try
         {
+            newNode = node_alloc_traits::allocate(node_alloc, 1);
             node_alloc_traits::construct(node_alloc, newNode, Node(value));
+            newNode->m_next = next_ptr;
         }
         catch (...)
         {
             node_alloc_traits::deallocate(node_alloc, newNode, 1);
-            throw;
         }
-
-        newNode->m_next = next_ptr;
 
         return newNode;
     }
@@ -2075,18 +2083,17 @@ namespace dsa
     template<typename T>
     auto ForwardList<T>::construct_node(T&& value, NodeBase* next_ptr) -> Node*
     {
-        Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
+        Node* newNode{};
         try
         {
+            newNode = node_alloc_traits::allocate(node_alloc, 1);
             node_alloc_traits::construct(node_alloc, newNode, Node(std::move(value)));
+            newNode->m_next = next_ptr;
         }
         catch (...)
         {
             node_alloc_traits::deallocate(node_alloc, newNode, 1);
-            throw;
         }
-
-        newNode->m_next = next_ptr;
 
         return newNode;
     }

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -231,8 +231,7 @@ namespace dsa
              */
             ForwardListIterator(NodeBase* node) noexcept
                 : m_current_node{ node }
-            {
-            }
+            {}
 
             /**
              * @brief Overload operator= to assign \p node to currently pointed ForwardListIterator
@@ -721,7 +720,7 @@ namespace dsa
         auto erase_after(const const_iterator& pos) -> iterator;
 
         /**
-         * @brief Function erases Node between specified ForwardList Const_Iterators
+         * @brief Function erases Node between specified ForwardList const_iterators
          *
          * @param[in] first element after which element will be erased
          * @param[in] last element after last erased element
@@ -1019,36 +1018,14 @@ namespace dsa
          * @brief Function initialize ForwardList pointer located just before user added data
          * It is used be before begin iterator
          */
-        void init_node()
-        {
-            if (m_head == nullptr)
-            {
-                // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-                m_head = new NodeBase;
-            }
-        }
+        void init_node();
 
         /**
          * @brief Function iterates ForwardList to find iterator to Node before last one
          *
          * @return iterator to Node before last one
          */
-        [[nodiscard]] auto find_iter_before_last() -> iterator
-        {
-            NodeBase* temp{ m_head->m_next };
-            while (temp && temp->m_next && temp->m_next->m_next)
-            {
-                temp = temp->m_next;
-            }
-
-            auto iter = iterator(temp);
-            if (!iter.m_current_node)
-            {
-                iter = before_begin();
-            }
-
-            return iter;
-        }
+        [[nodiscard]] auto find_iter_before_last() -> iterator;
 
         /**
          * @brief Function remove next element
@@ -1056,17 +1033,7 @@ namespace dsa
          * @param[in] pos iterator after which element will be erased
          * @return iterator to element following deleted one
          */
-        auto erase_element_after(iterator pos) -> iterator
-        {
-            NodeBase* temp{ pos.m_current_node };
-            NodeBase* to_remove{ temp->m_next };
-
-            temp->m_next = to_remove->m_next;
-            destroy_node(to_remove);
-
-            m_size--;
-            return iterator(temp->m_next);
-        }
+        auto erase_element_after(iterator pos) -> iterator;
 
         /**
          * @brief Function allocate and construct ForwardList node
@@ -1075,23 +1042,7 @@ namespace dsa
          * @param[in] next_ptr pointer to next Node
          * @return pointer to created Node
          */
-        [[nodiscard]] auto construct_node(const_reference value, NodeBase* next_ptr = nullptr) -> Node*
-        {
-            Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
-            try
-            {
-                node_alloc_traits::construct(node_alloc, newNode, Node(value));
-            }
-            catch (...)
-            {
-                node_alloc_traits::deallocate(node_alloc, newNode, 1);
-                throw;
-            }
-
-            newNode->m_next = next_ptr;
-
-            return newNode;
-        }
+        [[nodiscard]] auto construct_node(const_reference value, NodeBase* next_ptr = nullptr) -> Node*;
 
         /**
          * @brief Function allocate and construct ForwardList node
@@ -1100,38 +1051,14 @@ namespace dsa
          * @param[in] next_ptr pointer to next Node
          * @return pointer to created Node
          */
-        [[nodiscard]] auto construct_node(T&& value, NodeBase* next_ptr = nullptr) -> Node*
-        {
-            Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
-            try
-            {
-                node_alloc_traits::construct(node_alloc, newNode, Node(std::move(value)));
-            }
-            catch (...)
-            {
-                node_alloc_traits::deallocate(node_alloc, newNode, 1);
-                throw;
-            }
-
-            newNode->m_next = next_ptr;
-
-            return newNode;
-        }
+        [[nodiscard]] auto construct_node(T&& value, NodeBase* next_ptr = nullptr) -> Node*;
 
         /**
          * @brief Function destroys and deallocates memory used by Node
          *
          * @param[in] node_to_destroy pointer to Node to delete
          */
-        void destroy_node(NodeBase* node_to_destroy)
-        {
-            Node* node_dyn = dynamic_cast<Node*>(node_to_destroy);
-            if (node_dyn)
-            {
-                node_alloc_traits::destroy(node_alloc, node_dyn);
-                node_alloc_traits::deallocate(node_alloc, node_dyn, 1);
-            }
-        }
+        void destroy_node(NodeBase* node_to_destroy);
 
         /**
          * @brief Function inserts new Node after specified ForwardList iterator
@@ -1142,14 +1069,7 @@ namespace dsa
          * @retval iterator to iterator inserted after \pos
          * @retval nullptr if invalid iterator
          */
-        auto insert_element_after(iterator& pos, const_reference value) -> iterator
-        {
-            NodeBase* temp{ pos.m_current_node };
-            Node* newNode = construct_node(value, temp->m_next);
-            temp->m_next = newNode;
-            m_size++;
-            return iterator(newNode);
-        }
+        auto insert_element_after(iterator& pos, const_reference value) -> iterator;
 
         /**
          * @brief Function inserts new Node after specified ForwardList iterator
@@ -1160,14 +1080,7 @@ namespace dsa
          * @retval iterator to iterator inserted after \pos
          * @retval nullptr if invalid iterator
          */
-        auto insert_element_after(iterator& pos, T&& value) -> iterator
-        {
-            NodeBase* temp{ pos.m_current_node };
-            Node* newNode = construct_node(std::move(value), temp->m_next);
-            temp->m_next = newNode;
-            m_size++;
-            return iterator(newNode);
-        }
+        auto insert_element_after(iterator& pos, T&& value) -> iterator;
 
         /**
          * @brief Function checks ForwardList contains iterator
@@ -1177,19 +1090,7 @@ namespace dsa
          * @return true if \p pos belong to ForwardList
          * @return false if otherwise
          */
-        [[nodiscard]] auto if_valid_iterator(const const_iterator& pos) -> bool
-        {
-            bool valid_iterator{};
-            for (auto it = cbefore_begin(); it != cend(); ++it)
-            {
-                if (it == pos)
-                {
-                    valid_iterator = true;
-                    break;
-                }
-            }
-            return valid_iterator;
-        }
+        [[nodiscard]] auto if_valid_iterator(const const_iterator& pos) -> bool;
 
         /**
          * @brief Function calculate number of elements from first to last
@@ -1284,8 +1185,7 @@ namespace dsa
     template<typename T>
     ForwardList<T>::ForwardList(size_type count)
         : ForwardList(count, T{})
-    {
-    }
+    {}
 
     template<typename T>
     ForwardList<T>::ForwardList(size_type count, const T& value)
@@ -1870,83 +1770,6 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::distance(const_iterator first, const const_iterator& last) -> size_type
-    {
-        size_type dist{};
-        while (first != last)
-        {
-            ++first;
-            ++dist;
-        }
-
-        return dist;
-    }
-
-    template<typename T>
-    // transfers ownership of nodes, moving entire container is not necessary
-    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
-    void ForwardList<T>::transfer(const const_iterator& pos, ForwardList<T>&& other, const const_iterator& iter)
-    {
-        if (&other != this && other.m_size > 0)
-        {
-            NodeBase* temp_prev{ pos.m_current_node };  // to append to
-            NodeBase* temp_next{ iter.m_current_node }; // does not move
-
-            NodeBase* to_move{ temp_next->m_next };
-
-            if (to_move)
-            {
-                temp_next->m_next = to_move->m_next;
-                to_move->m_next = temp_prev->m_next;
-                temp_prev->m_next = to_move;
-
-                m_size += 1;
-                other.m_size -= 1;
-            }
-        }
-    }
-
-    template<typename T>
-    // transfers ownership of nodes, moving entire container is not necessary
-    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
-    void ForwardList<T>::transfer(const const_iterator& pos, ForwardList<T>&& other,
-        const const_iterator& first, const const_iterator& last)
-    {
-        if (&other != this && other.m_size > 0)
-        {
-            const size_type dist = distance(first, last) - 1;
-
-            if (first == last || dist == 0)
-            {
-                return;
-            }
-
-            NodeBase* temp_prev{ pos.m_current_node };     // to append to
-            NodeBase* temp_next{ first.m_current_node };   // does not move
-
-            NodeBase* first_to_move{ temp_next->m_next };
-            NodeBase* last_to_move{ temp_next };
-            for (size_type i = 0; i < dist; i++)
-            {
-                if (last_to_move)
-                {
-                    last_to_move = last_to_move->m_next;
-                }
-            }
-
-            if (temp_next)
-            {
-                temp_next->m_next = last_to_move->m_next;
-                last_to_move->m_next = temp_prev->m_next;
-                temp_prev->m_next = first_to_move;
-
-                m_size += dist;
-                other.m_size -= dist;
-            }
-        }
-    }
-
-    template<typename T>
     void ForwardList<T>::splice_after(const const_iterator& pos, ForwardList<T>& other)
     {
         transfer(pos, std::move(other), other.before_begin(), other.end());
@@ -2101,82 +1924,6 @@ namespace dsa
     }
 
     template<typename T>
-    template<typename Compare>
-    // Intentional recursive call for sorting nodes in top-down algorithm implementation
-    // NOLINTNEXTLINE(misc-no-recursion)
-    auto ForwardList<T>::merge_sort(NodeBase* source, Compare comp) -> NodeBase*
-    {
-        // Stop condition, one element list is already sorted
-        if (source == nullptr || source->m_next == nullptr)
-        {
-            return source;
-        }
-
-        // Divide list into equal-sized sublists consisting of first and second half of the list
-        NodeBase* left{ source };
-        NodeBase* right{};
-
-        // Use slow and fast pointer to find half of list
-        NodeBase* slow{ source };
-        NodeBase* fast{ source->m_next };
-        while (fast && fast->m_next)
-        {
-            slow = slow->m_next;
-            fast = fast->m_next->m_next;
-        }
-
-        // Split input list into two halfs
-        right = slow->m_next;
-        slow->m_next = nullptr;
-
-        // Recursively sort both sub-lists
-        left = merge_sort(left, comp);
-        right = merge_sort(right, comp);
-
-        // Merge sorted sublists
-        NodeBase* result{ merge(left, right, comp) };
-        return result;
-    }
-
-    template<typename T>
-    template<typename Compare>
-    // Intentional recursive call for merging nodes in top-down merge_sort algorithm implementation
-    // NOLINTNEXTLINE(misc-no-recursion)
-    auto ForwardList<T>::merge(NodeBase* left, NodeBase* right, Compare comp) -> NodeBase*
-    {
-        // Stop condition, empty element list is already sorted
-        if (left == nullptr)
-        {
-            return right;
-        }
-        if (right == nullptr)
-        {
-            return left;
-        }
-
-        NodeBase* result{};
-        Node* node_left = dynamic_cast<Node*>(left);
-        Node* node_right = dynamic_cast<Node*>(right);
-        if (node_left && node_right)
-        {
-            // Recursively merge nodes
-            //if (node_left->m_value <= node_right->m_value)
-            if (comp(node_left->m_value, node_right->m_value))
-            {
-                result = left;
-                result->m_next = merge(left->m_next, right, comp);
-            }
-            else
-            {
-                result = right;
-                result->m_next = merge(left, right->m_next, comp);
-            }
-        }
-
-        return result;
-    }
-
-    template<typename T>
     void ForwardList<T>::sort()
     {
         m_head->m_next = merge_sort(m_head->m_next, std::less<>());
@@ -2327,6 +2074,285 @@ namespace dsa
     auto erase_if(ForwardList<T>& container, Pred pred) -> ForwardList<T>::size_type
     {
         return container.remove_if(pred);
+    }
+
+    // definitions of private methods
+
+    template<typename T>
+    void ForwardList<T>::init_node()
+    {
+        if (m_head == nullptr)
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+            m_head = new NodeBase;
+        }
+    }
+
+    template<typename T>
+    auto ForwardList<T>::find_iter_before_last() -> iterator
+    {
+        NodeBase* temp{ m_head->m_next };
+        while (temp && temp->m_next && temp->m_next->m_next)
+        {
+            temp = temp->m_next;
+        }
+
+        auto iter = iterator(temp);
+        if (!iter.m_current_node)
+        {
+            iter = before_begin();
+        }
+
+        return iter;
+    }
+
+    template<typename T>
+    auto ForwardList<T>::erase_element_after(iterator pos) -> iterator
+    {
+        NodeBase* temp{ pos.m_current_node };
+        NodeBase* to_remove{ temp->m_next };
+
+        temp->m_next = to_remove->m_next;
+        destroy_node(to_remove);
+
+        m_size--;
+        return iterator(temp->m_next);
+    }
+
+    template<typename T>
+    auto ForwardList<T>::construct_node(const_reference value, NodeBase* next_ptr) -> Node*
+    {
+        Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
+        try
+        {
+            node_alloc_traits::construct(node_alloc, newNode, Node(value));
+        }
+        catch (...)
+        {
+            node_alloc_traits::deallocate(node_alloc, newNode, 1);
+            throw;
+        }
+
+        newNode->m_next = next_ptr;
+
+        return newNode;
+    }
+
+    template<typename T>
+    auto ForwardList<T>::construct_node(T&& value, NodeBase* next_ptr) -> Node*
+    {
+        Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
+        try
+        {
+            node_alloc_traits::construct(node_alloc, newNode, Node(std::move(value)));
+        }
+        catch (...)
+        {
+            node_alloc_traits::deallocate(node_alloc, newNode, 1);
+            throw;
+        }
+
+        newNode->m_next = next_ptr;
+
+        return newNode;
+    }
+
+    template<typename T>
+    void ForwardList<T>::destroy_node(NodeBase* node_to_destroy)
+    {
+        Node* node_dyn = dynamic_cast<Node*>(node_to_destroy);
+        if (node_dyn)
+        {
+            node_alloc_traits::destroy(node_alloc, node_dyn);
+            node_alloc_traits::deallocate(node_alloc, node_dyn, 1);
+        }
+    }
+
+    template<typename T>
+    auto ForwardList<T>::insert_element_after(iterator& pos, const_reference value) -> iterator
+    {
+        NodeBase* temp{ pos.m_current_node };
+        Node* newNode = construct_node(value, temp->m_next);
+        temp->m_next = newNode;
+        m_size++;
+        return iterator(newNode);
+    }
+
+    template<typename T>
+    auto ForwardList<T>::insert_element_after(iterator& pos, T&& value) -> iterator
+    {
+        NodeBase* temp{ pos.m_current_node };
+        Node* newNode = construct_node(std::move(value), temp->m_next);
+        temp->m_next = newNode;
+        m_size++;
+        return iterator(newNode);
+    }
+
+    template<typename T>
+    auto ForwardList<T>::if_valid_iterator(const const_iterator& pos) -> bool
+    {
+        bool valid_iterator{};
+        for (auto it = cbefore_begin(); it != cend(); ++it)
+        {
+            if (it == pos)
+            {
+                valid_iterator = true;
+                break;
+            }
+        }
+        return valid_iterator;
+    }
+
+    template<typename T>
+    auto ForwardList<T>::distance(const_iterator first, const const_iterator& last) -> size_type
+    {
+        size_type dist{};
+        while (first != last)
+        {
+            ++first;
+            ++dist;
+        }
+
+        return dist;
+    }
+
+    template<typename T>
+    // transfers ownership of nodes, moving entire container is not necessary
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+    void ForwardList<T>::transfer(const const_iterator& pos, ForwardList<T>&& other, const const_iterator& iter)
+    {
+        if (&other != this && other.m_size > 0)
+        {
+            NodeBase* temp_prev{ pos.m_current_node };  // to append to
+            NodeBase* temp_next{ iter.m_current_node }; // does not move
+
+            NodeBase* to_move{ temp_next->m_next };
+
+            if (to_move)
+            {
+                temp_next->m_next = to_move->m_next;
+                to_move->m_next = temp_prev->m_next;
+                temp_prev->m_next = to_move;
+
+                m_size += 1;
+                other.m_size -= 1;
+            }
+        }
+    }
+
+    template<typename T>
+    // transfers ownership of nodes, moving entire container is not necessary
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+    void ForwardList<T>::transfer(const const_iterator& pos, ForwardList<T>&& other,
+        const const_iterator& first, const const_iterator& last)
+    {
+        if (&other != this && other.m_size > 0)
+        {
+            const size_type dist = distance(first, last) - 1;
+
+            if (first == last || dist == 0)
+            {
+                return;
+            }
+
+            NodeBase* temp_prev{ pos.m_current_node };     // to append to
+            NodeBase* temp_next{ first.m_current_node };   // does not move
+
+            NodeBase* first_to_move{ temp_next->m_next };
+            NodeBase* last_to_move{ temp_next };
+            for (size_type i = 0; i < dist; i++)
+            {
+                if (last_to_move)
+                {
+                    last_to_move = last_to_move->m_next;
+                }
+            }
+
+            if (temp_next)
+            {
+                temp_next->m_next = last_to_move->m_next;
+                last_to_move->m_next = temp_prev->m_next;
+                temp_prev->m_next = first_to_move;
+
+                m_size += dist;
+                other.m_size -= dist;
+            }
+        }
+    }
+
+    template<typename T>
+    template<typename Compare>
+    // Intentional recursive call for sorting nodes in top-down algorithm implementation
+    // NOLINTNEXTLINE(misc-no-recursion)
+    auto ForwardList<T>::merge_sort(NodeBase* source, Compare comp) -> NodeBase*
+    {
+        // Stop condition, one element list is already sorted
+        if (source == nullptr || source->m_next == nullptr)
+        {
+            return source;
+        }
+
+        // Divide list into equal-sized sublists consisting of first and second half of the list
+        NodeBase* left{ source };
+        NodeBase* right{};
+
+        // Use slow and fast pointer to find half of list
+        NodeBase* slow{ source };
+        NodeBase* fast{ source->m_next };
+        while (fast && fast->m_next)
+        {
+            slow = slow->m_next;
+            fast = fast->m_next->m_next;
+        }
+
+        // Split input list into two halfs
+        right = slow->m_next;
+        slow->m_next = nullptr;
+
+        // Recursively sort both sub-lists
+        left = merge_sort(left, comp);
+        right = merge_sort(right, comp);
+
+        // Merge sorted sublists
+        NodeBase* result{ merge(left, right, comp) };
+        return result;
+    }
+
+    template<typename T>
+    template<typename Compare>
+    // Intentional recursive call for merging nodes in top-down merge_sort algorithm implementation
+    // NOLINTNEXTLINE(misc-no-recursion)
+    auto ForwardList<T>::merge(NodeBase* left, NodeBase* right, Compare comp) -> NodeBase*
+    {
+        // Stop condition, empty element list is already sorted
+        if (left == nullptr)
+        {
+            return right;
+        }
+        if (right == nullptr)
+        {
+            return left;
+        }
+
+        NodeBase* result{};
+        Node* node_left = dynamic_cast<Node*>(left);
+        Node* node_right = dynamic_cast<Node*>(right);
+        if (node_left && node_right)
+        {
+            // Recursively merge nodes
+            if (comp(node_left->m_value, node_right->m_value))
+            {
+                result = left;
+                result->m_next = merge(left->m_next, right, comp);
+            }
+            else
+            {
+                result = right;
+                result->m_next = merge(left, right->m_next, comp);
+            }
+        }
+
+        return result;
     }
 }
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -36,7 +36,6 @@ namespace dsa
      *
      * @tparam T type of data stored in ForwardList Node
      *
-     * @todo add remove
      * @todo add remove_if
      * @todo add sort
      * @todo add operator<=>
@@ -815,8 +814,11 @@ namespace dsa
          * @brief Function removes all elements equal to \p value
          *
          * @param[in] value value of elements to remove
+         * @return size_type number of elements removed
+         *
+         * @note invalidates only the iterators and references to the removed elements
          */
-        void remove(const_reference value);
+        auto remove(const_reference value) -> size_type;
 
         /**
          * @brief Function reverts in place Nodes of ForwardList
@@ -1749,10 +1751,12 @@ namespace dsa
     }
 
     template<typename T>
-    void ForwardList<T>::remove(const_reference value)
+    auto ForwardList<T>::remove(const_reference value) -> size_type
     {
         NodeBase* temp{ m_head };
         NodeBase* next{};
+
+        size_type removed_count{};
 
         while (temp)
         {
@@ -1766,6 +1770,7 @@ namespace dsa
                     temp->m_next = to_remove->m_next;
                     destroy_node(to_remove);
 
+                    removed_count++;
                     m_size--;
                     continue;
                 }
@@ -1773,6 +1778,8 @@ namespace dsa
 
             temp = temp->m_next;
         }
+
+        return removed_count;
     }
 
     template<typename T>

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -28,9 +28,6 @@ namespace dsa
     template<typename T>
     class ForwardList;
 
-    template<typename T>
-    auto operator+(const ForwardList<T>& list1, const ForwardList<T>& list2) -> ForwardList<T>;
-
     /**
      * @brief Implements ForwardList using Node with pointer to next element
      *        as internal base
@@ -863,43 +860,6 @@ namespace dsa
         void sort(Compare comp);
 
         /**
-         * @brief push elements of another ForwardList to base container back
-         *
-         * @param[in] other ForwardList to read elements from
-         * @return ForwardList<T>&
-         */
-        auto operator+=(const ForwardList<T>& other) -> ForwardList<T>&
-        {
-            auto before_last = find_iter_before_last();
-
-            for (auto it = other.cbegin(); it != other.cend(); ++it)
-            {
-                T value = *it;
-                before_last = insert_after(before_last, value);
-            }
-
-            return *this;
-        }
-
-        /**
-         * @brief push elements of another ForwardList to base container back
-         *
-         * @param[in] init_list initializer_list to read elements from
-         * @return ForwardList<T>&
-         */
-        auto operator+=(const std::initializer_list<T> init_list) -> ForwardList<T>&
-        {
-            auto before_last = find_iter_before_last();
-
-            for (const auto& item : init_list)
-            {
-                before_last = insert_after(before_last, item);
-            }
-
-            return *this;
-        }
-
-        /**
          * @brief Function returns ForwardList size
          *
          * @return size_type number of elements in container
@@ -910,18 +870,6 @@ namespace dsa
         }
 
     private:
-
-        /**
-         * @brief Construct new object based on two ForwardList objects
-         *
-         * Forward friend declaration of ForwardList operator+
-         *
-         * @tparam T type of data stored in ForwardList Node
-         * @param[in] list1 input ForwardList
-         * @param[in] list2 input ForwardList
-         * @return ForwardList<T> with content of two input lists
-         */
-        friend auto operator+<>(const ForwardList<T>& list1, const ForwardList<T>& list2)->ForwardList<T>;
 
         /**
          * @brief Function initialize ForwardList pointer located just before user added data
@@ -1947,30 +1895,6 @@ namespace dsa
     void ForwardList<T>::sort(Compare comp)
     {
         m_head->m_next = merge_sort(m_head->m_next, comp);
-    }
-
-    /**
-     * @brief Construct new object based on two ForwardList objects
-     *
-     * @tparam T type of data stored in ForwardList Node
-     * @param[in] list1 input ForwardList
-     * @param[in] list2 input ForwardList
-     * @return ForwardList<T> with content of two input lists
-     */
-    template<typename T>
-    auto operator+(const ForwardList<T>& list1, const ForwardList<T>& list2) -> ForwardList<T>
-    {
-        ForwardList<T> temp(list1);
-        auto before_last = temp.find_iter_before_last();
-        ++before_last;
-
-        for (auto iter = list2.cbegin(); iter != list2.cend(); ++iter)
-        {
-            T value = *iter;
-            before_last = temp.insert_after(before_last, value);
-        }
-
-        return temp;
     }
 
     /**

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -945,10 +945,50 @@ namespace dsa
             NodeBase* to_remove{ temp->m_next };
 
             temp->m_next = to_remove->m_next;
-            delete to_remove;
+            destroy_node(to_remove);
 
             m_size--;
             return iterator(temp->m_next);
+        }
+
+        /**
+         * @brief Function allocate and construct ForwardList node
+         *
+         * @param[in] value element of type T to be inserted
+         * @param[in] next_ptr pointer to next Node
+         * @return pointer to created Node
+         */
+        auto construct_node(const_reference value, NodeBase* next_ptr = nullptr) -> Node*
+        {
+            Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
+            try
+            {
+                node_alloc_traits::construct(node_alloc, newNode, Node(value));
+            }
+            catch (...)
+            {
+                node_alloc_traits::deallocate(node_alloc, newNode, 1);
+                throw;
+            }
+
+            newNode->m_next = next_ptr;
+
+            return newNode;
+        }
+
+        /**
+         * @brief Function destroys and deallocates memory used by Node
+         *
+         * @param[in] node_to_destroy pointer to Node to delete
+         */
+        void destroy_node(NodeBase* node_to_destroy)
+        {
+            Node* node_dyn = dynamic_cast<Node*>(node_to_destroy);
+            if (node_dyn)
+            {
+                node_alloc_traits::destroy(node_alloc, node_dyn);
+                node_alloc_traits::deallocate(node_alloc, node_dyn, 1);
+            }
         }
 
         /**
@@ -963,10 +1003,7 @@ namespace dsa
         auto insert_element_after(iterator& pos, const_reference value) -> iterator
         {
             NodeBase* temp{ pos.m_current_node };
-
-            Node* newNode = new Node(value);
-            newNode->m_next = temp->m_next;
-
+            Node* newNode = construct_node(value, temp->m_next);
             temp->m_next = newNode;
             m_size++;
             return iterator(newNode);
@@ -1037,6 +1074,21 @@ namespace dsa
          * @brief Allocator for memory management
          */
         allocator_type m_allocator{};
+
+        /**
+         * @brief Rebind allocator to create new objects of type Node
+         */
+        using node_allocator = typename std::allocator_traits<std::allocator<T>>::template rebind_alloc<Node>;
+
+        /**
+         * @brief Setup allocator traits used for Node creation and deletion
+         */
+        using node_alloc_traits = std::allocator_traits<node_allocator>;
+
+        /**
+         * @brief Initialize allocator rebind to Node objects
+         */
+        node_allocator node_alloc{};
     };
 
     template<typename T>
@@ -1263,7 +1315,7 @@ namespace dsa
             while (temp)
             {
                 m_head->m_next = temp->m_next;
-                delete temp;
+                destroy_node(temp);
                 temp = m_head->m_next;
             }
 
@@ -1351,7 +1403,7 @@ namespace dsa
     template<typename T>
     void ForwardList<T>::push_front(T value)
     {
-        Node* newNode = new Node(value);
+        Node* newNode = construct_node(value);
         if (!m_head->m_next)
         {
             m_head->m_next = newNode;
@@ -1382,7 +1434,7 @@ namespace dsa
         {
             m_head->m_next = temp->m_next;
         }
-        delete temp;
+        destroy_node(temp);
 
         m_size--;
     }
@@ -1454,7 +1506,7 @@ namespace dsa
         {
             if (m_size != 0)
             {
-                NodeBase* temp_head = new NodeBase;
+                Node* temp_head = construct_node(0);
                 NodeBase* temp_tail = temp_head;
 
                 NodeBase* to_move{};
@@ -1498,7 +1550,7 @@ namespace dsa
                 }
 
                 m_head->m_next = temp_head->m_next;
-                delete temp_head;
+                destroy_node(temp_head);
 
                 m_size += other.m_size;
                 other.m_size = 0;
@@ -1640,7 +1692,7 @@ namespace dsa
                 {
                     NodeBase* to_remove = temp->m_next;
                     temp->m_next = to_remove->m_next;
-                    delete to_remove;
+                    destroy_node(to_remove);
 
                     m_size--;
                     continue;
@@ -1699,7 +1751,7 @@ namespace dsa
                     {
                         NodeBase* to_remove = next;
                         prev->m_next = to_remove->m_next;
-                        delete to_remove;
+                        destroy_node(to_remove);
 
                         m_size--;
                         continue;

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -36,7 +36,6 @@ namespace dsa
      *
      * @tparam T type of data stored in ForwardList Node
      *
-     * @todo add remove_if
      * @todo add sort
      * @todo add operator<=>
      * @todo add non-member specialized swap function
@@ -819,6 +818,18 @@ namespace dsa
          * @note invalidates only the iterators and references to the removed elements
          */
         auto remove(const_reference value) -> size_type;
+
+        /**
+         * @brief Function removes all elements for which \p predicate returns \p true
+         *
+         * @tparam UnaryPred
+         * @param[in] predicate to remove elements
+         * @return size_type number of elements removed
+         *
+         * @note invalidates only the iterators and references to the removed elements
+         */
+        template<typename UnaryPred>
+        auto remove_if(UnaryPred predicate) -> size_type;
 
         /**
          * @brief Function reverts in place Nodes of ForwardList
@@ -1753,6 +1764,13 @@ namespace dsa
     template<typename T>
     auto ForwardList<T>::remove(const_reference value) -> size_type
     {
+        return remove_if([value](T node_val) { return node_val == value; });
+    }
+
+    template<typename T>
+    template<typename UnaryPred>
+    auto ForwardList<T>::remove_if(UnaryPred predicate) -> size_type
+    {
         NodeBase* temp{ m_head };
         NodeBase* next{};
 
@@ -1764,7 +1782,7 @@ namespace dsa
 
             if (Node* node = dynamic_cast<Node*>(next))
             {
-                if (node->value() == value)
+                if (predicate(node->value()))
                 {
                     NodeBase* to_remove = temp->m_next;
                     temp->m_next = to_remove->m_next;

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -299,33 +299,6 @@ namespace dsa
             }
 
             /**
-             * @brief Overload operator[] for ForwardListIterator iterator access
-             *
-             * @param[in] index number of Node to move forward
-             * @return ForwardListIterator to Node pointed by \p index from ForwardList front
-             * @retval valid ForwardListIterator if index is valid
-             * @retval nullptr if index is invalid
-             */
-            auto operator[](size_type index) -> ForwardListIterator
-            {
-                NodeBase* temp{ m_current_node };
-
-                for (size_type i = 0; i < index; i++)
-                {
-                    if (temp->m_next)
-                    {
-                        temp = temp->m_next;
-                    }
-                    else
-                    {
-                        return nullptr;
-                    }
-                }
-
-                return temp;
-            }
-
-            /**
              * @brief Overload operator* to dereference Node value / data
              *
              * @return T& reference or const reference to data stored in Node

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -963,8 +963,10 @@ namespace dsa
         /**
          * @brief Function removes consecutive duplicated elements
          * @details Only the first occurrence of given element in each group is preserved
+         *
+         * @return size_type number of elements removed
          */
-        void unique();
+        auto unique() -> size_type;
 
         /**
          * @brief Function sorts the elements and preserves the order of equivalent elements
@@ -2036,11 +2038,14 @@ namespace dsa
     }
 
     template<typename T>
-    void ForwardList<T>::unique()
+    auto ForwardList<T>::unique() -> size_type
     {
         NodeBase* temp{ m_head };
         NodeBase* prev{};
         NodeBase* next{};
+
+        size_type removed_count{};
+
         while (temp)
         {
             prev = temp;
@@ -2059,6 +2064,7 @@ namespace dsa
                         prev->m_next = to_remove->m_next;
                         destroy_node(to_remove);
 
+                        removed_count++;
                         m_size--;
                         continue;
                     }
@@ -2072,6 +2078,8 @@ namespace dsa
                 temp = temp->m_next;
             }
         }
+
+        return removed_count;
     }
 
     template<typename T>

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -33,8 +33,6 @@ namespace dsa
      *        as internal base
      *
      * @tparam T type of data stored in ForwardList Node
-     *
-     * @todo remove public functions / operators not supported by std::forward_list
      */
     template<typename T>
     class ForwardList

--- a/tests/common.h
+++ b/tests/common.h
@@ -43,18 +43,56 @@
   */
 namespace tests
 {
-    struct ThrowingType
-    {
-        ThrowingType() = default;
-        ~ThrowingType() = default;
-        ThrowingType(const ThrowingType&) = default;
-        ThrowingType(ThrowingType&&) = default;
+    constexpr size_t throwing_type_size_limit = 5;
 
-        auto operator=(ThrowingType&& /*other*/) noexcept(false) -> ThrowingType&
+    /**
+     * @brief Class used to test exception handling
+     */
+    class ThrowingType
+    {
+    public:
+
+        /**
+         * @brief Default ctor of ThrowingType
+         */
+        ThrowingType()
         {
-            return *this;
+            conditional_exception("ThrowingType size limit reached in ctor");
         }
 
+        /**
+         * @brief Copy ctor of ThrowingType
+         *
+         * @param[in] other unused parameter
+         */
+        ThrowingType(const ThrowingType& /*other*/)
+        {
+            conditional_exception("ThrowingType size limit reached in copy ctor");
+        }
+
+        /**
+         * @brief Move ctor of ThrowingType
+         *
+         * @param[in] other unused parameter
+         */
+         // move constructors intentionally throw exception
+         // NOLINTNEXTLINE(cppcoreguidelines-noexcept-move-operations,performance-noexcept-move-constructor,bugprone-exception-escape)
+        ThrowingType(ThrowingType&& /*other*/)
+        {
+            conditional_exception("ThrowingType size limit reached in move ctor");
+        }
+
+        /**
+         * @brief Default dtor of ThrowingType
+         */
+        ~ThrowingType() = default;
+
+        /**
+         * @brief Copy assignment of ThrowingType
+         *
+         * @param[in] other unused parameter
+         * @return source ThrowingType object
+         */
         auto operator=(const ThrowingType& other) noexcept(false) -> ThrowingType&
         {
             // empty if statement silences clang-tidy warning for copy assignment operator in mock struct
@@ -62,15 +100,64 @@ namespace tests
             return *this;
         }
 
-        auto operator==(const ThrowingType& /* unused */) const -> bool
+        /**
+         * @brief Move assignment of ThrowingType
+         *
+         * @param[in] other unused parameter
+         * @return source ThrowingType object
+         */
+        auto operator=(ThrowingType&& /*other*/) noexcept(false) -> ThrowingType&
+        {
+            return *this;
+        }
+
+        /**
+         * @brief Operator used to check if two objects of ThrowingType are equal
+         *
+         * @param[in] other unused parameter
+         * @return true
+         */
+        auto operator==(const ThrowingType& /* other */) const -> bool
         {
             return true;
         }
 
-        auto operator<=>(const ThrowingType& /* unused */) const noexcept(false)
+        /**
+         * @brief Operator used to compare two objects of ThrowingType
+         *
+         * @param[in] other unused parameter
+         * @return std::strong_ordering::equal
+         */
+        auto operator<=>(const ThrowingType& /* other */) const noexcept(false)
         {
             return std::strong_ordering::equal;
         }
+
+    private:
+
+        /**
+         * @brief Function throws exception
+         *
+         * @param[in] msg message to print to standard output
+         */
+        void conditional_exception(const std::string& msg) const
+        {
+            if (++m_counter >= m_size_limit)
+            {
+                m_counter = 0;
+                throw std::runtime_error(msg);
+            }
+        }
+
+        /**
+         * @brief Internal counter for throwing exceptions
+         */
+        static inline size_t m_counter{ 0 };
+
+        /**
+         * @brief Internal size limit for throwing exceptions
+         */
+        size_t m_size_limit{ throwing_type_size_limit };
     };
 
     /**

--- a/tests/common.h
+++ b/tests/common.h
@@ -43,6 +43,36 @@
   */
 namespace tests
 {
+    struct ThrowingType
+    {
+        ThrowingType() = default;
+        ~ThrowingType() = default;
+        ThrowingType(const ThrowingType&) = default;
+        ThrowingType(ThrowingType&&) = default;
+
+        auto operator=(ThrowingType&& /*other*/) noexcept(false) -> ThrowingType&
+        {
+            return *this;
+        }
+
+        auto operator=(const ThrowingType& other) noexcept(false) -> ThrowingType&
+        {
+            // empty if statement silences clang-tidy warning for copy assignment operator in mock struct
+            if (this != &other) {}
+            return *this;
+        }
+
+        auto operator==(const ThrowingType& /* unused */) const -> bool
+        {
+            return true;
+        }
+
+        auto operator<=>(const ThrowingType& /* unused */) const noexcept(false)
+        {
+            return std::strong_ordering::equal;
+        }
+    };
+
     /**
      * @enum ExceptionCode
      * @brief Determines return codes for exceptions in tests

--- a/tests/forward_list/CMakeLists.txt
+++ b/tests/forward_list/CMakeLists.txt
@@ -59,3 +59,7 @@ add_test(NAME forward_list_itors_test COMMAND forward_list_itors_test)
 add_executable(forward_list_ranges_test forward_list_ranges_test.cpp ${SRC_DIR}/common.cpp)
 target_link_libraries(forward_list_ranges_test PRIVATE dsa_testing)
 add_test(NAME forward_list_ranges_test COMMAND forward_list_ranges_test)
+
+add_executable(forward_list_sort_test forward_list_sort_test.cpp ${SRC_DIR}/common.cpp)
+target_link_libraries(forward_list_sort_test PRIVATE dsa_testing)
+add_test(NAME forward_list_sort_test COMMAND forward_list_sort_test)

--- a/tests/forward_list/forward_list_ctors_test.cpp
+++ b/tests/forward_list/forward_list_ctors_test.cpp
@@ -16,6 +16,7 @@
 #include <forward_list>
 #include <initializer_list>
 #include <iostream>
+#include <iterator>
 #include <utility>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
@@ -87,6 +88,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected10{ 0, 0, 0, 0, 0 };
         tests::compare("ForwardList10", list10, expected10);
 
+        std::cout << "Construct from other ForwardList\n";
+        dsa::ForwardList<int> temp11 = { 0, 10, 20, 30, 40, 50 };
+        const dsa::ForwardList<int> list11(std::next(temp11.begin(), 1), std::next(temp11.begin(), 4));
+        const std::initializer_list<int> expected11{ 10, 20, 30 };
+        tests::compare("ForwardList11", list11, expected11);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -116,14 +123,26 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list5 = std_list1;
         tests::compare("ForwardList5 vs std", list5, expected);
 
-        std::forward_list<int> std_temp_1(std_list1);
-        const std::forward_list<int> std_list6 = std::move(std_temp_1);
-        tests::compare("ForwardList6 vs std", list6, expected);
+        std::forward_list<int> std_list6{ 0, 10, 20 };
+        auto* std_pointer6 = &std_list6;
+        std_list6 = *std_pointer6;
+        tests::compare("ForwardList6 vs std", list6, std_list6);
 
-        std::forward_list<int> std_temp_2(std_list1);
-        std::forward_list<int> std_list7(0);
-        std_list7 = std::move(std_temp_2);
-        tests::compare("ForwardList7 vs std", list7, expected);
+        std::forward_list<int> std_temp_7(std_list1);
+        const std::forward_list<int> std_list7 = std::move(std_temp_7);
+        tests::compare("ForwardList7 vs std", list7, std_list7);
+
+        std::forward_list<int> std_temp_8(std_list1);
+        std::forward_list<int> std_list8(1, 0);
+        std_list8 = std::move(std_temp_8);
+        tests::compare("ForwardList8 vs std", list8, std_list8);
+
+        const std::forward_list<int> std_list10(5);
+        tests::compare("ForwardList10 vs std", list10, std_list10);
+
+        std::forward_list<int> std_temp11 = { 0, 10, 20, 30, 40, 50 };
+        const std::forward_list<int> std_list11(std::next(std_temp11.begin(), 1), std::next(std_temp11.begin(), 4));
+        tests::compare("ForwardList11 vs std", list11, std_list11);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_get_test.cpp
+++ b/tests/forward_list/forward_list_get_test.cpp
@@ -26,37 +26,19 @@ int main() // NOLINT(modernize-use-trailing-return-type)
     {
         std::cout << "Start forward_list_get_test:\n";
 
-        const dsa::ForwardList<int> list1 = dsa::ForwardList<int>({ 0, 10, 20 });
-        // Try reading some nodes with invalid indexes
+        dsa::ForwardList<int> list1 = dsa::ForwardList<int>({ 0, 10, 20 });
         const std::initializer_list<int> expected1 = { 0, 10, 20 };
-        auto indexes = { -1, 0, 1, 2, 100 };
-        for (size_t i = 0; i < indexes.size(); i++)
+        const size_t list1_size = list1.size();
+        for (size_t i = 0; i < list1_size; i++)
         {
-            auto* temp = list1.get(i);
-            if (static_cast<bool>(temp))
-            {
-                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-                tests::compare(temp->value(), expected1.begin()[i]);
-            }
+            const int temp = list1.front();
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            tests::compare("ForwardList1", temp, expected1.begin()[i]);
+            list1.pop_front();
         }
-        tests::compare("ForwardList1", list1, expected1);
 
         const dsa::ForwardList<int> list2 = dsa::ForwardList<int>({ 20, 10, 0 });
-        const std::initializer_list<int> expected2 = { 20, 10, 0 };
-        size_t idx = 0;
-        for (const auto& item : expected2)
-        {
-            auto* temp = list2.get(idx);
-            if (static_cast<bool>(temp))
-            {
-                tests::compare(temp->value(), item);
-            }
-            idx++;
-        }
-        tests::compare("ForwardList2", list2, expected2);
-
-        const dsa::ForwardList<int> list3 = dsa::ForwardList<int>({ 0, 10, 20 });
-        tests::compare("ForwardList3 front", list3.front(), 0);
+        tests::compare("ForwardList2 front", list2.front(), 20);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_grow_test.cpp
+++ b/tests/forward_list/forward_list_grow_test.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <iterator>
 #include <memory>
+#include <stdexcept>
 #include <utility>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
@@ -154,6 +155,82 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         constexpr int expected16{ 1 };
         tests::compare("ForwardList16", *list16.front(), expected16);
         tests::compare("ptr16 == nullptr", ptr16 == nullptr, true);
+
+        try
+        {
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                const tests::ThrowingType throwing_type{};
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "Runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::ForwardList<tests::ThrowingType> list17{};
+            const tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                list17.push_front(throwing_type);
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "List17 runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::ForwardList<tests::ThrowingType> list18{};
+            tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                // intentional use of moved object
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                list18.push_front(std::move(throwing_type));
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "list18 runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::ForwardList<tests::ThrowingType> list19{};
+            const tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                list19.emplace_after(list19.before_begin(), throwing_type);
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "List19 runtime error exception handled correctly\n\n";
+        }
 
 
         std::cout << "Compare operations results with std container\n\n";

--- a/tests/forward_list/forward_list_grow_test.cpp
+++ b/tests/forward_list/forward_list_grow_test.cpp
@@ -245,6 +245,26 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList21", list21, expected21);
         tests::compare("ForwardList21 it", list21_it == nullptr, true);
 
+        dsa::ForwardList<int> list22{ 0, 10, 20 };
+        auto list22_it = list22.insert_after(list22.begin(), list22.begin(), list22.begin());
+        const std::initializer_list<int> expected22{ 0, 10, 20 };
+        tests::compare("ForwardList22", list22, expected22);
+        tests::compare("ForwardList22 it", *list22_it, *list22.begin());
+
+        dsa::ForwardList<std::unique_ptr<int>> list23{};
+        auto ptr23 = std::make_unique<int>(1);
+        auto list23_it = list23.insert_after(list23.end(), std::move(ptr23));
+        tests::compare("ForwardList23 it", list23_it == nullptr, true);
+
+        dsa::ForwardList<int> list24{ 0, 10, 20 };
+        dsa::ForwardList<int> list25{ 30, 40, 50 };
+        auto list24_it = list24.insert_after(list24.begin(), list25.begin(), std::next(list25.begin()));
+        const std::initializer_list<int> expected24{ 0, 30, 10, 20 };
+        const std::initializer_list<int> expected28{ 30, 40, 50 };
+        tests::compare("ForwardList24", list24, expected24);
+        tests::compare("ForwardList24 it", *list24_it, list25.front());
+        tests::compare("ForwardList25", list25, expected28);
+
 
         std::cout << "Compare operations results with std container\n\n";
 

--- a/tests/forward_list/forward_list_grow_test.cpp
+++ b/tests/forward_list/forward_list_grow_test.cpp
@@ -17,6 +17,7 @@
 #include <initializer_list>
 #include <iostream>
 #include <iterator>
+#include <memory>
 #include <utility>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
@@ -146,6 +147,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected15 = { 0, 10, 20, 30, 40 };
         tests::compare("ForwardList15", list15, expected15);
 
+        dsa::ForwardList<std::unique_ptr<int>> list16{};
+        auto ptr16 = std::make_unique<int>(1);
+        list16.push_front(std::move(ptr16));
+        constexpr int expected16{ 1 };
+        tests::compare("ForwardList16", *list16.front(), expected16);
+        tests::compare("ptr16 == nullptr", ptr16 == nullptr, true);
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -191,12 +198,11 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList11 it vs std", *list11_it, *std_list11_it);
         tests::compare("ForwardList11 temp it vs std", *temp11_it, *std_temp11_it);
 
-
-
-
-
-
-
+        std::forward_list<std::unique_ptr<int>> std_list16{};
+        auto std_ptr16 = std::make_unique<int>(1);
+        std_list16.push_front(std::move(std_ptr16));
+        tests::compare("ForwardList17 vs std", *list16.front(), expected16);
+        tests::compare("ptr16 == nullptr vs std", ptr16 == nullptr, std_ptr16 == nullptr);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_grow_test.cpp
+++ b/tests/forward_list/forward_list_grow_test.cpp
@@ -232,6 +232,19 @@ int main() // NOLINT(modernize-use-trailing-return-type)
             std::cout << "List19 runtime error exception handled correctly\n\n";
         }
 
+        dsa::ForwardList<int> list20{ 0, 10, 20 };
+        dsa::ForwardList<int> temp20{ 30, 40, 50 };
+        auto list20_it = list20.insert_after(std::next(list20.end(), 1), temp20.begin(), temp20.end());
+        const std::initializer_list<int> expected20{ 0, 10, 20 };
+        tests::compare("ForwardList20", list20, expected20);
+        tests::compare("ForwardList20 it", list20_it == nullptr, true);
+
+        dsa::ForwardList<int> list21{ 0, 10, 20 };
+        auto list21_it = list21.insert_after(std::next(list21.end(), 1), 30);
+        const std::initializer_list<int> expected21{ 0, 10, 20 };
+        tests::compare("ForwardList21", list21, expected21);
+        tests::compare("ForwardList21 it", list21_it == nullptr, true);
+
 
         std::cout << "Compare operations results with std container\n\n";
 

--- a/tests/forward_list/forward_list_grow_test.cpp
+++ b/tests/forward_list/forward_list_grow_test.cpp
@@ -17,6 +17,7 @@
 #include <initializer_list>
 #include <iostream>
 #include <iterator>
+#include <utility>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -93,33 +94,58 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto iter8 = list8.insert_after(list8.end(), { 4, 5, 6 });
         tests::compare("iter8 == nullptr", iter8 == nullptr, true);
 
-        dsa::ForwardList<int> list9{};
-        list9.emplace_front(30);
-        list9.emplace_front(20);
-        list9.emplace_front(10);
-        list9.emplace_front(5);
-        list9.emplace_front(0);
-        const std::initializer_list<int> expected9 = { 0, 5, 10, 20, 30 };
-        tests::compare("list9", list9, expected9);
+        dsa::ForwardList<std::unique_ptr<int>> list9{};
+        auto ptr9 = std::make_unique<int>(1);
+        list9.insert_after(list9.before_begin(), std::move(ptr9));
+        constexpr int expected9{ 1 };
+        tests::compare("ForwardList9 front()", *list9.front(), expected9);
+        tests::compare("ptr9 == nullptr", ptr9 == nullptr, true);
 
-        dsa::ForwardList<int> list10{ 0, 10, 20, 30 };
-        list10.emplace_after(list10.before_begin(), -10);
-        const std::initializer_list<int> expected10 = { -10, 0, 10, 20, 30 };
-        tests::compare("list10", list10, expected10);
+        dsa::ForwardList<int> list10{};
+        const dsa::ForwardList<int> temp10{ 0, 10, 20, 30, 40, 50 };
+        auto temp10_it = std::next(temp10.begin(), 3);
+        auto list10_it = list10.insert_after(
+            list10.before_begin(), std::next(temp10.begin(), 1), std::next(temp10.begin(), 4));
+        const std::initializer_list<int> expected10{ 10, 20, 30 };
+        tests::compare("ForwardList10", list10, expected10);
+        tests::compare("ForwardList10 it", *list10_it, *temp10_it);
 
-        dsa::ForwardList<int> list11{ 0, 10, 20, 30 };
-        auto iter11 = list11.begin();
-        std::advance(iter11, 2);
-        list11.emplace_after(iter11, 25);
-        const std::initializer_list<int> expected11 = { 0, 10, 20, 25, 30 };
-        tests::compare("list11", list11, expected11);
+        dsa::ForwardList<int> list11{ 0, 10, 20 };
+        const dsa::ForwardList<int> temp11{ 30, 40, 50 };
+        auto temp11_it = std::next(temp11.begin(), 2);
+        auto list11_it = list11.insert_after(std::next(list11.begin(), 2), temp11.begin(), temp11.end());
+        const std::initializer_list<int> expected11{ 0, 10, 20, 30, 40, 50 };
+        tests::compare("ForwardList11", list11, expected11);
+        tests::compare("ForwardList11 it", *list11_it, *temp11_it);
 
-        dsa::ForwardList<int> list12{ 0, 10, 20, 30 };
-        auto iter12 = list12.begin();
-        std::advance(iter12, 3);
-        list12.emplace_after(iter12, 40);
-        const std::initializer_list<int> expected12 = { 0, 10, 20, 30, 40 };
-        tests::compare("list12", list12, expected12);
+        dsa::ForwardList<int> list12{};
+        list12.emplace_front(30);
+        list12.emplace_front(20);
+        list12.emplace_front(10);
+        list12.emplace_front(5);
+        list12.emplace_front(0);
+        const std::initializer_list<int> expected12 = { 0, 5, 10, 20, 30 };
+        tests::compare("ForwardList12", list12, expected12);
+
+        dsa::ForwardList<int> list13{ 0, 10, 20, 30 };
+        list13.emplace_after(list13.before_begin(), -10);
+        const std::initializer_list<int> expected13 = { -10, 0, 10, 20, 30 };
+        tests::compare("ForwardList13", list13, expected13);
+
+        dsa::ForwardList<int> list14{ 0, 10, 20, 30 };
+        auto iter14 = list14.begin();
+        std::advance(iter14, 2);
+        list14.emplace_after(iter14, 25);
+        const std::initializer_list<int> expected14 = { 0, 10, 20, 25, 30 };
+        tests::compare("ForwardList14", list14, expected14);
+
+        dsa::ForwardList<int> list15{ 0, 10, 20, 30 };
+        auto iter15 = list15.begin();
+        std::advance(iter15, 3);
+        list15.emplace_after(iter15, 40);
+        const std::initializer_list<int> expected15 = { 0, 10, 20, 30, 40 };
+        tests::compare("ForwardList15", list15, expected15);
+
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -140,6 +166,37 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::forward_list<int> std_list7{ 40 };
         std_list7.insert_after(std_list7.before_begin(), { 10, 20, 30 });
         tests::compare("ForwardList7 vs std", list7, std_list7);
+
+        std::forward_list<std::unique_ptr<int>> std_list9{};
+        auto std_ptr9 = std::make_unique<int>(1);
+        std_list9.insert_after(std_list9.before_begin(), std::move(std_ptr9));
+        tests::compare("ForwardList9 front() vs std", *list9.front(), *std_list9.front());
+        tests::compare("ptr9 == nullptr vs std", ptr9 == nullptr, std_ptr9 == nullptr);
+
+        std::forward_list<int> std_list10{};
+        const std::forward_list<int> std_temp10{ 0, 10, 20, 30, 40, 50 };
+        auto std_temp10_it = std::next(std_temp10.begin(), 3);
+        auto std_list10_it = std_list10.insert_after(
+            std_list10.before_begin(), std::next(std_temp10.begin(), 1), std::next(std_temp10.begin(), 4));
+        tests::compare("ForwardList10 vs std", list10, std_list10);
+        tests::compare("ForwardList10 it vs std", *list10_it, *std_list10_it);
+        tests::compare("ForwardList10 temp it vs std", *temp10_it, *std_temp10_it);
+
+        std::forward_list<int> std_list11{ 0, 10, 20 };
+        const std::forward_list<int> std_temp11{ 30, 40, 50 };
+        auto std_temp11_it = std::next(std_temp11.begin(), 2);
+        auto std_list11_it = std_list11.insert_after(
+            std::next(std_list11.begin(), 2), std_temp11.begin(), std_temp11.end());
+        tests::compare("ForwardList11 vs std", list11, std_list11);
+        tests::compare("ForwardList11 it vs std", *list11_it, *std_list11_it);
+        tests::compare("ForwardList11 temp it vs std", *temp11_it, *std_temp11_it);
+
+
+
+
+
+
+
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_grow_test.cpp
+++ b/tests/forward_list/forward_list_grow_test.cpp
@@ -93,6 +93,34 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto iter8 = list8.insert_after(list8.end(), { 4, 5, 6 });
         tests::compare("iter8 == nullptr", iter8 == nullptr, true);
 
+        dsa::ForwardList<int> list9{};
+        list9.emplace_front(30);
+        list9.emplace_front(20);
+        list9.emplace_front(10);
+        list9.emplace_front(5);
+        list9.emplace_front(0);
+        const std::initializer_list<int> expected9 = { 0, 5, 10, 20, 30 };
+        tests::compare("list9", list9, expected9);
+
+        dsa::ForwardList<int> list10{ 0, 10, 20, 30 };
+        list10.emplace_after(list10.before_begin(), -10);
+        const std::initializer_list<int> expected10 = { -10, 0, 10, 20, 30 };
+        tests::compare("list10", list10, expected10);
+
+        dsa::ForwardList<int> list11{ 0, 10, 20, 30 };
+        auto iter11 = list11.begin();
+        std::advance(iter11, 2);
+        list11.emplace_after(iter11, 25);
+        const std::initializer_list<int> expected11 = { 0, 10, 20, 25, 30 };
+        tests::compare("list11", list11, expected11);
+
+        dsa::ForwardList<int> list12{ 0, 10, 20, 30 };
+        auto iter12 = list12.begin();
+        std::advance(iter12, 3);
+        list12.emplace_after(iter12, 40);
+        const std::initializer_list<int> expected12 = { 0, 10, 20, 30, 40 };
+        tests::compare("list12", list12, expected12);
+
 
         std::cout << "Compare operations results with std container\n\n";
 

--- a/tests/forward_list/forward_list_grow_test.cpp
+++ b/tests/forward_list/forward_list_grow_test.cpp
@@ -12,6 +12,7 @@
 #include "common.h"
 #include "dsa/forward_list.h"
 
+#include <cstddef>
 #include <exception>
 #include <forward_list>
 #include <initializer_list>
@@ -59,7 +60,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list3.push_front(10);
         iterator = list3.insert_after(list3.cbegin(), 20);
         list3.insert_after(iterator, { 1, 2, 3 });
-        list3.insert_after(list3.cbegin()[list3.size() - 1], 60);
+        list3.insert_after(std::next(list3.cbegin(), static_cast<ptrdiff_t>(list3.size() - 1)), 60);
         const std::initializer_list<int> expected3 = { 10, 20, 1, 2, 3, 30, 40, 50, 60 };
         tests::compare("ForwardList3", list3, expected3);
 

--- a/tests/forward_list/forward_list_merge_test.cpp
+++ b/tests/forward_list/forward_list_merge_test.cpp
@@ -14,6 +14,7 @@
 
 #include <exception>
 #include <forward_list>
+#include <functional>
 #include <initializer_list>
 #include <iostream>
 #include <utility>
@@ -81,14 +82,77 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // NOLINTNEXTLINE(bugprone-use-after-move)
         tests::compare("ForwardList12", list12, expected12);
 
-        // self merge
-        dsa::ForwardList<int> list13{ il_1 };
-        list13.merge(list13);
-        tests::compare("ForwardList13", list13, il_1);
+        // merging using non default compration argument
 
-        dsa::ForwardList<int> list14;
-        list14.merge(list14);
-        tests::compare("ForwardList14", list14, {});
+        dsa::ForwardList<int> list13 = dsa::ForwardList<int>(il_1);
+        dsa::ForwardList<int> list14 = dsa::ForwardList<int>(il_2);
+        list13.sort(std::greater<>());
+        list14.sort(std::greater<>());
+        list13.merge(list14, std::greater<>());
+        const std::initializer_list<int> expected13 = { 50, 40, 30, 20, 10, 5, 4, 3, 2, 1 };
+        tests::compare("ForwardList13", list13, expected13);
+        const std::initializer_list<int> expected14 = {};
+        tests::compare("ForwardList14", list14, expected14);
+
+        dsa::ForwardList<int> list15 = dsa::ForwardList<int>(il_1);
+        dsa::ForwardList<int> list16;
+        list15.sort(std::greater<>());
+        list16.sort(std::greater<>());
+        list16.merge(list15, std::greater<>());
+        const std::initializer_list<int> expected15{};
+        tests::compare("ForwardList15", list15, expected15);
+        const std::initializer_list<int> expected16{ 5, 4, 3, 2, 1 };
+        tests::compare("ForwardList16", list16, expected16);
+
+        dsa::ForwardList<int> list17 = dsa::ForwardList<int>(il_3);
+        dsa::ForwardList<int> list18 = dsa::ForwardList<int>(il_4);
+        list17.sort(std::greater<>());
+        list18.sort(std::greater<>());
+        list17.merge(list18, std::greater<>());
+        const std::initializer_list<int> expected17{ 9, 7, 6, 5, 4, 3, 2, 1, 1, 1 };
+        tests::compare("ForwardList17", list17, expected17);
+        const std::initializer_list<int> expected18{};
+        tests::compare("ForwardList18", list18, expected18);
+
+        dsa::ForwardList<int> list19 = dsa::ForwardList<int>(il_4);
+        dsa::ForwardList<int> list20 = dsa::ForwardList<int>(il_3);
+        list19.sort(std::greater<>());
+        list20.sort(std::greater<>());
+        list19.merge(list20, std::greater<>());
+        const std::initializer_list<int> expected19{ 9, 7, 6, 5, 4, 3, 2, 1, 1, 1 };
+        tests::compare("ForwardList19", list19, expected19);
+        const std::initializer_list<int> expected20{};
+        tests::compare("ForwardList20", list20, expected20);
+
+        dsa::ForwardList<int> list21 = dsa::ForwardList<int>(il_2);
+        dsa::ForwardList<int> list22 = dsa::ForwardList<int>(il_3);
+        list21.sort(std::greater<>());
+        list22.sort(std::greater<>());
+        list21.merge(list22, std::greater<>());
+        const std::initializer_list<int> expected21{ 50, 40, 30, 20, 10, 7, 5, 3, 1, 1 };
+        tests::compare("ForwardList21", list21, expected21);
+        const std::initializer_list<int> expected22{};
+        tests::compare("ForwardList22", list22, expected22);
+
+        dsa::ForwardList<int> list23 = dsa::ForwardList<int>(il_3);
+        dsa::ForwardList<int> list24 = dsa::ForwardList<int>(il_2);
+        list23.sort(std::greater<>());
+        list24.sort(std::greater<>());
+        list23.merge(std::move(list24), std::greater<>());
+        const std::initializer_list<int> expected23{ 50, 40, 30, 20, 10, 7, 5, 3, 1, 1 };
+        tests::compare("ForwardList23", list23, expected23);
+        const std::initializer_list<int> expected24{};
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        tests::compare("ForwardList24", list24, expected24);
+
+        // self merge
+        dsa::ForwardList<int> list25{ il_1 };
+        list25.merge(list25);
+        tests::compare("ForwardList25", list25, il_1);
+
+        dsa::ForwardList<int> list26;
+        list26.merge(list26);
+        tests::compare("ForwardList26", list26, {});
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -116,6 +180,79 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list7.merge(std_list8);
         tests::compare("ForwardList7 vs std", list7, std_list7);
         tests::compare("ForwardList8 vs std", list8, std_list8);
+
+        std::forward_list<int> std_list9{ il_2 };
+        std::forward_list<int> std_list10{ il_3 };
+        std_list9.merge(std_list10);
+        tests::compare("ForwardList9 vs std", list9, std_list9);
+        tests::compare("ForwardList10 vs std", list10, std_list10);
+
+        std::forward_list<int> std_list11{ il_3 };
+        std::forward_list<int> std_list12{ il_2 };
+        std_list11.merge(std::move(std_list12));
+        tests::compare("ForwardList11 vs std", list11, std_list11);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        tests::compare("ForwardList12 vs std", list12, std_list12);
+
+        // merging using non default compration argument
+
+        std::forward_list<int> std_list13{ il_1 };
+        std::forward_list<int> std_list14{ il_2 };
+        std_list13.sort(std::greater<>());
+        std_list14.sort(std::greater<>());
+        std_list13.merge(std_list14, std::greater<>());
+        tests::compare("ForwardList13 vs std", list13, std_list13);
+        tests::compare("ForwardList14 vs std", list14, std_list14);
+
+        std::forward_list<int> std_list15{ il_1 };
+        std::forward_list<int> std_list16;
+        std_list15.sort(std::greater<>());
+        std_list16.sort(std::greater<>());
+        std_list16.merge(std_list15, std::greater<>());
+        tests::compare("ForwardList15 vs std", list15, std_list15);
+        tests::compare("ForwardList16 vs std", list16, std_list16);
+
+        std::forward_list<int> std_list17{ il_3 };
+        std::forward_list<int> std_list18{ il_4 };
+        std_list17.sort(std::greater<>());
+        std_list18.sort(std::greater<>());
+        std_list17.merge(std_list18, std::greater<>());
+        tests::compare("ForwardList17 vs std", list17, std_list17);
+        tests::compare("ForwardList18 vs std", list18, std_list18);
+
+        std::forward_list<int> std_list19{ il_4 };
+        std::forward_list<int> std_list20{ il_3 };
+        std_list19.sort(std::greater<>());
+        std_list20.sort(std::greater<>());
+        std_list19.merge(std_list20, std::greater<>());
+        tests::compare("ForwardList19 vs std", list19, std_list19);
+        tests::compare("ForwardList20 vs std", list20, std_list20);
+
+        std::forward_list<int> std_list21{ il_2 };
+        std::forward_list<int> std_list22{ il_3 };
+        std_list21.sort(std::greater<>());
+        std_list22.sort(std::greater<>());
+        std_list21.merge(std_list22, std::greater<>());
+        tests::compare("ForwardList21 vs std", list21, std_list21);
+        tests::compare("ForwardList22 vs std", list22, std_list22);
+
+        std::forward_list<int> std_list23{ il_3 };
+        std::forward_list<int> std_list24{ il_2 };
+        std_list23.sort(std::greater<>());
+        std_list24.sort(std::greater<>());
+        std_list23.merge(std::move(std_list24), std::greater<>());
+        tests::compare("ForwardList23 vs std", list23, std_list23);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        tests::compare("ForwardList24 vs std", list24, std_list24);
+
+        // self merge
+        std::forward_list<int> std_list25{ il_1 };
+        std_list25.merge(std_list25);
+        tests::compare("ForwardList25 vs std", list25, std_list25);
+
+        std::forward_list<int> std_list26;
+        std_list26.merge(std_list26);
+        tests::compare("ForwardList26 vs std", list26, std_list26);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_operators_test.cpp
+++ b/tests/forward_list/forward_list_operators_test.cpp
@@ -37,20 +37,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "ForwardList2:\t" << list2 << '\n';
         std::cout << "ForwardList3:\t" << list3 << "\n\n";
 
-        const dsa::ForwardList<int> list4(list1 + list2);
-        const std::initializer_list<int> expected4 = { 1, 2, 3, 1, 2, 6 };
-        tests::compare("ForwardList4", list4, expected4);
-
-        dsa::ForwardList<int> list5(1, 0);
-        list5 += list2;
-        const std::initializer_list<int> expected5 = { 0, 1, 2, 6 };
-        tests::compare("ForwardList5", list5, expected5);
-
-        dsa::ForwardList<int> list6(1, 0);
-        list6 += { 1, 2, 6 };
-        const std::initializer_list<int> expected6 = { 0, 1, 2, 6 };
-        tests::compare("ForwardList6", list6, expected6);
-
         std::cout << "Compare operators for objects of the same size\n\n";
 
         // intentional self-comparison, an object should be equal to itself

--- a/tests/forward_list/forward_list_operators_test.cpp
+++ b/tests/forward_list/forward_list_operators_test.cpp
@@ -136,39 +136,9 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         // test noexcept
 
-        struct ThrowingType
-        {
-            ThrowingType() = default;
-            ~ThrowingType() = default;
-            ThrowingType(const ThrowingType&) = default;
-            ThrowingType(ThrowingType&&) = default;
-
-            auto operator=(ThrowingType&& /*other*/) noexcept(false) -> ThrowingType&
-            {
-                return *this;
-            }
-
-            auto operator=(const ThrowingType& other) noexcept(false) -> ThrowingType&
-            {
-                // empty if statement silences clang-tidy warning for copy assignment operator in mock struct
-                if (this != &other) {}
-                return *this;
-            }
-
-            auto operator==(const ThrowingType& /* unused */) const -> bool
-            {
-                return true;
-            }
-
-            auto operator<=>(const ThrowingType& /* unused */) const noexcept(false)
-            {
-                return std::strong_ordering::equal;
-            }
-        };
-
         // operators
-        static_assert(!noexcept(dsa::ForwardList<ThrowingType>{1} == dsa::ForwardList<ThrowingType>{1}));
-        static_assert(!noexcept(dsa::ForwardList<ThrowingType>{1} <=> dsa::ForwardList<ThrowingType>{1}));
+        static_assert(!noexcept(dsa::ForwardList<tests::ThrowingType>{1} == dsa::ForwardList<tests::ThrowingType>{1}));
+        static_assert(!noexcept(dsa::ForwardList<tests::ThrowingType>{1} <=> dsa::ForwardList<tests::ThrowingType>{1}));
 
 
         std::cout << "Compare operations results with std container\n\n";

--- a/tests/forward_list/forward_list_operators_test.cpp
+++ b/tests/forward_list/forward_list_operators_test.cpp
@@ -12,10 +12,14 @@
 #include "common.h"
 #include "dsa/forward_list.h"
 
+#include <cassert>
+#include <compare>
 #include <exception>
 #include <forward_list>
 #include <initializer_list>
 #include <iostream>
+#include <limits>
+#include <type_traits>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -67,6 +71,18 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("list1 >= list2", list1 >= list2, false);
         tests::compare("list2 >= list1", list2 >= list1, true);
 
+        // test three way comparison
+
+        tests::compare("list1 <=> list2 !=", (list1 <=> list2) != 0, (list1 <=> list2) != 0);
+        tests::compare("list1 <=> list2 <", (list1 <=> list2) < 0, (list1 <=> list2) < 0);
+        tests::compare("list1 <=> list2 >", (list1 <=> list2) > 0, (list1 <=> list2) > 0);
+        tests::compare("list1 <=> list2 <=", (list1 <=> list2) <= 0, (list1 <=> list2) <= 0);
+        tests::compare("list1 <=> list2 >=", (list1 <=> list2) >= 0, (list1 <=> list2) >= 0);
+
+        tests::compare("list1 <=> list2 <", (list1 <=> list2) == std::weak_ordering::less, true);
+        tests::compare("list1 <=> list2 <>", (list1 <=> list2) != std::weak_ordering::equivalent, true);
+        tests::compare("list1 <=> list2 <=", (list1 <=> list2) != std::weak_ordering::greater, true);
+
         std::cout << "Compare operators for objects of different size\n\n";
 
         tests::compare("list1 == list3", list1 == list3, false);
@@ -93,6 +109,67 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("list2 >= list3", list2 >= list3, true);
         tests::compare("list3 >= list2", list3 >= list2, false);
 
+        // test three way comparison
+
+        tests::compare("list1 <=> list3 ==", (list1 <=> list3) == 0, false);
+        tests::compare("list1 <=> list3 <", (list1 <=> list3) < 0, true);
+        tests::compare("list1 <=> list3 >", (list1 <=> list3) > 0, false);
+        tests::compare("list1 <=> list3 <=", (list1 <=> list3) <= 0, true);
+        tests::compare("list1 <=> list3 >=", (list1 <=> list3) >= 0, false);
+
+        tests::compare("list1 <=> list3 >=", (list1 <=> list3) != std::weak_ordering::less, false);
+        tests::compare("list1 <=> list3 ==", (list1 <=> list3) == std::weak_ordering::equivalent, false);
+        tests::compare("list1 <=> list3 <=", (list1 <=> list3) != std::weak_ordering::greater, true);
+
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::ForwardList<int>>, std::strong_ordering>,
+            "Int list should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::ForwardList<double>>, std::partial_ordering>,
+            "Double list should support strong ordering");
+
+        // test partial ordering
+        const dsa::ForwardList<double> list7{ 1.0, 2.0, 3.0 };
+        const dsa::ForwardList<double> list8{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() };
+        assert((list7 <=> list8) == std::partial_ordering::unordered);
+        tests::compare("list7 <=> list8 weak ordering", (list7 <=> list8) != std::weak_ordering::less, true);
+
+        // test noexcept
+
+        struct ThrowingType
+        {
+            ThrowingType() = default;
+            ~ThrowingType() = default;
+            ThrowingType(const ThrowingType&) = default;
+            ThrowingType(ThrowingType&&) = default;
+
+            auto operator=(ThrowingType&& /*other*/) noexcept(false) -> ThrowingType&
+            {
+                return *this;
+            }
+
+            auto operator=(const ThrowingType& other) noexcept(false) -> ThrowingType&
+            {
+                // empty if statement silences clang-tidy warning for copy assignment operator in mock struct
+                if (this != &other) {}
+                return *this;
+            }
+
+            auto operator==(const ThrowingType& /* unused */) const -> bool
+            {
+                return true;
+            }
+
+            auto operator<=>(const ThrowingType& /* unused */) const noexcept(false)
+            {
+                return std::strong_ordering::equal;
+            }
+        };
+
+        // operators
+        static_assert(!noexcept(dsa::ForwardList<ThrowingType>{1} == dsa::ForwardList<ThrowingType>{1}));
+        static_assert(!noexcept(dsa::ForwardList<ThrowingType>{1} <=> dsa::ForwardList<ThrowingType>{1}));
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -117,6 +194,21 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         tests::compare("list1 >= list2 vs std", list1 >= list2, std_list1 >= std_list2);
         tests::compare("list2 >= list1 vs std", list2 >= list1, std_list2 >= std_list1);
+
+        // test three way comparison
+
+        tests::compare("list1 <=> list2 vs std !=", (list1 <=> list2) != 0, (std_list1 <=> std_list2) != 0);
+        tests::compare("list1 <=> list2 vs std <", (list1 <=> list2) < 0, (std_list1 <=> std_list2) < 0);
+        tests::compare("list1 <=> list2 vs std >", (list1 <=> list2) > 0, (std_list1 <=> std_list2) > 0);
+        tests::compare("list1 <=> list2 vs std <=", (list1 <=> list2) <= 0, (std_list1 <=> std_list2) <= 0);
+        tests::compare("list1 <=> list2 vs std >=", (list1 <=> list2) >= 0, (std_list1 <=> std_list2) >= 0);
+
+        tests::compare("list1 <=> list2 vs std <",
+            (list1 <=> list2) == std::weak_ordering::less, (std_list1 <=> std_list2) == std::weak_ordering::less);
+        tests::compare("list1 <=> list2 vs std <>",
+            (list1 <=> list2) != std::weak_ordering::equivalent, (std_list1 <=> std_list2) != std::weak_ordering::equivalent);
+        tests::compare("list1 <=> list2 vs std <=",
+            (list1 <=> list2) != std::weak_ordering::greater, (std_list1 <=> std_list2) != std::weak_ordering::greater);
 
         std::cout << "Compare operators for objects of different size\n\n";
 
@@ -143,6 +235,38 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("list3 >= list1 vs std", list3 >= list1, std_list3 >= std_list1);
         tests::compare("list2 >= list3 vs std", list2 >= list3, std_list2 >= std_list3);
         tests::compare("list3 >= list2 vs std", list3 >= list2, std_list3 >= std_list2);
+
+        // test three way comparison
+
+        tests::compare("list1 <=> list3 vs std ==", (list1 <=> list3) == 0, (std_list1 <=> std_list3) == 0);
+        tests::compare("list1 <=> list3 vs std <", (list1 <=> list3) < 0, (std_list1 <=> std_list3) < 0);
+        tests::compare("list1 <=> list3 vs std >", (list1 <=> list3) > 0, (std_list1 <=> std_list3) > 0);
+        tests::compare("list1 <=> list3 vs std <=", (list1 <=> list3) <= 0, (std_list1 <=> std_list3) <= 0);
+        tests::compare("list1 <=> list3 vs std >=", (list1 <=> list3) >= 0, (std_list1 <=> std_list3) >= 0);
+
+        tests::compare("list1 <=> list3 vs std >=",
+            (list1 <=> list3) != std::weak_ordering::less, (std_list1 <=> std_list3) != std::weak_ordering::less);
+        tests::compare("list1 <=> list3 vs std ==",
+            (list1 <=> list3) == std::weak_ordering::equivalent, (std_list1 <=> std_list3) == std::weak_ordering::equivalent);
+        tests::compare("list1 <=> list3 vs std <= ",
+            (list1 <=> list3) != std::weak_ordering::greater, (std_list1 <=> std_list3) != std::weak_ordering::greater);
+
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::forward_list<int>>, std::strong_ordering>,
+            "Int list should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::forward_list<double>>, std::partial_ordering>,
+            "Double list should support strong ordering");
+
+        // test partial ordering
+        const std::forward_list<double> std_list7{ 1.0, 2.0, 3.0 };
+        const std::forward_list<double> std_list8{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() };
+        assert((std_list7 <=> std_list8) == std::partial_ordering::unordered);
+        assert((list7 <=> list8) == (std_list7 <=> std_list8));
+        tests::compare("std_list7 <=> std_list8 weak ordering",
+            (std_list7 <=> std_list8) == std::partial_ordering::unordered, true);
+        tests::compare("(list7 <=> list8) == (std_list7 <=> std_list8)",
+            (list7 <=> list8) == (std_list7 <=> std_list8), true);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_set_test.cpp
+++ b/tests/forward_list/forward_list_set_test.cpp
@@ -12,7 +12,6 @@
 #include "common.h"
 #include "dsa/forward_list.h"
 
-#include <cstddef>
 #include <exception>
 #include <forward_list>
 #include <initializer_list>
@@ -28,12 +27,9 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "Start forward_list_set_test:\n";
 
         dsa::ForwardList<int> list1 = dsa::ForwardList<int>({ 0, 10, 20 });
-        // Try setting values for nodes with invalid indexes
         constexpr int new_value{ 50 };
-        list1.set(static_cast<size_t>(-1), new_value);
-        list1.set(1, new_value);
-        list1.set(100, new_value);
-        const std::initializer_list<int> expected1{ 0, 50, 20 };
+        list1.front() = new_value;
+        const std::initializer_list<int> expected1{ 50, 10, 20 };
         tests::compare("ForwardList1", list1, expected1);
 
         dsa::ForwardList<int> list2 = dsa::ForwardList<int>({ 0, 10, 20 });

--- a/tests/forward_list/forward_list_set_test.cpp
+++ b/tests/forward_list/forward_list_set_test.cpp
@@ -16,6 +16,7 @@
 #include <forward_list>
 #include <initializer_list>
 #include <iostream>
+#include <iterator>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -27,9 +28,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "Start forward_list_set_test:\n";
 
         dsa::ForwardList<int> list1 = dsa::ForwardList<int>({ 0, 10, 20 });
-        constexpr int new_value{ 50 };
-        list1.front() = new_value;
-        const std::initializer_list<int> expected1{ 50, 10, 20 };
+        const std::initializer_list<int> expected1{ 0, 1, 2 };
+        list1 = expected1;
         tests::compare("ForwardList1", list1, expected1);
 
         dsa::ForwardList<int> list2 = dsa::ForwardList<int>({ 0, 10, 20 });
@@ -38,20 +38,62 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList2", list2, expected2);
 
         dsa::ForwardList<int> list3 = dsa::ForwardList<int>({ 0, 10, 20 });
-        const std::initializer_list<int> expected3 = { 1, 2, 3, 4 };
-        list3.assign(expected3);
+        list3.assign(0, 1);
+        const std::initializer_list<int> expected3 = {};
         tests::compare("ForwardList3", list3, expected3);
+
+        dsa::ForwardList<int> list4 = dsa::ForwardList<int>({ 0, 10, 20 });
+        const std::initializer_list<int> expected4 = { 1, 2, 3, 4 };
+        list4.assign(expected4);
+        tests::compare("ForwardList4", list4, expected4);
+
+        dsa::ForwardList<int> list5 = dsa::ForwardList<int>({ 0, 10, 20 });
+        dsa::ForwardList<int> temp5 = dsa::ForwardList<int>({ 0, 1, 2, 3, 4, 5 });
+        list5.assign(std::next(temp5.begin(), 1), std::next(temp5.begin(), 4));
+        const std::initializer_list<int> expected5 = { 1, 2, 3 };
+        tests::compare("ForwardList5", list5, expected5);
+
+        dsa::ForwardList<int> list6 = dsa::ForwardList<int>({ 0, 10, 20 });
+        constexpr int new_value{ 50 };
+        list6.front() = new_value;
+        const std::initializer_list<int> expected6{ 50, 10, 20 };
+        tests::compare("ForwardList6", list6, expected6);
+
+        dsa::ForwardList<int> list7 = dsa::ForwardList<int>({ 0, 10, 20 });
+        const std::initializer_list<int> expected7 = { 1, 2, 3, 4 };
+        list7.assign(expected7);
+        tests::compare("ForwardList7", list7, expected7);
 
 
         std::cout << "Compare operations results with std container\n\n";
+
+        std::forward_list<int> std_list1{ 0, 10, 20 };
+        std_list1 = expected1;
+        tests::compare("ForwardList1 vs std", list1, std_list1);
 
         std::forward_list<int> std_list2{ 0, 10, 20 };
         std_list2.assign(4, 1);
         tests::compare("ForwardList2 vs std", list2, std_list2);
 
         std::forward_list<int> std_list3{ 0, 10, 20 };
-        std_list3.assign(expected3);
+        std_list3.assign(0, 1);
         tests::compare("ForwardList3 vs std", list3, std_list3);
+
+        std::forward_list<int> std_list4{ 0, 10, 20 };
+        std_list4.assign(expected4);
+        tests::compare("ForwardList4 vs std", list4, std_list4);
+
+        std::forward_list<int> std_list5{ 0, 10, 20 };
+        std_list5.assign(std::next(temp5.begin(), 1), std::next(temp5.begin(), 4));
+        tests::compare("ForwardList5 vs std", list5, std_list5);
+
+        std::forward_list<int> std_list6{ 0, 10, 20 };
+        std_list6.front() = new_value;
+        tests::compare("ForwardList6 vs std", list6, std_list6);
+
+        std::forward_list<int> std_list7{ 0, 10, 20 };
+        std_list7.assign(expected7);
+        tests::compare("ForwardList7 vs std", list7, std_list7);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_shrink_test.cpp
+++ b/tests/forward_list/forward_list_shrink_test.cpp
@@ -147,6 +147,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList19", list19, expected19);
         tests::compare("ForwardList19 erase_if count", cnt19, std::size_t{ 3 });
 
+        dsa::ForwardList<int> list20{ 0, 1, 2, 3, 4, 5 };
+        auto iter20 = list20.erase_after(std::next(list20.end()), std::next(list20.end()));
+        tests::compare("iter20 == nullptr", iter20 == nullptr, true);
+        iter20 = list20.erase_after(list20.begin(), std::next(list20.end()));
+        tests::compare("iter20 == nullptr", iter20 == nullptr, true);
+
 
         std::cout << "Compare operations results with std container\n\n";
 

--- a/tests/forward_list/forward_list_shrink_test.cpp
+++ b/tests/forward_list/forward_list_shrink_test.cpp
@@ -68,24 +68,48 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList6", list6, expected6);
         tests::compare("ForwardList6 removed count", cnt6, std::size_t{ 6 });
 
-        dsa::ForwardList<int> list7 = dsa::ForwardList<int>({ 0 });
-        tests::compare(list7.empty(), false);
-        list7.clear();
-        tests::compare(list7.empty(), true);
-        const std::initializer_list<int> expected7 = { };
+        dsa::ForwardList<int> list7 = dsa::ForwardList<int>({ 0, 10, 0, 0, 40, 0 });
+        auto cnt7 = list7.remove_if([](int val) { return val == 0; });
+        const std::initializer_list<int> expected7 = { 10, 40 };
         tests::compare("ForwardList7", list7, expected7);
+        tests::compare("ForwardList7 removed count", cnt7, std::size_t{ 4 });
 
-        dsa::ForwardList<int> list8 = dsa::ForwardList<int>({ 10, 20, 30 });
-        list8.pop_front();
-        list8.pop_front();
-        list8.pop_front();
-        list8.pop_front();
+        dsa::ForwardList<int> list8 = dsa::ForwardList<int>({ 0, 0, 0, 0, 0, 0 });
+        auto cnt8 = list8.remove_if([](int val) { return val == 0; });
         const std::initializer_list<int> expected8 = { };
         tests::compare("ForwardList8", list8, expected8);
+        tests::compare("ForwardList8 removed count", cnt8, std::size_t{ 6 });
 
-        dsa::ForwardList<int> list9;
-        auto iter9 = list9.erase_after(list9.begin(), list9.end());
-        tests::compare("iter9 == nullptr", iter9 == nullptr, true);
+        dsa::ForwardList<int> list9 = dsa::ForwardList<int>({ 0, 1, 2, 3, 4, 5 });
+        auto cnt9 = list9.remove_if([](int val) { return val % 2 == 0; });
+        const std::initializer_list<int> expected9 = { 1, 3, 5 };
+        tests::compare("ForwardList9", list9, expected9);
+        tests::compare("ForwardList9 removed count", cnt9, std::size_t{ 3 });
+
+        dsa::ForwardList<int> list10 = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt10 = list10.remove_if([](int val) { return val <= 5; });
+        const std::initializer_list<int> expected10 = { 10, 7, 9 };
+        tests::compare("ForwardList10", list10, expected10);
+        tests::compare("ForwardList10 removed count", cnt10, std::size_t{ 3 });
+
+        dsa::ForwardList<int> list11 = dsa::ForwardList<int>({ 0 });
+        tests::compare(list11.empty(), false);
+        list11.clear();
+        tests::compare(list11.empty(), true);
+        const std::initializer_list<int> expected11 = { };
+        tests::compare("ForwardList11", list11, expected11);
+
+        dsa::ForwardList<int> list12 = dsa::ForwardList<int>({ 10, 20, 30 });
+        list12.pop_front();
+        list12.pop_front();
+        list12.pop_front();
+        list12.pop_front();
+        const std::initializer_list<int> expected12 = { };
+        tests::compare("ForwardList12", list12, expected12);
+
+        dsa::ForwardList<int> list13;
+        auto iter13 = list13.erase_after(list13.begin(), list13.end());
+        tests::compare("iter13 == nullptr", iter13 == nullptr, true);
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -130,6 +154,26 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto std_cnt6 = std_list6.remove(0);
         tests::compare("ForwardList6 vs std", list6, std_list6);
         tests::compare("ForwardList6 removed count vs std", cnt6, std_cnt6);
+
+        std::forward_list<int> std_list7{ 0, 10, 0, 0, 40, 0 };
+        auto std_cnt7 = std_list7.remove_if([](int val) { return val == 0; });
+        tests::compare("ForwardList7 vs std", list7, std_list7);
+        tests::compare("ForwardList7 removed count vs std", cnt7, std_cnt7);
+
+        std::forward_list<int> std_list8{ 0, 0, 0, 0, 0, 0 };
+        auto std_cnt8 = std_list8.remove_if([](int val) { return val == 0; });
+        tests::compare("ForwardList8 vs std", list8, std_list8);
+        tests::compare("ForwardList8 removed count vs std", cnt8, std_cnt8);
+
+        std::forward_list<int> std_list9{ 0, 1, 2, 3, 4, 5 };
+        auto std_cnt9 = std_list9.remove_if([](int val) { return val % 2 == 0; });
+        tests::compare("ForwardList9 vs std", list9, std_list9);
+        tests::compare("ForwardList9 removed count vs std", cnt9, std_cnt9);
+
+        std::forward_list<int> std_list10{ 0, 10, 2, 5, 7, 9 };
+        auto std_cnt10 = std_list10.remove_if([](int val) { return val <= 5; });
+        tests::compare("ForwardList10 vs std", list10, std_list10);
+        tests::compare("ForwardList10 removed count vs std", cnt10, std_cnt10);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_shrink_test.cpp
+++ b/tests/forward_list/forward_list_shrink_test.cpp
@@ -29,30 +29,30 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "Start forward_list_shrink_test:\n";
 
         dsa::ForwardList<int> list1 = dsa::ForwardList<int>({ 0, 10, 20, 30, 40, 50 });
-        list1.erase_after(list1.begin()[list1.size() - 2]);
+        list1.erase_after(std::next(list1.begin(), static_cast<ptrdiff_t>(list1.size() - 2)));
         list1.pop_front();
-        auto indexes = { 100, 5, 2, 0, -1 };
+        auto indexes = { 5, 2, 0 };
         for (const auto& item : indexes)
         {
-            list1.erase_after(list1.begin()[static_cast<size_t>(item)]);
+            list1.erase_after(std::next(list1.begin(), static_cast<ptrdiff_t>(item)));
         }
         const std::initializer_list<int> expected1 = { 10, 30 };
         tests::compare("ForwardList1", list1, expected1);
 
         dsa::ForwardList<int> list2 = dsa::ForwardList<int>({ 0, 10, 20, 30, 40, 50 });
-        list2.erase_after(list2.begin()[1], list2.begin()[3]);
+        list2.erase_after(std::next(list2.begin(), 1), std::next(list2.begin(), 3));
         const std::initializer_list<int> expected2 = { 0, 10, 30, 40, 50 };
         tests::compare("ForwardList2", list2, expected2);
 
         dsa::ForwardList<int> list3 = dsa::ForwardList<int>({ 0, 10, 20, 30, 40, 50 });
-        list3.erase_after(list3.begin()[1]);
-        list3.erase_after(list3.begin()[1], list3.begin()[3]);
+        list3.erase_after(std::next(list3.begin(), 1));
+        list3.erase_after(std::next(list3.begin(), 1), std::next(list3.begin(), 3));
         const std::initializer_list<int> expected3 = { 0, 10, 40, 50 };
         tests::compare("ForwardList3", list3, expected3);
 
         dsa::ForwardList<int> list4 = dsa::ForwardList<int>({ 0, 10, 20, 30, 40, 50 });
-        list4.erase_after(list4.begin()[1]);
-        list4.erase_after(list4.begin()[1], list4.begin()[4]);
+        list4.erase_after(std::next(list4.begin(), 1));
+        list4.erase_after(std::next(list4.begin(), 1), std::next(list4.begin(), 4));
         const std::initializer_list<int> expected4 = { 0, 10, 50 };
         tests::compare("ForwardList4", list4, expected4);
 

--- a/tests/forward_list/forward_list_shrink_test.cpp
+++ b/tests/forward_list/forward_list_shrink_test.cpp
@@ -57,14 +57,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList4", list4, expected4);
 
         dsa::ForwardList<int> list5 = dsa::ForwardList<int>({ 0, 10, 0, 0, 40, 0 });
-        list5.remove(0);
+        auto cnt5 = list5.remove(0);
         const std::initializer_list<int> expected5 = { 10, 40 };
         tests::compare("ForwardList5", list5, expected5);
+        tests::compare("ForwardList5 removed count", cnt5, std::size_t{ 4 });
 
         dsa::ForwardList<int> list6 = dsa::ForwardList<int>({ 0, 0, 0, 0, 0, 0 });
-        list6.remove(0);
+        auto cnt6 = list6.remove(0);
         const std::initializer_list<int> expected6 = { };
         tests::compare("ForwardList6", list6, expected6);
+        tests::compare("ForwardList6 removed count", cnt6, std::size_t{ 6 });
 
         dsa::ForwardList<int> list7 = dsa::ForwardList<int>({ 0 });
         tests::compare(list7.empty(), false);
@@ -120,12 +122,14 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList4 vs std", list4, std_list4);
 
         std::forward_list<int> std_list5{ 0, 10, 0, 0, 40, 0 };
-        std_list5.remove(0);
+        auto std_cnt5 = std_list5.remove(0);
         tests::compare("ForwardList5 vs std", list5, std_list5);
+        tests::compare("ForwardList5 removed count vs std", cnt5, std_cnt5);
 
         std::forward_list<int> std_list6{ 0, 0, 0, 0, 0, 0 };
-        std_list6.remove(0);
+        auto std_cnt6 = std_list6.remove(0);
         tests::compare("ForwardList6 vs std", list6, std_list6);
+        tests::compare("ForwardList6 removed count vs std", cnt6, std_cnt6);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_shrink_test.cpp
+++ b/tests/forward_list/forward_list_shrink_test.cpp
@@ -111,6 +111,42 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto iter13 = list13.erase_after(list13.begin(), list13.end());
         tests::compare("iter13 == nullptr", iter13 == nullptr, true);
 
+        dsa::ForwardList<int> list14 = dsa::ForwardList<int>({ 0, 10, 0, 0, 40, 0 });
+        auto cnt14 = dsa::erase(list14, 0);
+        const std::initializer_list<int> expected14 = { 10, 40 };
+        tests::compare("ForwardList14", list14, expected14);
+        tests::compare("ForwardList14 removed count", cnt14, std::size_t{ 4 });
+
+        dsa::ForwardList<int> list15 = dsa::ForwardList<int>({ 0, 0, 0, 0, 0, 0 });
+        auto cnt15 = dsa::erase(list15, 0);
+        const std::initializer_list<int> expected15 = { };
+        tests::compare("ForwardList15", list15, expected15);
+        tests::compare("ForwardList15 erase count", cnt15, std::size_t{ 6 });
+
+        dsa::ForwardList<int> list16 = dsa::ForwardList<int>({ 0, 10, 0, 0, 40, 0 });
+        auto cnt16 = dsa::erase_if(list16, [](int val) { return val == 0; });
+        const std::initializer_list<int> expected16 = { 10, 40 };
+        tests::compare("ForwardList16", list16, expected16);
+        tests::compare("ForwardList16 erase count", cnt16, std::size_t{ 4 });
+
+        dsa::ForwardList<int> list17 = dsa::ForwardList<int>({ 0, 0, 0, 0, 0, 0 });
+        auto cnt17 = dsa::erase_if(list17, [](int val) { return val == 0; });
+        const std::initializer_list<int> expected17 = { };
+        tests::compare("ForwardList17", list17, expected17);
+        tests::compare("ForwardList17 erase_if count", cnt17, std::size_t{ 6 });
+
+        dsa::ForwardList<int> list18 = dsa::ForwardList<int>({ 0, 1, 2, 3, 4, 5 });
+        auto cnt18 = dsa::erase_if(list18, [](int val) { return val % 2 == 0; });
+        const std::initializer_list<int> expected18 = { 1, 3, 5 };
+        tests::compare("ForwardList18", list18, expected18);
+        tests::compare("ForwardList18 erase_if count", cnt18, std::size_t{ 3 });
+
+        dsa::ForwardList<int> list19 = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt19 = dsa::erase_if(list19, [](int val) { return val <= 5; });
+        const std::initializer_list<int> expected19 = { 10, 7, 9 };
+        tests::compare("ForwardList19", list19, expected19);
+        tests::compare("ForwardList19 erase_if count", cnt19, std::size_t{ 3 });
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -174,6 +210,43 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto std_cnt10 = std_list10.remove_if([](int val) { return val <= 5; });
         tests::compare("ForwardList10 vs std", list10, std_list10);
         tests::compare("ForwardList10 removed count vs std", cnt10, std_cnt10);
+
+        std::forward_list<int> std_list14{ 0, 10, 0, 0, 40, 0 };
+        // Linter do not recognizes that functions std::erase/erase_if are included from std::forward_list in C++20
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt14 = std::erase(std_list14, 0);
+        tests::compare("ForwardList14 vs std", list14, expected14);
+        tests::compare("ForwardList14 removed count vs std", cnt14, std_cnt14);
+
+        std::forward_list<int> std_list15{ 0, 0, 0, 0, 0, 0 };
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt15 = std::erase(std_list15, 0);
+        tests::compare("ForwardList15 vs std", list15, expected15);
+        tests::compare("ForwardList15 erase count vs std", cnt15, std_cnt15);
+
+        std::forward_list<int> std_list16{ 0, 10, 0, 0, 40, 0 };
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt16 = std::erase_if(std_list16, [](int val) { return val == 0; });
+        tests::compare("ForwardList16 vs std", list16, std_list16);
+        tests::compare("ForwardList16 erase count vs std", cnt16, std_cnt16);
+
+        std::forward_list<int> std_list17{ 0, 0, 0, 0, 0, 0 };
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt17 = std::erase_if(std_list17, [](int val) { return val == 0; });
+        tests::compare("ForwardList17 vs std", list17, std_list17);
+        tests::compare("ForwardList17 erase_if count vs std", cnt17, std_cnt17);
+
+        std::forward_list<int> std_list18{ 0, 1, 2, 3, 4, 5 };
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt18 = std::erase_if(std_list18, [](int val) { return val % 2 == 0; });
+        tests::compare("ForwardList18 vs std", list18, std_list18);
+        tests::compare("ForwardList18 erase_if count vs std", cnt18, std_cnt18);
+
+        std::forward_list<int> std_list19{ 0, 10, 2, 5, 7, 9 };
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt19 = std::erase_if(std_list19, [](int val) { return val <= 5; });
+        tests::compare("ForwardList19 vs std", list19, std_list19);
+        tests::compare("ForwardList19 erase_if count vs std", cnt19, std_cnt19);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_sort_test.cpp
+++ b/tests/forward_list/forward_list_sort_test.cpp
@@ -62,6 +62,22 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected6{ 50, 40, 30, 20, 10, 1, 1, 1, 1, 1 };
         tests::compare("ForwardList6", list6, expected6);
 
+        // empty
+        dsa::ForwardList<int> list7{};
+        list7.sort();
+        const std::initializer_list<int> expected7{};
+        tests::compare("ForwardList7", list7, expected7);
+
+        dsa::ForwardList<int> list8{ 1 };
+        list8.sort();
+        const std::initializer_list<int> expected8{ 1 };
+        tests::compare("ForwardList8", list8, expected8);
+
+        dsa::ForwardList<int> list9{ 0, -10 };
+        list9.sort();
+        const std::initializer_list<int> expected9{ -10, 0 };
+        tests::compare("ForwardList9", list9, expected9);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -89,6 +105,18 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::forward_list<int> std_list6{ il_2 };
         std_list6.sort(std::greater<>());
         tests::compare("ForwardList6", list6, std_list6);
+
+        std::forward_list<int> std_list7{};
+        std_list7.sort();
+        tests::compare("ForwardList7", list7, std_list7);
+
+        std::forward_list<int> std_list8{ 1 };
+        std_list8.sort();
+        tests::compare("ForwardList8", list8, std_list8);
+
+        std::forward_list<int> std_list9{ 0, -10 };
+        std_list9.sort();
+        tests::compare("ForwardList9", list9, std_list9);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_sort_test.cpp
+++ b/tests/forward_list/forward_list_sort_test.cpp
@@ -14,6 +14,7 @@
 
 #include <exception>
 #include <forward_list>
+#include <functional>
 #include <initializer_list>
 #include <iostream>
 
@@ -29,6 +30,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> il_1{ 1, 10, 2, 20, 3, 30, 4, 40, 5, 50 };
         const std::initializer_list<int> il_2{ 1, 10, 1, 20, 1, 30, 1, 40, 1, 50 };
 
+        // ascending
         dsa::ForwardList<int> list1 = dsa::ForwardList<int>(il_1);
         list1.sort();
         const std::initializer_list<int> expected1{ 1, 2, 3, 4, 5, 10, 20, 30, 40, 50 };
@@ -38,6 +40,27 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list2.sort();
         const std::initializer_list<int> expected2{ 1, 1, 1, 1, 1, 10, 20, 30, 40, 50 };
         tests::compare("ForwardList2", list2, expected2);
+
+        dsa::ForwardList<int> list3 = dsa::ForwardList<int>(il_1);
+        list3.sort(std::less<>());
+        const std::initializer_list<int> expected3{ 1, 2, 3, 4, 5, 10, 20, 30, 40, 50 };
+        tests::compare("ForwardList3", list3, expected3);
+
+        dsa::ForwardList<int> list4 = dsa::ForwardList<int>(il_2);
+        list4.sort(std::less<>());
+        const std::initializer_list<int> expected4{ 1, 1, 1, 1, 1, 10, 20, 30, 40, 50 };
+        tests::compare("ForwardList4", list4, expected4);
+
+        // descending
+        dsa::ForwardList<int> list5 = dsa::ForwardList<int>(il_1);
+        list5.sort(std::greater<>());
+        const std::initializer_list<int> expected5{ 50, 40, 30, 20, 10, 5, 4, 3, 2, 1 };
+        tests::compare("ForwardList5", list5, expected5);
+
+        dsa::ForwardList<int> list6 = dsa::ForwardList<int>(il_2);
+        list6.sort(std::greater<>());
+        const std::initializer_list<int> expected6{ 50, 40, 30, 20, 10, 1, 1, 1, 1, 1 };
+        tests::compare("ForwardList6", list6, expected6);
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -49,6 +72,23 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::forward_list<int> std_list2{ il_2 };
         std_list2.sort();
         tests::compare("ForwardList2 vs std", list2, std_list2);
+
+        std::forward_list<int> std_list3{ il_1 };
+        std_list3.sort(std::less<>());
+        tests::compare("ForwardList3", list3, std_list3);
+
+        std::forward_list<int> std_list4{ il_2 };
+        std_list4.sort(std::less<>());
+        tests::compare("ForwardList4", list4, std_list4);
+
+        // descending
+        std::forward_list<int> std_list5{ il_1 };
+        std_list5.sort(std::greater<>());
+        tests::compare("ForwardList5", list5, std_list5);
+
+        std::forward_list<int> std_list6{ il_2 };
+        std_list6.sort(std::greater<>());
+        tests::compare("ForwardList6", list6, std_list6);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_sort_test.cpp
+++ b/tests/forward_list/forward_list_sort_test.cpp
@@ -1,0 +1,64 @@
+/**
+ * @file forward_list_sort_test.cpp
+ * @brief This file tests functions sorting ForwardList objects
+ * @author Michal Zygmunt
+ *
+ * @copyright Copyright (c) 2026 Michal Zygmunt
+ * This project is distributed under the MIT License.
+ * See accompanying LICENSE.txt file or obtain copy at
+ * https://opensource.org/license/mit
+ */
+
+#include "common.h"
+#include "dsa/forward_list.h"
+
+#include <exception>
+#include <forward_list>
+#include <initializer_list>
+#include <iostream>
+
+int main() // NOLINT(modernize-use-trailing-return-type)
+{
+    // tests are based on hardcoded magic numbers for comparison of container content
+    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+
+    try
+    {
+        std::cout << "Start forward_list_sort_test:\n";
+
+        const std::initializer_list<int> il_1{ 1, 10, 2, 20, 3, 30, 4, 40, 5, 50 };
+        const std::initializer_list<int> il_2{ 1, 10, 1, 20, 1, 30, 1, 40, 1, 50 };
+
+        dsa::ForwardList<int> list1 = dsa::ForwardList<int>(il_1);
+        list1.sort();
+        const std::initializer_list<int> expected1{ 1, 2, 3, 4, 5, 10, 20, 30, 40, 50 };
+        tests::compare("ForwardList1", list1, expected1);
+
+        dsa::ForwardList<int> list2 = dsa::ForwardList<int>(il_2);
+        list2.sort();
+        const std::initializer_list<int> expected2{ 1, 1, 1, 1, 1, 10, 20, 30, 40, 50 };
+        tests::compare("ForwardList2", list2, expected2);
+
+
+        std::cout << "Compare operations results with std container\n\n";
+
+        std::forward_list<int> std_list1{ il_1 };
+        std_list1.sort();
+        tests::compare("ForwardList1 vs std", list1, std_list1);
+
+        std::forward_list<int> std_list2{ il_2 };
+        std_list2.sort();
+        tests::compare("ForwardList2 vs std", list2, std_list2);
+
+
+        tests::print_stats();
+    }
+    catch (...)
+    {
+        return tests::handle_exception(std::current_exception());
+    }
+
+    return tests::failed_count();
+
+    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+}

--- a/tests/forward_list/forward_list_splice_test.cpp
+++ b/tests/forward_list/forward_list_splice_test.cpp
@@ -12,6 +12,7 @@
 #include "common.h"
 #include "dsa/forward_list.h"
 
+#include <cstddef>
 #include <exception>
 #include <forward_list>
 #include <initializer_list>
@@ -43,7 +44,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list3 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list4 = dsa::ForwardList<int>(il_2);
-        list3.splice_after(list3.begin()[3], list4);
+        list3.splice_after(std::next(list3.begin(), 3), list4);
         const std::initializer_list<int> expected3 = { 1, 2, 3, 4, 10, 20, 30, 40, 50, 5 };
         tests::compare("ForwardList3", list3, expected3);
         const std::initializer_list<int> expected4 = {};
@@ -51,7 +52,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list5 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list6 = dsa::ForwardList<int>(il_2);
-        list5.splice_after(list5.begin()[list5.size() - 1], list6);
+        list5.splice_after(std::next(list5.begin(), static_cast<ptrdiff_t>(list5.size() - 1)), list6);
         const std::initializer_list<int> expected5 = { 1, 2, 3, 4, 5, 10, 20, 30, 40, 50 };
         tests::compare("ForwardList5", list5, expected5);
         const std::initializer_list<int> expected6 = {};
@@ -61,7 +62,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list7 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list8;
-        list7.splice_after(list7.begin()[list7.size() - 1], list8);
+        list7.splice_after(std::next(list7.begin(), static_cast<ptrdiff_t>(list7.size() - 1)), list8);
         const std::initializer_list<int> expected7 = il_1;
         tests::compare("ForwardList7", list7, expected7);
         const std::initializer_list<int> expected8 = {};
@@ -79,7 +80,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list11 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list12 = dsa::ForwardList<int>(il_2);
-        list11.splice_after(list11.begin(), list12, list12.begin()[2]);
+        list11.splice_after(list11.begin(), list12, std::next(list12.begin(), 2));
         const std::initializer_list<int> expected11 = { 1, 40, 2, 3, 4, 5 };
         tests::compare("ForwardList11", list11, expected11);
         const std::initializer_list<int> expected12 = { 10, 20, 30, 50 };
@@ -87,7 +88,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list13 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list14 = dsa::ForwardList<int>(il_2);
-        list13.splice_after(list13.begin(), list14, list14.begin()[list14.size() - 2]);
+        list13.splice_after(list13.begin(),
+            list14, std::next(list14.begin(), static_cast<ptrdiff_t>(list14.size() - 2)));
         const std::initializer_list<int> expected13 = { 1, 50, 2, 3, 4, 5 };
         tests::compare("ForwardList13", list13, expected13);
         const std::initializer_list<int> expected14 = { 10, 20, 30, 40 };
@@ -95,7 +97,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list15 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list16 = dsa::ForwardList<int>(il_2);
-        list15.splice_after(list15.begin()[3], list16, list16.begin());
+        list15.splice_after(std::next(list15.begin(), 3), list16, list16.begin());
         const std::initializer_list<int> expected15 = { 1, 2, 3, 4, 20, 5 };
         tests::compare("ForwardList15", list15, expected15);
         const std::initializer_list<int> expected16 = { 10, 30, 40, 50 };
@@ -103,7 +105,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list17 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list18 = dsa::ForwardList<int>(il_2);
-        list17.splice_after(list17.begin()[3], list18, list18.begin()[2]);
+        list17.splice_after(std::next(list17.begin(), 3), list18, std::next(list18.begin(), 2));
         const std::initializer_list<int> expected17 = { 1, 2, 3, 4, 40, 5 };
         tests::compare("ForwardList17", list17, expected17);
         const std::initializer_list<int> expected18 = { 10, 20, 30, 50 };
@@ -111,7 +113,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list19 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list20 = dsa::ForwardList<int>(il_2);
-        list19.splice_after(list19.begin()[3], list20, list20.begin()[list20.size() - 2]);
+        list19.splice_after(std::next(list19.begin(), 3),
+            list20, std::next(list20.begin(), static_cast<ptrdiff_t>(list20.size() - 2)));
         const std::initializer_list<int> expected19 = { 1, 2, 3, 4, 50, 5 };
         tests::compare("ForwardList19", list19, expected19);
         const std::initializer_list<int> expected20 = { 10, 20, 30, 40 };
@@ -120,7 +123,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list21 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list22 = dsa::ForwardList<int>(il_2);
-        list21.splice_after(list21.begin()[list21.size() - 1], list22, list22.begin());
+        list21.splice_after(std::next(list21.begin(), static_cast<ptrdiff_t>(list21.size() - 1)),
+            list22, list22.begin());
         const std::initializer_list<int> expected21 = { 1, 2, 3, 4, 5, 20 };
         tests::compare("ForwardList21", list21, expected21);
         const std::initializer_list<int> expected22 = { 10, 30, 40, 50 };
@@ -128,7 +132,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list23 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list24 = dsa::ForwardList<int>(il_2);
-        list23.splice_after(list23.begin()[list23.size() - 1], list24, list24.begin()[3]);
+        list23.splice_after(std::next(list23.begin(), static_cast<ptrdiff_t>(list23.size() - 1)),
+            list24, std::next(list24.begin(), 3));
         const std::initializer_list<int> expected23 = { 1, 2, 3, 4, 5, 50 };
         tests::compare("ForwardList23", list23, expected23);
         const std::initializer_list<int> expected24 = { 10, 20, 30, 40 };
@@ -136,7 +141,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list25 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list26 = dsa::ForwardList<int>(il_2);
-        list25.splice_after(list25.begin()[list25.size() - 1], list26, list26.begin()[list26.size() - 2]);
+        list25.splice_after(std::next(list25.begin(), static_cast<ptrdiff_t>(list25.size() - 1)),
+            list26, std::next(list26.begin(), static_cast<ptrdiff_t>(list26.size() - 2)));
         const std::initializer_list<int> expected25 = { 1, 2, 3, 4, 5, 50 };
         tests::compare("ForwardList25", list25, expected25);
         const std::initializer_list<int> expected26 = { 10, 20, 30, 40 };
@@ -147,7 +153,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list27 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list28 = dsa::ForwardList<int>(il_2);
-        list27.splice_after(list27.begin(), list28, list28.begin(), list28.begin()[1]);
+        list27.splice_after(list27.begin(), list28, list28.begin(), std::next(list28.begin(), 1));
         const std::initializer_list<int> expected27 = { 1, 2, 3, 4, 5 };
         tests::compare("ForwardList27", list27, expected27);
         const std::initializer_list<int> expected28 = { 10, 20, 30, 40, 50 };
@@ -155,7 +161,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list29 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list30 = dsa::ForwardList<int>(il_2);
-        list29.splice_after(list29.begin(), list30, list30.begin()[1], list30.begin()[3]);
+        list29.splice_after(list29.begin(), list30, std::next(list30.begin(), 1), std::next(list30.begin(), 3));
         const std::initializer_list<int> expected29 = { 1, 30, 2, 3, 4, 5 };
         tests::compare("ForwardList29", list29, expected29);
         const std::initializer_list<int> expected30 = { 10, 20, 40, 50 };
@@ -163,7 +169,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list31 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list32 = dsa::ForwardList<int>(il_2);
-        list31.splice_after(list31.begin(), list32, list32.begin(), list32.begin()[list32.size() - 1]);
+        list31.splice_after(list31.begin(),
+            list32, list32.begin(), std::next(list32.begin(), static_cast<ptrdiff_t>(list32.size() - 1)));
         const std::initializer_list<int> expected31 = { 1, 20, 30, 40, 2, 3, 4, 5 };
         tests::compare("ForwardList31", list31, expected31);
         const std::initializer_list<int> expected32 = { 10, 50 };
@@ -172,7 +179,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list33 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list34 = dsa::ForwardList<int>(il_2);
-        list33.splice_after(list33.begin()[2], list34, list34.begin(), list34.begin()[1]);
+        list33.splice_after(std::next(list33.begin(), 2), list34, list34.begin(), std::next(list34.begin(), 1));
         const std::initializer_list<int> expected33 = { 1, 2, 3, 4, 5 };
         tests::compare("ForwardList33", list33, expected33);
         const std::initializer_list<int> expected34 = { 10, 20, 30, 40, 50 };
@@ -180,7 +187,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list35 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list36 = dsa::ForwardList<int>(il_2);
-        list35.splice_after(list35.begin()[2], list36, list36.begin()[1], list36.begin()[3]);
+        list35.splice_after(std::next(list35.begin(), 2),
+            list36, std::next(list36.begin(), 1), std::next(list36.begin(), 3));
         const std::initializer_list<int> expected35 = { 1, 2, 3, 30, 4, 5 };
         tests::compare("ForwardList35", list35, expected35);
         const std::initializer_list<int> expected36 = { 10, 20, 40, 50 };
@@ -188,7 +196,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list37 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list38 = dsa::ForwardList<int>(il_2);
-        list37.splice_after(list37.begin()[2], list38, list38.begin(), list38.begin()[list38.size() - 1]);
+        list37.splice_after(std::next(list37.begin(), 2),
+            list38, list38.begin(), std::next(list38.begin(), static_cast<ptrdiff_t>(list38.size() - 1)));
         const std::initializer_list<int> expected37 = { 1, 2, 3, 20, 30, 40, 4, 5 };
         tests::compare("ForwardList37", list37, expected37);
         const std::initializer_list<int> expected38 = { 10, 50 };
@@ -197,7 +206,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list39 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list40 = dsa::ForwardList<int>(il_2);
-        list39.splice_after(list39.begin()[list39.size() - 1], list40, list40.begin(), list40.begin()[1]);
+        list39.splice_after(std::next(list39.begin(), static_cast<ptrdiff_t>(list39.size() - 1)),
+            list40, list40.begin(), std::next(list40.begin(), 1));
         const std::initializer_list<int> expected39 = { 1, 2, 3, 4, 5 };
         tests::compare("ForwardList39", list39, expected39);
         const std::initializer_list<int> expected40 = { 10, 20, 30, 40, 50 };
@@ -205,7 +215,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list41 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list42 = dsa::ForwardList<int>(il_2);
-        list41.splice_after(list41.begin()[list41.size() - 1], list42, list42.begin()[1], list42.begin()[3]);
+        list41.splice_after(std::next(list41.begin(), static_cast<ptrdiff_t>(list41.size() - 1)),
+            list42, std::next(list42.begin(), 1), std::next(list42.begin(), 3));
         const std::initializer_list<int> expected41 = { 1, 2, 3, 4, 5, 30 };
         tests::compare("ForwardList41", list41, expected41);
         const std::initializer_list<int> expected42 = { 10, 20, 40, 50 };
@@ -213,7 +224,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list43 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list44 = dsa::ForwardList<int>(il_2);
-        list43.splice_after(list43.begin()[list43.size() - 1], list44, list44.begin(), list44.begin()[list44.size() - 1]);
+        list43.splice_after(std::next(list43.begin(), static_cast<ptrdiff_t>(list43.size() - 1)),
+            list44, list44.begin(), std::next(list44.begin(), static_cast<ptrdiff_t>(list44.size() - 1)));
         const std::initializer_list<int> expected43 = { 1, 2, 3, 4, 5, 20, 30, 40 };
         tests::compare("ForwardList43", list43, expected43);
         const std::initializer_list<int> expected44 = { 10, 50 };
@@ -222,7 +234,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list45 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list46 = dsa::ForwardList<int>(il_2);
-        list45.splice_after(list45.before_begin(), list46, list46.begin(), list46.begin()[list46.size() - 1]);
+        list45.splice_after(list45.before_begin(),
+            list46, list46.begin(), std::next(list46.begin(), static_cast<ptrdiff_t>(list46.size() - 1)));
         const std::initializer_list<int> expected45 = { 20, 30, 40, 1, 2, 3, 4, 5 };
         tests::compare("ForwardList45", list45, expected45);
         const std::initializer_list<int> expected46 = { 10, 50 };
@@ -230,7 +243,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list47 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list48 = dsa::ForwardList<int>(il_2);
-        list47.splice_after(list47.before_begin()[list47.size() - 1], list48, list48.begin(), list48.end());
+        list47.splice_after(std::next(list47.before_begin(), static_cast<ptrdiff_t>(list47.size() - 1)),
+            list48, list48.begin(), list48.end());
         const std::initializer_list<int> expected47 = { 1, 2, 3, 4, 20, 30, 40, 50, 5 };
         tests::compare("ForwardList47", list47, expected47);
         const std::initializer_list<int> expected48 = { 10 };
@@ -238,7 +252,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list49 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list50 = dsa::ForwardList<int>(il_2);
-        list49.splice_after(list49.before_begin()[list49.size()], list50, list50.before_begin(), list50.end());
+        list49.splice_after(std::next(list49.before_begin(), static_cast<ptrdiff_t>(list49.size())),
+            list50, list50.before_begin(), list50.end());
         const std::initializer_list<int> expected49 = { 1, 2, 3, 4, 5, 10, 20, 30, 40, 50 };
         tests::compare("ForwardList49", list49, expected49);
         const std::initializer_list<int> expected50 = {};
@@ -329,7 +344,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list65 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list66;
-        list65.splice_after(list65.begin()[list65.size() - 1], std::move(list66));
+        list65.splice_after(std::next(list65.begin(), static_cast<ptrdiff_t>(list65.size() - 1)), std::move(list66));
         const std::initializer_list<int> expected65 = il_1;
         tests::compare("ForwardList65", list65, expected65);
         const std::initializer_list<int> expected66 = {};
@@ -351,7 +366,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list69 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list70 = dsa::ForwardList<int>(il_2);
-        list69.splice_after(list69.begin(), std::move(list70), list70.begin(), list70.begin()[1]);
+        list69.splice_after(list69.begin(), std::move(list70), list70.begin(), std::next(list70.begin(), 1));
         const std::initializer_list<int> expected69 = { 1, 2, 3, 4, 5 };
         tests::compare("ForwardList69", list69, expected69);
         const std::initializer_list<int> expected70 = { 10, 20, 30, 40, 50 };

--- a/tests/forward_list/forward_list_splice_test.cpp
+++ b/tests/forward_list/forward_list_splice_test.cpp
@@ -328,7 +328,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList61", list61, il_1);
         tests::compare("ForwardList62", list62, il_2);
 
-
         std::cout << "Testing moving other list\n\n";
 
         dsa::ForwardList<int> list63 = dsa::ForwardList<int>(il_1);
@@ -372,6 +371,24 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected70 = { 10, 20, 30, 40, 50 };
         // NOLINTNEXTLINE(bugprone-use-after-move)
         tests::compare("ForwardList70", list70, expected70);
+
+        dsa::ForwardList<int> list71{ il_1 };
+        list71.splice_after(list71.begin(), list71, list71.begin());
+        const std::initializer_list<int> expected71 = { 1, 2, 3, 4, 5 };
+        tests::compare("ForwardList71", list71, expected71);
+
+        dsa::ForwardList<int> list72{ il_1 };
+        dsa::ForwardList<int> list73{};
+        list72.splice_after(list72.begin(), list73, list73.before_begin());
+        const std::initializer_list<int> expected72 = { 1, 2, 3, 4, 5 };
+        const std::initializer_list<int> expected73{};
+        tests::compare("ForwardList72", list72, expected72);
+        tests::compare("ForwardList73", list73, expected73);
+
+        dsa::ForwardList<int> list74{ il_1 };
+        list74.splice_after(list74.begin(), list74, list74.begin(), list74.end());
+        const std::initializer_list<int> expected74 = { 1, 2, 3, 4, 5 };
+        tests::compare("ForwardList74", list74, expected74);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_swap_test.cpp
+++ b/tests/forward_list/forward_list_swap_test.cpp
@@ -16,6 +16,7 @@
 #include <forward_list>
 #include <initializer_list>
 #include <iostream>
+#include <utility>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -44,6 +45,49 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList3", list3, expected3);
         const std::initializer_list<int> expected4 = il_1;
         tests::compare("ForwardList4", list4, expected4);
+
+        dsa::ForwardList<int> list5 = dsa::ForwardList<int>(il_1);
+        dsa::ForwardList<int> list6 = dsa::ForwardList<int>(il_2);
+        dsa::swap(list5, list6);
+        const std::initializer_list<int> expected5 = il_2;
+        tests::compare("ForwardList5", list5, expected5);
+        const std::initializer_list<int> expected6 = il_1;
+        tests::compare("ForwardList6", list6, expected6);
+
+        dsa::ForwardList<int> list7 = dsa::ForwardList<int>(il_1);
+        dsa::ForwardList<int> list8;
+        dsa::swap(list7, list8);
+        const std::initializer_list<int> expected7 = { };
+        tests::compare("ForwardList7", list7, expected7);
+        const std::initializer_list<int> expected8 = il_1;
+        tests::compare("ForwardList8", list8, expected8);
+
+        struct ThrowingType
+        {
+            ThrowingType() = default;
+            ~ThrowingType() = default;
+            ThrowingType(const ThrowingType&) = default;
+            ThrowingType(ThrowingType&&) = default;
+
+            auto operator=(ThrowingType&& /*other*/) noexcept(false) -> ThrowingType&
+            {
+                return *this;
+            }
+
+            auto operator=(const ThrowingType& other) noexcept(false) -> ThrowingType&
+            {
+                // empty if statement silences clang-tidy warning for copy assignment operator in mock struct
+                if (this != &other) {}
+                return *this;
+            }
+        };
+
+        // swap safe type
+        static_assert(noexcept(swap(std::declval<dsa::ForwardList<int>&>(),
+            std::declval<dsa::ForwardList<int>&>())));
+        // swap throwing type
+        static_assert(!noexcept(swap(std::declval<dsa::ForwardList<ThrowingType>&>(),
+            std::declval<dsa::ForwardList<ThrowingType>&>())));
 
 
         std::cout << "Compare operations results with std container\n\n";

--- a/tests/forward_list/forward_list_swap_test.cpp
+++ b/tests/forward_list/forward_list_swap_test.cpp
@@ -62,32 +62,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected8 = il_1;
         tests::compare("ForwardList8", list8, expected8);
 
-        struct ThrowingType
-        {
-            ThrowingType() = default;
-            ~ThrowingType() = default;
-            ThrowingType(const ThrowingType&) = default;
-            ThrowingType(ThrowingType&&) = default;
-
-            auto operator=(ThrowingType&& /*other*/) noexcept(false) -> ThrowingType&
-            {
-                return *this;
-            }
-
-            auto operator=(const ThrowingType& other) noexcept(false) -> ThrowingType&
-            {
-                // empty if statement silences clang-tidy warning for copy assignment operator in mock struct
-                if (this != &other) {}
-                return *this;
-            }
-        };
-
         // swap safe type
         static_assert(noexcept(swap(std::declval<dsa::ForwardList<int>&>(),
             std::declval<dsa::ForwardList<int>&>())));
         // swap throwing type
-        static_assert(!noexcept(swap(std::declval<dsa::ForwardList<ThrowingType>&>(),
-            std::declval<dsa::ForwardList<ThrowingType>&>())));
+        static_assert(!noexcept(swap(std::declval<dsa::ForwardList<tests::ThrowingType>&>(),
+            std::declval<dsa::ForwardList<tests::ThrowingType>&>())));
 
 
         std::cout << "Compare operations results with std container\n\n";

--- a/tests/forward_list/forward_list_unique_test.cpp
+++ b/tests/forward_list/forward_list_unique_test.cpp
@@ -12,6 +12,7 @@
 #include "common.h"
 #include "dsa/forward_list.h"
 
+#include <cstddef>
 #include <exception>
 #include <forward_list>
 #include <initializer_list>
@@ -27,70 +28,84 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "Start forward_list_unique_test:\n";
 
         dsa::ForwardList<int> list1 = dsa::ForwardList<int>({ 1, 2, 3, 4, 5 });
-        list1.unique();
+        auto removed1 = list1.unique();
         const std::initializer_list<int> expected1 = { 1, 2, 3, 4, 5 };
         tests::compare("ForwardList1", list1, expected1);
+        tests::compare("ForwardList1 removed", removed1, size_t{ 0 });
 
         dsa::ForwardList<int> list2 = dsa::ForwardList<int>({ 1, 4, 2, 3, 2, 4, 3, 5, 1 });
-        list2.unique();
+        auto removed2 = list2.unique();
         const std::initializer_list<int> expected2 = { 1, 4, 2, 3, 2, 4, 3, 5, 1 };
         tests::compare("ForwardList2", list2, expected2);
+        tests::compare("ForwardList2 removed", removed2, size_t{ 0 });
 
         dsa::ForwardList<int> list3 = dsa::ForwardList<int>({ 1, 1, 2, 4, 2, 1, 3, 1, 1 });
-        list3.unique();
+        auto removed3 = list3.unique();
         const std::initializer_list<int> expected3 = { 1, 2, 4, 2, 1, 3, 1 };
         tests::compare("ForwardList3", list3, expected3);
+        tests::compare("ForwardList3 removed", removed3, size_t{ 2 });
 
         dsa::ForwardList<int> list4 = dsa::ForwardList<int>({ 1, 1, 1, 2, 2, 2, 1, 1, 1 });
-        list4.unique();
+        auto removed4 = list4.unique();
         const std::initializer_list<int> expected4 = { 1, 2, 1 };
         tests::compare("ForwardList4", list4, expected4);
+        tests::compare("ForwardList4 removed", removed4, size_t{ 6 });
 
         dsa::ForwardList<int> list5 = dsa::ForwardList<int>({ 0, 0, 0, 0, 0, 0 });
-        list5.unique();
+        auto removed5 = list5.unique();
         const std::initializer_list<int> expected5 = { 0 };
         tests::compare("ForwardList5", list5, expected5);
+        tests::compare("ForwardList5 removed", removed5, size_t{ 5 });
 
         dsa::ForwardList<int> list6 = dsa::ForwardList<int>();
-        list6.unique();
+        auto removed6 = list6.unique();
         const std::initializer_list<int> expected6 = { };
         tests::compare("ForwardList6", list6, expected6);
+        tests::compare("ForwardList6 removed", removed6, size_t{ 0 });
 
         dsa::ForwardList<int> list7;
-        list7.unique();
+        auto removed7 = list7.unique();
         const std::initializer_list<int> expected7 = {};
         tests::compare("ForwardList7", list7, expected7);
+        tests::compare("ForwardList7 removed", removed7, size_t{ 0 });
 
 
         std::cout << "Compare operations results with std container\n\n";
 
         std::forward_list<int> std_list1{ 1, 2, 3, 4, 5 };
-        std_list1.unique();
+        auto std_removed1 = std_list1.unique();
         tests::compare("ForwardList1 vs std", list1, std_list1);
+        tests::compare("ForwardList1 removed vs std", removed1, std_removed1);
 
         std::forward_list<int> std_list2{ 1, 4, 2, 3, 2, 4, 3, 5, 1 };
-        std_list2.unique();
+        auto std_removed2 = std_list2.unique();
         tests::compare("ForwardList2 vs std", list2, std_list2);
+        tests::compare("ForwardList2 removed vs std", removed2, std_removed2);
 
         std::forward_list<int> std_list3{ 1, 1, 2, 4, 2, 1, 3, 1, 1 };
-        std_list3.unique();
+        auto std_removed3 = std_list3.unique();
         tests::compare("ForwardList3 vs std", list3, std_list3);
+        tests::compare("ForwardList3 removed vs std", removed3, std_removed3);
 
         std::forward_list<int> std_list4{ 1, 1, 1, 2, 2, 2, 1, 1, 1 };
-        std_list4.unique();
+        auto std_removed4 = std_list4.unique();
         tests::compare("ForwardList4 vs std", list4, std_list4);
+        tests::compare("ForwardList4 removed vs std", removed4, std_removed4);
 
         std::forward_list<int> std_list5{ 0, 0, 0, 0, 0, 0 };
-        std_list5.unique();
+        auto std_removed5 = std_list5.unique();
         tests::compare("ForwardList5 vs std", list5, std_list5);
+        tests::compare("ForwardList5 removed vs std", removed5, std_removed5);
 
         std::forward_list<int> std_list6 = std::forward_list<int>();
-        std_list6.unique();
+        auto std_removed6 = std_list6.unique();
         tests::compare("ForwardList6 vs std", list6, std_list6);
+        tests::compare("ForwardList6 removed vs std", removed6, std_removed6);
 
         std::forward_list<int> std_list7;
-        std_list7.unique();
+        auto std_removed7 = std_list7.unique();
         tests::compare("ForwardList7 vs std", list7, std_list7);
+        tests::compare("ForwardList7 removed vs std", removed7, std_removed7);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_unique_test.cpp
+++ b/tests/forward_list/forward_list_unique_test.cpp
@@ -12,6 +12,7 @@
 #include "common.h"
 #include "dsa/forward_list.h"
 
+#include <cmath>
 #include <cstddef>
 #include <exception>
 #include <forward_list>
@@ -69,6 +70,24 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList7", list7, expected7);
         tests::compare("ForwardList7 removed", removed7, size_t{ 0 });
 
+        // find unique values using predicate
+        auto predicate = [](const int& input_a, const int& input_b)
+            {
+                return std::abs(input_a - input_b) <= 5;
+            };
+
+        dsa::ForwardList<int> list8 = dsa::ForwardList<int>({ 1, 5, 7, 15, 25 });
+        auto removed8 = list8.unique(predicate);
+        const std::initializer_list<int> expected8 = { 1, 7, 15, 25 };
+        tests::compare("ForwardList8", list8, expected8);
+        tests::compare("ForwardList8 removed", removed8, size_t{ 1 });
+
+        dsa::ForwardList<int> list9 = dsa::ForwardList<int>({ 1, 4, 12, 13, 12, 14, 3, 15, 1 });
+        auto removed9 = list9.unique(predicate);
+        const std::initializer_list<int> expected9 = { 1, 12, 3, 15, 1 };
+        tests::compare("ForwardList9", list9, expected9);
+        tests::compare("ForwardList9 removed", removed9, size_t{ 4 });
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -106,6 +125,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto std_removed7 = std_list7.unique();
         tests::compare("ForwardList7 vs std", list7, std_list7);
         tests::compare("ForwardList7 removed vs std", removed7, std_removed7);
+
+        std::forward_list<int> std_list8{ 1, 5, 7, 15, 25 };
+        auto std_removed8 = std_list8.unique(predicate);
+        tests::compare("ForwardList8 vs std", list8, std_list8);
+        tests::compare("ForwardList8 removed vs std", removed8, std_removed8);
+
+        std::forward_list<int> std_list9{ 1, 4, 12, 13, 12, 14, 3, 15, 1 };
+        auto std_removed9 = std_list9.unique(predicate);
+        tests::compare("ForwardList9 vs std", list9, std_list9);
+        tests::compare("ForwardList9 removed vs std", removed9, std_removed9);
 
 
         tests::print_stats();


### PR DESCRIPTION
Update `dsa::ForwardList` class to better match `std::forward_list` API and behaviour.

Closes #30 

## Checklist

- [x] provide the same member types and methods as `std::forward_list`, including:
  * get_allocator, emplace_after, emplace_front
  * assign using input iterator
  * ctor using iterators
  * insert_after using iterators and move semantics
  * push_front using move semantics
  * merge function using comparison function object
  * unique function using comparison function object
  * operator<=>
  * add member functions: remove, remove_if, sort
  * add non-member specialised functions: swap, erase, erase_if
- [x] remove public functions / operators not supported by `std::forward_list`
  * get, set
  * operator+, operator+= used for merging objects
  * operator[] for class iterators, use std::next, std::advance for iterator traversal
  * size() is only function retained, not compatible with std::forward_list
- [x] update tests to match features provided by updated implementation
- [x] separate function declarations and definitions (move method implementation outside class, where possible)
- [x] updated `[[nodiscard]]` attributes