### PR TITLE
Use tests::ThrowingType in Array class tests

### DIFF
--- a/tests/array/array_operators_test.cpp
+++ b/tests/array/array_operators_test.cpp
@@ -92,48 +92,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         assert((Array4 <=> Array5) == std::partial_ordering::unordered);
         tests::compare("Array4 <=> Array5 weak ordering", (Array1 <=> Array3) != std::weak_ordering::less, true);
 
-        // test noexcept
-
-        struct ThrowingType
-        {
-            ThrowingType() = default;
-            ~ThrowingType() = default;
-            ThrowingType(const ThrowingType&) = default;
-            ThrowingType(ThrowingType&&) = default;
-
-            auto operator=(ThrowingType&& /*other*/) noexcept(false) -> ThrowingType&
-            {
-                return *this;
-            }
-
-            auto operator=(const ThrowingType& other) noexcept(false) -> ThrowingType&
-            {
-                // empty if statement silences clang-tidy warning for copy assignment operator in mock struct
-                if (this != &other) {}
-                return *this;
-            }
-
-            auto operator==(const ThrowingType& /* unused */) const -> bool
-            {
-                return true;
-            }
-
-            auto operator<=>(const ThrowingType& /* unused */) const noexcept(false)
-            {
-                return std::strong_ordering::equal;
-            }
-        };
-
         // swap safe type
         static_assert(noexcept(swap(std::declval<dsa::Array<int, 3>&>(),
             std::declval<dsa::Array<int, 3>&>())));
         // swap throwing type
-        static_assert(!noexcept(swap(std::declval<dsa::Array<ThrowingType, 3>&>(),
-            std::declval<dsa::Array<ThrowingType, 3>&>())));
+        static_assert(!noexcept(swap(std::declval<dsa::Array<tests::ThrowingType, 3>&>(),
+            std::declval<dsa::Array<tests::ThrowingType, 3>&>())));
 
         // operators
-        static_assert(!noexcept(dsa::Array<ThrowingType, 3>{} == dsa::Array<ThrowingType, 3>{}));
-        static_assert(!noexcept(dsa::Array<ThrowingType, 3>{} <=> dsa::Array<ThrowingType, 3>{}));
+        static_assert(!noexcept(dsa::Array<tests::ThrowingType, 3>{} == dsa::Array<tests::ThrowingType, 3>{}));
+        static_assert(!noexcept(dsa::Array<tests::ThrowingType, 3>{} <=> dsa::Array<tests::ThrowingType, 3>{}));
 
 
         std::cout << "Compare operations results with std container\n\n";


### PR DESCRIPTION
Update dsa::Array to use tests::ThrowingType class for noexcept evaluation

Closes #38 

## Tasks

- [x] Use tests::ThrowingType in dsa::Array for noexcept correctness evaluation