### PR TITLE
Update List class to better match std::list API and behaviour

### DIFF
--- a/dsa.natvis
+++ b/dsa.natvis
@@ -54,8 +54,8 @@
 		<Expand>
 			<LinkedListItems>
 				<Size>m_size</Size>
-				<HeadPointer>m_head._Mypair._Myval2</HeadPointer>
-				<NextPointer>m_next._Mypair._Myval2</NextPointer>
+				<HeadPointer>m_head</HeadPointer>
+				<NextPointer>m_next</NextPointer>
 				<ValueNode>(*this)</ValueNode>
 			</LinkedListItems>
 		</Expand>
@@ -66,7 +66,7 @@
 		<DisplayString>{m_value}</DisplayString>
 		<Expand>
 			<Item Name="Value">m_value</Item>
-			<Item Name="NextPtr">m_next._Mypair._Myval2</Item>
+			<Item Name="NextPtr">m_next</Item>
 			<Item Name="PrevPtr">m_prev</Item>
 		</Expand>
 	</Type>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1134,16 +1134,6 @@ namespace dsa
     private:
 
         /**
-         * @brief Function returns pointer to specific Node of List
-         *
-         * @param[in] index index of element
-         * @return Node*
-         * @retval Node* if index is valid
-         * @retval nullptr if invalid index
-         */
-        [[nodiscard]] auto get(size_type index) const -> Node*;
-
-        /**
          * @brief Function sets value of specifed Node of List
          *
          * @param[in] index index of element to be modified
@@ -2268,63 +2258,6 @@ namespace dsa
     }
 
     // definitions of private methods
-
-    template<typename T>
-    auto List<T>::get(size_type index) const -> typename List<T>::Node*
-    {
-        if (index >= m_size)
-        {
-            return nullptr;
-        }
-
-        NodeBase* temp{};
-
-        // select list end to look for selected index
-        enum Mode : std::uint8_t { FRONT, BACK, AUTO };
-        constexpr Mode mode = Mode::AUTO;
-
-
-        if constexpr (mode == FRONT)
-        {
-            // count nodes from front
-            temp = m_head;
-            for (size_type i = 0; i < index; i++)
-            {
-                temp = temp->m_next;
-            }
-        }
-        else if constexpr (mode == BACK)
-        {
-            // count nodes from back
-            temp = m_tail->m_prev;
-            for (size_type i = m_size - 1; i > index; i--)
-            {
-                temp = temp->m_prev;
-            }
-        }
-        else // mode == AUTO
-        {
-            // optimize counting nodes from front or back
-            if (index < m_size / 2)
-            {
-                temp = m_head;
-                for (size_type i = 0; i < index; i++)
-                {
-                    temp = temp->m_next;
-                }
-            }
-            else
-            {
-                temp = m_tail->m_prev;
-                for (size_type i = m_size - 1; i > index; i--)
-                {
-                    temp = temp->m_prev;
-                }
-            }
-        }
-
-        return dynamic_cast<Node*>(temp);
-    }
 
     template<typename T>
     auto List<T>::set(size_type index, T value) -> bool

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1867,7 +1867,14 @@ namespace dsa
 
         if (m_size != 0)
         {
-            Node* temp_head = construct_node(nullptr, nullptr, 0);
+            Node* temp_head{ construct_node(nullptr, nullptr, T{}) };
+            if (!temp_head)
+            {
+                // if temporary node could not be allocated
+                // do not modify object state
+                return;
+            }
+
             NodeBase* temp_tail = temp_head;
 
             NodeBase* to_move{};

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -125,7 +125,7 @@ namespace dsa
              *
              * @param[in] value to store in Node object
              */
-            Node(T value)
+            Node(const T& value)
                 : m_value{ value }
             {}
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -2251,12 +2251,9 @@ namespace dsa
     template<typename T>
     void List<T>::init_node()
     {
-        if (m_head == nullptr)
-        {
-            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-            m_head = new NodeBase;
-            m_tail = m_head;
-        }
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        m_head = new NodeBase;
+        m_tail = m_head;
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -36,7 +36,6 @@ namespace dsa
      *
      * @tparam T type of data stored in List Node
      *
-     * @todo add sort
      * @todo add operator<=>
      * @todo add non-member specialized swap function
      * @todo add non-member specialized erase function
@@ -1120,6 +1119,16 @@ namespace dsa
         auto unique(BinaryPred predicate) -> size_type;
 
         /**
+         * @brief Function sorts the elements and preserves the order of equivalent elements
+         *
+         * @details elements are compared using \p operator<
+         *
+         * @note no iterators or references are invalidated,
+         *       if an exception is thrown, the order of elements is unspecified
+         */
+        void sort();
+
+        /**
          * @brief Append elements of another List to base container
          *
          * @tparam T type of data stored in List Node
@@ -1362,6 +1371,26 @@ namespace dsa
          // transfers ownership of nodes, moving entire container is not necessary
          // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
         void transfer(const_iterator pos, List<T>&& other, const_iterator first, const const_iterator& last);
+
+        /**
+         * @brief Function sorts nodes using merge sort algorithm
+         * @details Sorting is implemented using recursive (top-down) algorithm
+         *          Sorting is stable and inplace
+         *
+         * @param[in,out] source list to sort
+         * @return NodeBase* of sorted list
+         */
+        auto merge_sort(NodeBase* source) -> NodeBase*;
+
+        /**
+         * @brief Helper function for merge_sort to merge two sub-lists
+         * @details Merging of sorted sub-lists is performed recursively
+         *
+         * @param[in,out] left first input sub-list
+         * @param[in,out] right second input sub-list
+         * @return NodeBase* containing sorted elements from both input lists
+         */
+        auto merge(NodeBase* left, NodeBase* right) -> NodeBase*;
 
         NodeBase* m_head{};
         NodeBase* m_tail{};
@@ -2352,6 +2381,104 @@ namespace dsa
         }
 
         return removed_count;
+    }
+
+    template<typename T>
+    // Intentional recursive call for sorting nodes in top-down algorithm implementation
+    // NOLINTNEXTLINE(misc-no-recursion)
+    auto List<T>::merge_sort(NodeBase* source) -> NodeBase*
+    {
+        // Stop condition, one element list is already sorted
+        if (source == nullptr || source->m_next == nullptr)
+        {
+            return source;
+        }
+
+        // Divide list into equal-sized sublists consisting of first and second half of the list
+        NodeBase* left{ source };
+        NodeBase* right{};
+
+        // Use slow and fast pointer to find half of list
+        NodeBase* slow{ source };
+        NodeBase* fast{ source->m_next };
+        while (fast && fast->m_next)
+        {
+            slow = slow->m_next;
+            fast = fast->m_next->m_next;
+        }
+
+        // Split input list into two halfs
+        right = slow->m_next;
+        right->m_prev = nullptr;
+        slow->m_next = nullptr;
+
+        // Recursively sort both sub-lists
+        left = merge_sort(left);
+        right = merge_sort(right);
+
+        // Merge sorted sublists
+        NodeBase* result{ merge(left, right) };
+        return result;
+    }
+
+    template<typename T>
+    // Intentional recursive call for merging nodes in top-down merge_sort algorithm implementation
+    // NOLINTNEXTLINE(misc-no-recursion)
+    auto List<T>::merge(NodeBase* left, NodeBase* right) -> NodeBase*
+    {
+        // Stop condition, empty element list is already sorted
+        if (left == nullptr)
+        {
+            return right;
+        }
+        if (right == nullptr)
+        {
+            return left;
+        }
+
+        NodeBase* result{};
+        Node* node_left = dynamic_cast<Node*>(left);
+        Node* node_right = dynamic_cast<Node*>(right);
+        if (node_left && node_right)
+        {
+            // Recursively merge nodes
+            if (node_left->m_value <= node_right->m_value)
+            {
+                result = left;
+                result->m_next = merge(left->m_next, right, comp);
+            }
+            else
+            {
+                result = right;
+                result->m_next = merge(left, right->m_next);
+            }
+            result->m_next->m_prev = result;
+        }
+
+        return result;
+    }
+
+    template<typename T>
+    void List<T>::sort()
+    {
+        if (m_size == 0)
+        {
+            return;
+        }
+
+        // prevent sorting sentinel node
+        m_tail->m_prev->m_next = nullptr;
+
+        m_head = merge_sort(m_head);
+
+        // find last node to attach sentinel to
+        NodeBase* last{ m_head };
+        while (last->m_next)
+        {
+            last = last->m_next;
+        }
+        last->m_next = m_tail;
+        m_tail->m_prev = last;
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -2040,15 +2040,7 @@ namespace dsa
                     if (predicate(node_next->value(), node_temp->value()))
                     {
                         NodeBase* to_remove = next;
-
-                        if (to_remove->m_next)
-                        {
-                            to_remove->m_next->m_prev = prev;
-                        }
-                        else // temp was last node
-                        {
-                            m_tail = prev;
-                        }
+                        to_remove->m_next->m_prev = prev;
 
                         prev->m_next = to_remove->m_next;
                         destroy_node(to_remove);

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -37,7 +37,6 @@ namespace dsa
      *
      * @tparam T type of data stored in List Node
      *
-     * @todo add non-member specialized swap function
      * @todo add non-member specialized erase function
      * @todo add non-member specialized erase_if function
      * @todo remove public functions / operators not supported by std::forward_list
@@ -2697,6 +2696,19 @@ namespace dsa
         // first n elements are equal
         // check sizes
         return lhs.size() <=> rhs.size();
+    }
+
+    /**
+     * @brief Exchanges content of two List containers
+     *
+     * @tparam T data type stored in containers
+     * @param[in] lhs container to swap content
+     * @param[in] rhs container to swap content
+     */
+    template<typename T>
+    void swap(List<T>& lhs, List<T>& rhs) noexcept(noexcept(lhs.swap(rhs)))
+    {
+        lhs.swap(rhs);
     }
 }
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1320,15 +1320,7 @@ namespace dsa
     {
         if (&other != this)
         {
-            while (m_head->m_next)
-            {
-                pop_front();
-            }
-
-            for (size_type i = 0; i < other.size(); i++)
-            {
-                push_back(other.get(i)->value());
-            }
+            assign(other.begin(), other.end());
         }
 
         return *this;

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -901,8 +901,12 @@ namespace dsa
          * @brief Function adds new Node at the beginning of List
          *
          * @param[in] value element of type T
+         *
+         * @note no iterators or references are invalidated,
+         *       if construction of new element fails or an exception is thrown for any reason
+         *       state of the object does not change and this function has no effect
          */
-        void push_front(T value);
+        void push_front(const_reference value);
 
         /**
          * @brief Insert new element at the beginning of the container
@@ -1738,7 +1742,7 @@ namespace dsa
     }
 
     template<typename T>
-    void List<T>::push_front(T value)
+    void List<T>::push_front(const_reference value)
     {
         init_node();
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -959,8 +959,10 @@ namespace dsa
          * @brief Function swaps content of two List objects
          *
          * @param[in,out] other object to swap content with
+         *
+         * @note all iterators and references remain valid
          */
-        void swap(List<T>& other) noexcept;
+        void swap(List<T>& other) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value);
 
         /**
          * @brief Function combines two sorted Lists into one sorted List
@@ -1943,7 +1945,7 @@ namespace dsa
     }
 
     template<typename T>
-    void List<T>::swap(List<T>& other) noexcept
+    void List<T>::swap(List<T>& other) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value)
     {
         std::swap(m_head, other.m_head);
         std::swap(m_tail, other.m_tail);

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -113,7 +113,7 @@ namespace dsa
             /**
              * @brief Pointer to next node
              */
-            std::unique_ptr<NodeBase> m_next{};
+            NodeBase* m_next{};
 
             /**
              * @brief Pointer to previous node
@@ -135,8 +135,7 @@ namespace dsa
              */
             Node(T value)
                 : m_value{ value }
-            {
-            }
+            {}
 
             /**
              * @brief Function returns value stored in Node object
@@ -237,8 +236,7 @@ namespace dsa
              */
             ListIterator(NodeBase* node) noexcept
                 : m_current_node{ node }
-            {
-            }
+            {}
 
             /**
              * @brief Overload operator= to assign \p node to currently pointed ListIterator
@@ -261,7 +259,7 @@ namespace dsa
             {
                 if (m_current_node)
                 {
-                    m_current_node = m_current_node->m_next.get();
+                    m_current_node = m_current_node->m_next;
                 }
 
                 return *this;
@@ -348,7 +346,7 @@ namespace dsa
                 {
                     if (temp->m_next)
                     {
-                        temp = temp->m_next.get();
+                        temp = temp->m_next;
                     }
                     else
                     {
@@ -926,8 +924,8 @@ namespace dsa
         {
             if (m_head == nullptr)
             {
-                m_head = std::make_unique<NodeBase>();
-                m_tail = m_head.get();
+                m_head = new NodeBase;
+                m_tail = m_head;
             }
         }
 
@@ -953,13 +951,14 @@ namespace dsa
             }
 
             NodeBase* temp{ pos.m_current_node->m_prev };
-            NodeBase* to_remove{ temp->m_next.get() };
+            NodeBase* to_remove{ temp->m_next };
 
-            temp->m_next = std::move(to_remove->m_next);
+            temp->m_next = to_remove->m_next;
             temp->m_next->m_prev = temp;
+            delete to_remove;
 
             m_size--;
-            return iterator(temp->m_next.get());
+            return iterator(temp->m_next);
         }
 
         /**
@@ -987,15 +986,15 @@ namespace dsa
 
             NodeBase* temp{ pos.m_current_node->m_prev };
 
-            auto newNode = std::make_unique<Node>(value);
-            newNode->m_next = std::move(temp->m_next);
+            Node* newNode = new Node(value);
+            newNode->m_next = temp->m_next;
             newNode->m_prev = temp;
 
-            temp->m_next = std::move(newNode);
-            temp->m_next->m_next->m_prev = temp->m_next.get();
+            temp->m_next->m_prev = newNode;
+            temp->m_next = newNode;
 
             m_size++;
-            return iterator(temp->m_next.get());
+            return iterator(newNode);
         }
 
         /**
@@ -1049,7 +1048,7 @@ namespace dsa
          // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
         void transfer(const_iterator pos, List<T>&& other, const_iterator first, const const_iterator& last);
 
-        std::unique_ptr<NodeBase> m_head{};
+        NodeBase* m_head{};
         NodeBase* m_tail{};
         size_t m_size{};
     };
@@ -1063,8 +1062,7 @@ namespace dsa
     template<typename T>
     List<T>::List(size_t count)
         : List(count, T{})
-    {
-    }
+    {}
 
     template<typename T>
     List<T>::List(size_t count, const T& value)
@@ -1126,13 +1124,14 @@ namespace dsa
         if (&other != this)
         {
             clear();
+            NodeBase* temp{ m_head };
 
-            m_head = std::move(other.m_head);
-            m_tail = std::move(other.m_tail);
+            m_head = other.m_head;
+            m_tail = other.m_tail;
             m_size = other.m_size;
 
-            other.m_head = nullptr;
-            other.m_tail = nullptr;
+            other.m_head = temp;
+            other.m_tail = other.m_head;
             other.m_size = 0;
         }
 
@@ -1143,6 +1142,7 @@ namespace dsa
     List<T>::~List()
     {
         clear();
+        delete m_head;
     }
 
     template<typename T>
@@ -1194,13 +1194,13 @@ namespace dsa
     template<typename T>
     auto List<T>::begin() -> typename List<T>::iterator
     {
-        return iterator(m_head.get());
+        return iterator(m_head);
     }
 
     template<typename T>
     auto List<T>::begin() const -> typename List<T>::const_iterator
     {
-        return const_iterator(m_head.get());
+        return const_iterator(m_head);
     }
 
     template<typename T>
@@ -1250,9 +1250,13 @@ namespace dsa
     {
         if (m_head && m_head->m_next)
         {
-            while (m_head->m_next)
+            NodeBase* temp{ m_head };
+            while (temp->m_next)
             {
-                m_head = std::move(m_head->m_next);
+                m_head->m_prev = nullptr;
+                m_head = temp->m_next;
+                delete temp;
+                temp = m_head;
             }
 
             m_size = 0;
@@ -1342,18 +1346,18 @@ namespace dsa
     {
         init_node();
 
-        auto newNode = std::make_unique<Node>(value);
+        Node* newNode = new Node(value);
         if (!m_head->m_next)
         {
-            newNode->m_next = std::move(m_head);
-            m_head = std::move(newNode);
-            m_tail->m_prev = m_head.get();
+            newNode->m_next = m_head;
+            m_head = newNode;
+            m_tail->m_prev = m_head;
         }
         else
         {
-            m_head->m_prev = newNode.get();
-            newNode->m_next = std::move(m_head);
-            m_head = std::move(newNode);
+            m_head->m_prev = newNode;
+            newNode->m_next = m_head;
+            m_head = newNode;
         }
 
         m_size++;
@@ -1367,16 +1371,17 @@ namespace dsa
             return;
         }
 
+        NodeBase* temp{ m_head };
+        m_head = m_head->m_next;
         if (m_size == 1)
         {
-            m_head = std::move(m_head->m_next);
             m_tail->m_prev = nullptr;
         }
         else
         {
-            m_head = std::move(m_head->m_next);
             m_head->m_prev = nullptr;
         }
+        delete temp;
 
         m_size--;
     }
@@ -1386,20 +1391,20 @@ namespace dsa
     {
         init_node();
 
-        auto newNode = std::make_unique<Node>(value);
+        Node* newNode = new Node(value);
 
         if (!m_head->m_next) // only sentinel exists
         {
-            newNode->m_next = std::move(m_head);
-            m_head = std::move(newNode);
-            m_tail->m_prev = m_head.get();
+            newNode->m_next = m_head;
+            m_head = newNode;
+            m_tail->m_prev = m_head;
         }
         else
         {
             newNode->m_prev = m_tail->m_prev;
-            newNode->m_next = std::move(m_tail->m_prev->m_next);
-            m_tail->m_prev = newNode.get();
-            m_tail->m_prev->m_prev->m_next = std::move(newNode);
+            newNode->m_next = m_tail->m_prev->m_next;
+            m_tail->m_prev = newNode;
+            m_tail->m_prev->m_prev->m_next = newNode;
         }
 
         m_size++;
@@ -1413,17 +1418,20 @@ namespace dsa
             return;
         }
 
+        NodeBase* temp{};
         if (m_size == 1)
         {
-            m_head = std::move(m_head->m_next);
+            temp = m_head;
+            m_head = m_head->m_next;
             m_tail->m_prev = nullptr;
         }
         else
         {
-            NodeBase* temp{ m_tail->m_prev->m_prev };
-            m_tail->m_prev->m_prev->m_next = std::move(m_tail->m_prev->m_next);
-            m_tail->m_prev = temp;
+            temp = m_tail->m_prev;
+            temp->m_prev->m_next = temp->m_next;
+            m_tail->m_prev = temp->m_prev;
         }
+        delete temp;
 
         m_size--;
     }
@@ -1484,63 +1492,68 @@ namespace dsa
         {
             if (m_size != 0)
             {
-                auto temp_head = std::make_unique<Node>(0);
-                NodeBase* temp_tail = temp_head.get();
+                Node* temp_head = new Node(0);
+                NodeBase* temp_tail = temp_head;
 
-                std::unique_ptr<NodeBase> to_move{};
-                std::unique_ptr<NodeBase> to_return{};
+                NodeBase* to_move{};
+                NodeBase* to_return{};
 
-                std::unique_ptr<NodeBase> sentinel_this{ std::move(m_tail->m_prev->m_next) };
-                const std::unique_ptr<NodeBase> sentinel_other{ std::move(other.m_tail->m_prev->m_next) };
+                NodeBase* sentinel_this{ m_tail->m_prev->m_next };
+                NodeBase* sentinel_other{ other.m_tail->m_prev->m_next };
 
-                while (m_head && other.m_head)
+                while (m_head->m_next && other.m_head->m_next)
                 {
-                    Node* node_this = dynamic_cast<Node*>(m_head.get());
-                    Node* node_other = dynamic_cast<Node*>(other.m_head.get());
+                    Node* node_this = dynamic_cast<Node*>(m_head);
+                    Node* node_other = dynamic_cast<Node*>(other.m_head);
 
                     if (node_this && node_other)
                     {
                         if (node_this->value() <= node_other->value())
                         {
-                            to_move = std::move(m_head);
+                            to_move = m_head;
                             to_move->m_prev = temp_tail;
 
-                            to_return = std::move(to_move->m_next);
-                            temp_tail->m_next = std::move(to_move);
-                            m_head = std::move(to_return);
+                            to_return = to_move->m_next;
+                            temp_tail->m_next = to_move;
+                            m_head = to_return;
                         }
                         else
                         {
-                            to_move = std::move(other.m_head);
+                            to_move = other.m_head;
                             to_move->m_prev = temp_tail;
 
-                            to_return = std::move(to_move->m_next);
-                            temp_tail->m_next = std::move(to_move);
-                            other.m_head = std::move(to_return);
+                            to_return = to_move->m_next;
+                            temp_tail->m_next = to_move;
+                            other.m_head = to_return;
                         }
 
-                        temp_tail = temp_tail->m_next.get();
+                        temp_tail = temp_tail->m_next;
                     }
                 }
 
                 NodeBase* last{};
-                if (m_head == nullptr) // other.m_head attached at the end
+                if (m_head->m_next == nullptr) // other.m_head attached at the end
                 {
                     last = sentinel_other->m_prev;
                     other.m_head->m_prev = temp_tail;
-                    temp_tail->m_next = std::move(other.m_head);
+                    temp_tail->m_next = other.m_head;
                 }
                 else // this.m_head attached at the end
                 {
                     last = sentinel_this->m_prev;
                     m_head->m_prev = temp_tail;
-                    temp_tail->m_next = std::move(m_head);
+                    temp_tail->m_next = m_head;
                 }
-                last->m_next = std::move(sentinel_this);
+                last->m_next = sentinel_this;
                 last->m_next->m_prev = last;
 
-                m_head = std::move(temp_head->m_next);
+                m_head = temp_head->m_next;
                 m_head->m_prev = nullptr;
+                delete temp_head;
+
+                other.m_head = other.m_tail;
+                other.m_head->m_next = nullptr;
+                other.m_head->m_prev = nullptr;
 
                 m_size += other.m_size;
                 other.m_size = 0;
@@ -1583,18 +1596,18 @@ namespace dsa
 
             // select fragment from other
 
-            std::unique_ptr<NodeBase> fragment{};
-            std::unique_ptr<NodeBase> fragment_end{ std::move(last_to_move->m_next) };
+            NodeBase* fragment{};
+            NodeBase* fragment_end{ last_to_move->m_next };
             if (first == other.begin())
             {
-                fragment = std::move(other.m_head);
-                other.m_head = std::move(fragment_end);
+                fragment = other.m_head;
+                other.m_head = fragment_end;
                 other.m_head->m_prev = nullptr;
             }
             else
             {
-                fragment = std::move(first.m_current_node->m_prev->m_next);
-                fragment->m_prev->m_next = std::move(fragment_end);
+                fragment = first.m_current_node->m_prev->m_next;
+                fragment->m_prev->m_next = fragment_end;
                 fragment->m_prev->m_next->m_prev = first.m_current_node->m_prev;
                 fragment->m_prev = nullptr;
             }
@@ -1603,15 +1616,15 @@ namespace dsa
 
             if (pos == begin())
             {
-                last_to_move->m_next = std::move(m_head);
+                last_to_move->m_next = m_head;
                 last_to_move->m_next->m_prev = last_to_move;
-                m_head = std::move(fragment);
+                m_head = fragment;
             }
             else
             {
-                last_to_move->m_next = std::move(temp_prev->m_next);
+                last_to_move->m_next = temp_prev->m_next;
                 last_to_move->m_next->m_prev = last_to_move;
-                temp_prev->m_next = std::move(fragment);
+                temp_prev->m_next = fragment;
                 temp_prev->m_next->m_prev = temp_prev;
             }
 
@@ -1635,13 +1648,13 @@ namespace dsa
     template<typename T>
     void List<T>::splice(const const_iterator& pos, List<T>& other, const const_iterator& iter)
     {
-        transfer(pos, std::move(other), iter, iter.m_current_node->m_next.get());
+        transfer(pos, std::move(other), iter, iter.m_current_node->m_next);
     }
 
     template<typename T>
     void List<T>::splice(const_iterator pos, List<T>&& other, const_iterator iter)
     {
-        transfer(pos, std::move(other), iter, iter.m_current_node->m_next.get());
+        transfer(pos, std::move(other), iter, iter.m_current_node->m_next);
     }
 
     template<typename T>
@@ -1660,19 +1673,19 @@ namespace dsa
     template<typename T>
     void List<T>::remove(const_reference value)
     {
-        NodeBase* temp{ m_head.get() };
+        NodeBase* temp{ m_head };
         NodeBase* next{};
 
-        while (temp->m_next.get())
+        while (temp->m_next)
         {
-            next = temp->m_next.get();
+            next = temp->m_next;
 
-            if (Node* node = dynamic_cast<Node*>(m_head.get()))
+            if (Node* node = dynamic_cast<Node*>(m_head))
             {
                 if (node->value() == value)
                 {
                     pop_front();
-                    temp = m_head.get();
+                    temp = m_head;
                     continue;
                 }
             }
@@ -1687,7 +1700,7 @@ namespace dsa
                 }
             }
 
-            temp = temp->m_next.get();
+            temp = temp->m_next;
         }
     }
 
@@ -1699,31 +1712,31 @@ namespace dsa
             return;
         }
 
-        NodeBase* new_back{ m_head.get() };
-        std::unique_ptr<NodeBase> sentinel = std::move(m_tail->m_prev->m_next);
+        NodeBase* new_back{ m_head };
+        NodeBase* sentinel = m_tail->m_prev->m_next;
 
-        std::unique_ptr<NodeBase> temp = std::move(m_head);
-        std::unique_ptr<NodeBase> prev{};
+        NodeBase* temp = m_head;
+        NodeBase* prev{};
 
         for (size_t i = 0; i < m_size; i++)
         {
-            std::unique_ptr<NodeBase> next = std::move(temp->m_next);
-            temp->m_next = std::move(prev);
-            temp->m_prev = next.get();
+            NodeBase* next = temp->m_next;
+            temp->m_next = prev;
+            temp->m_prev = next;
 
-            prev = std::move(temp);
-            temp = std::move(next);
+            prev = temp;
+            temp = next;
         }
 
-        m_head = std::move(prev);
+        m_head = prev;
         m_tail->m_prev = new_back;
-        m_tail->m_prev->m_next = std::move(sentinel);
+        m_tail->m_prev->m_next = sentinel;
     }
 
     template<typename T>
     void List<T>::unique()
     {
-        NodeBase* temp{ m_head.get() };
+        NodeBase* temp{ m_head };
         NodeBase* prev{};
         NodeBase* next{};
         while (temp)
@@ -1732,7 +1745,7 @@ namespace dsa
 
             while (prev)
             {
-                next = prev->m_next.get();
+                next = prev->m_next;
 
                 Node* node_next = dynamic_cast<Node*>(next);
                 Node* node_temp = dynamic_cast<Node*>(temp);
@@ -1751,15 +1764,16 @@ namespace dsa
                             m_tail = prev;
                         }
 
-                        prev->m_next = std::move(to_remove->m_next);
+                        prev->m_next = to_remove->m_next;
+                        delete to_remove;
 
                         m_size--;
                         continue;
                     }
                 }
 
-                prev = prev->m_next.get();
-                temp = temp->m_next.get();
+                prev = prev->m_next;
+                temp = temp->m_next;
             }
         }
     }
@@ -1782,10 +1796,10 @@ namespace dsa
         if constexpr (mode == FRONT)
         {
             // count nodes from front
-            temp = m_head.get();
+            temp = m_head;
             for (size_t i = 0; i < index; i++)
             {
-                temp = temp->m_next.get();
+                temp = temp->m_next;
             }
         }
         else if constexpr (mode == BACK)
@@ -1802,10 +1816,10 @@ namespace dsa
             // optimize counting nodes from front or back
             if (index < m_size / 2)
             {
-                temp = m_head.get();
+                temp = m_head;
                 for (size_t i = 0; i < index; i++)
                 {
-                    temp = temp->m_next.get();
+                    temp = temp->m_next;
                 }
             }
             else

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1103,8 +1103,10 @@ namespace dsa
         /**
          * @brief Function removes consecutive duplicated elements
          * @details Only the first occurrence of given element in each group is preserved
+         *
+         * @return size_type number of elements removed
          */
-        void unique();
+        auto unique() -> size_type;
 
         /**
          * @brief Append elements of another List to base container
@@ -2284,11 +2286,14 @@ namespace dsa
     }
 
     template<typename T>
-    void List<T>::unique()
+    auto List<T>::unique() -> size_type
     {
         NodeBase* temp{ m_head };
         NodeBase* prev{};
         NodeBase* next{};
+
+        size_type removed_count{};
+
         while (temp)
         {
             prev = temp;
@@ -2317,6 +2322,7 @@ namespace dsa
                         prev->m_next = to_remove->m_next;
                         destroy_node(to_remove);
 
+                        removed_count++;
                         m_size--;
                         continue;
                     }
@@ -2326,6 +2332,8 @@ namespace dsa
                 temp = temp->m_next;
             }
         }
+
+        return removed_count;
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1944,31 +1944,18 @@ namespace dsa
     auto List<T>::remove_if(UnaryPred predicate) -> size_type
     {
         NodeBase* temp{ m_head };
-        NodeBase* next{};
 
         size_type removed_count{};
 
-        while (temp->m_next)
+        while (temp)
         {
-            next = temp->m_next;
-
-            if (Node* node = dynamic_cast<Node*>(m_head))
+            if (Node* node = dynamic_cast<Node*>(temp))
             {
                 if (predicate(node->value()))
                 {
-                    pop_front();
-                    temp = m_head;
-                    removed_count++;
-                    continue;
-                }
-            }
-
-            if (next && next != m_tail && next->m_next != nullptr)
-            {
-                Node* node = dynamic_cast<Node*>(next);
-                if (predicate(node->value()))
-                {
+                    NodeBase* next{ node->m_next };
                     erase(ListIterator<false>(node));
+                    temp = next;
                     removed_count++;
                     continue;
                 }
@@ -2242,7 +2229,6 @@ namespace dsa
     template<typename T>
     auto List<T>::erase_element(iterator pos) -> iterator
     {
-
         if (pos == begin())
         {
             pop_front();

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1095,6 +1095,8 @@ namespace dsa
 
         /**
          * @brief Function reverts in place Nodes of List
+         *
+         * @note no iterators or references are invalidated
          */
         void reverse() noexcept;
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -935,6 +935,8 @@ namespace dsa
 
         /**
          * @brief Function removes first Node of List
+         *
+         * @note references and iterators to the erased element are invalidated
          */
         void pop_front();
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -429,6 +429,13 @@ namespace dsa
         using size_type = std::size_t;
 
         /**
+         * @brief Alias for pointer difference type used in class
+         *
+         * @tparam T pointer size type
+         */
+        using difference_type = std::ptrdiff_t;
+
+        /**
          * @brief Alias for pointer to data type used in class
          *
          * @tparam T* pointer to data type

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1006,61 +1006,85 @@ namespace dsa
 
         /**
          * @brief Function moves elements from other List object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator before which content of other container will be inserted
          * @param[in,out] other container to take elements from
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice(const const_iterator& pos, List<T>& other);
 
         /**
          * @brief Function moves elements from other List object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator before which content of other container will be inserted
          * @param[in,out] other container to take elements from
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice(const_iterator pos, List<T>&& other);
 
         /**
          * @brief Function moves elements from other List object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator before which content of other container will be inserted
          * @param[in,out] other container to take elements from
          * @param[in] iter const_iterator pointing to element to move
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice(const const_iterator& pos, List<T>& other, const const_iterator& iter);
 
         /**
          * @brief Function moves elements from other List object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator before which content of other container will be inserted
          * @param[in,out] other container to take elements from
          * @param[in] iter const_iterator pointing to element to move
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice(const_iterator pos, List<T>&& other, const_iterator iter);
 
         /**
          * @brief Function moves elements in range [first, last) from other List object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator before which content of other container will be inserted
          * @param[in,out] other container to take elements from
          * @param[in] first const_iterator pointing to first element to move
          * @param[in] last const_iterator pointing to element after last taken element
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice(const const_iterator& pos, List<T>& other, const const_iterator& first, const const_iterator& last);
 
         /**
          * @brief Function moves elements in range [first, last) from other List object
+         * @details Content of other object will be taken by constructed object
          *
          * @param[in] pos const_iterator before which content of other container will be inserted
          * @param[in,out] other container to take elements from
          * @param[in] first const_iterator pointing to first element to move
          * @param[in] last const_iterator pointing to element after last taken element
-         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
          */
         void splice(const_iterator pos, List<T>&& other, const_iterator first, const_iterator last);
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -858,8 +858,12 @@ namespace dsa
          * @brief Function adds new Node at the end of List
          *
          * @param[in] value element of type T
+         *
+         * @note no iterators or references are invalidated,
+         *       if construction of new element fails or an exception is thrown for any reason
+         *       state of the object does not change and this function has no effect
          */
-        void push_back(T value);
+        void push_back(const_reference value);
 
         /**
          * @brief Insert new element to the end of the container
@@ -1774,7 +1778,7 @@ namespace dsa
     }
 
     template<typename T>
-    void List<T>::push_back(T value)
+    void List<T>::push_back(const_reference value)
     {
         init_node();
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -36,9 +36,6 @@ namespace dsa
      *
      * @tparam T type of data stored in List Node
      *
-     * @todo add emplace
-     * @todo add emplace_back
-     * @todo add emplace_front
      * @todo add remove_if
      * @todo add sort
      * @todo add operator<=>
@@ -789,6 +786,21 @@ namespace dsa
         auto insert(const const_iterator& pos, std::initializer_list<T> init_list) -> iterator;
 
         /**
+         * @brief Insert new element into the container before \p pos
+         *
+         * @tparam ...Args
+         * @param[in] pos iterator before which new element will be inserted
+         * @param[in] ...args args arguments to forward to the constructor of the element
+         * @return iterator pointing to the emplaced element
+         *
+         * @note no iterators or references are invalidated,
+         *       if construction of new element fails or an exception is thrown for any reason
+         *       state of the object does not change and this function has no effect
+         */
+        template<typename... Args>
+        auto emplace(const_iterator pos, Args&&... args) -> iterator;
+
+        /**
         * @brief Function erases Node object at specified \p pos
         *
         * @param[in] pos iterator to element to erase
@@ -842,6 +854,20 @@ namespace dsa
         void push_back(T value);
 
         /**
+         * @brief Insert new element to the end of the container
+         *
+         * @tparam ...Args
+         * @param[in] ...args args arguments to forward to the constructor of the element
+         * @return reference to the emplaced element
+         *
+         * @note no iterators or references are invalidated,
+         *       if construction of new element fails or an exception is thrown for any reason
+         *       state of the object does not change and this function has no effect
+         */
+        template<typename... Args>
+        auto emplace_back(Args&&... args) -> reference;
+
+        /**
          * @brief Function removes last Node of List
          */
         void pop_back();
@@ -852,6 +878,20 @@ namespace dsa
          * @param[in] value element of type T
          */
         void push_front(T value);
+
+        /**
+         * @brief Insert new element at the beginning of the container
+         *
+         * @tparam ...Args
+         * @param[in] ...args args arguments to forward to the constructor of the element
+         * @return reference to the emplaced element
+         *
+         * @note no iterators or references are invalidated,
+         *       if construction of new element fails or an exception is thrown for any reason
+         *       state of the object does not change and this function has no effect
+         */
+        template<typename... Args>
+        auto emplace_front(Args&&... args) -> reference;
 
         /**
          * @brief Function removes first Node of List
@@ -1575,6 +1615,44 @@ namespace dsa
     }
 
     template<typename T>
+    template<typename... Args>
+    auto List<T>::emplace(const_iterator pos, Args&&... args) -> iterator
+    {
+        Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
+        try
+        {
+            node_alloc_traits::construct(node_alloc, newNode, std::forward<Args>(args)...);
+
+            if (pos == cbegin())
+            {
+                newNode->m_next = m_head;
+                !m_head->m_next ? m_tail->m_prev = newNode : m_head->m_prev = newNode;
+                m_head = newNode;
+            }
+            else
+            {
+                NodeBase* prev_pos{ pos.m_current_node->m_prev };
+                NodeBase* next_pos{ prev_pos->m_next };
+
+                prev_pos->m_next = newNode;
+                newNode->m_prev = prev_pos;
+
+                newNode->m_next = next_pos;
+                next_pos->m_prev = newNode;
+            }
+        }
+        catch (...)
+        {
+            node_alloc_traits::deallocate(node_alloc, newNode, 1);
+            throw;
+        }
+
+        ++m_size;
+        return iterator(newNode);
+    }
+
+
+    template<typename T>
     auto List<T>::erase(iterator pos) -> typename List<T>::iterator
     {
         if (!if_valid_iterator(pos))
@@ -1631,6 +1709,14 @@ namespace dsa
     }
 
     template<typename T>
+    template<typename... Args>
+    auto List<T>::emplace_front(Args&&... args) -> reference
+    {
+        emplace(begin(), std::forward<Args>(args)...);
+        return front();
+    }
+
+    template<typename T>
     void List<T>::pop_front()
     {
         if (m_size == 0)
@@ -1675,6 +1761,14 @@ namespace dsa
         }
 
         m_size++;
+    }
+
+    template<typename T>
+    template<typename... Args>
+    auto List<T>::emplace_back(Args&&... args) -> reference
+    {
+        emplace(end(), std::forward<Args>(args)...);
+        return back();
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -2305,8 +2305,7 @@ namespace dsa
     template<typename T>
     void List<T>::destroy_node(NodeBase* node_to_destroy)
     {
-        Node* node_dyn = dynamic_cast<Node*>(node_to_destroy);
-        if (node_dyn)
+        if (Node* node_dyn = dynamic_cast<Node*>(node_to_destroy))
         {
             node_alloc_traits::destroy(node_alloc, node_dyn);
             node_alloc_traits::deallocate(node_alloc, node_dyn, 1);

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1751,45 +1751,13 @@ namespace dsa
     {
         init_node();
 
-        Node* newNode = construct_node(nullptr, nullptr, value);
-
-        if (!m_head->m_next) // only sentinel exists
-        {
-            newNode->m_next = m_head;
-            m_head = newNode;
-            m_tail->m_prev = m_head;
-        }
-        else
-        {
-            newNode->m_prev = m_tail->m_prev;
-            newNode->m_next = m_tail->m_prev->m_next;
-            m_tail->m_prev = newNode;
-            m_tail->m_prev->m_prev->m_next = newNode;
-        }
-
-        m_size++;
+        emplace_back(value);
     }
 
     template<typename T>
     void List<T>::push_back(T&& value)
     {
-        Node* newNode = construct_node(nullptr, nullptr, std::move(value));
-
-        if (!m_head->m_next) // only sentinel exists
-        {
-            newNode->m_next = m_head;
-            m_head = newNode;
-            m_tail->m_prev = m_head;
-        }
-        else
-        {
-            newNode->m_prev = m_tail->m_prev;
-            newNode->m_next = m_tail->m_prev->m_next;
-            m_tail->m_prev = newNode;
-            m_tail->m_prev->m_prev->m_next = newNode;
-        }
-
-        m_size++;
+        emplace_back(std::move(value));
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1172,6 +1172,8 @@ namespace dsa
             return *this;
         }
 
+    private:
+
         /**
          * @brief Function returns pointer to specific Node of List
          *
@@ -1192,8 +1194,6 @@ namespace dsa
          * @retval false if invalid index
          */
         auto set(size_type index, T value) -> bool;
-
-    private:
 
         /**
          * @brief Construct new object based on two List objects

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -438,30 +438,30 @@ namespace dsa
         /**
          * @brief Alias for pointer to data type used in class
          *
-         * @tparam T* pointer to data type
+         * @tparam value_type* pointer to data type
          */
-        using pointer = T*;
+        using pointer = value_type*;
 
         /**
          * @brief Alias for const pointer to data type used in class
          *
-         * @tparam T* pointer to data type
+         * @tparam value_type* const pointer to data type
          */
-        using const_pointer = const T*;
+        using const_pointer = const value_type*;
 
         /**
          * @brief Alias for reference to data type used in class
          *
-         * @tparam T& reference to data type
+         * @tparam value_type& reference to data type
          */
-        using reference = T&;
+        using reference = value_type&;
 
         /**
          * @brief Alias for const reference to data type used in class
          *
-         * @tparam T& const reference to data type
+         * @tparam value_type& const reference to data type
          */
-        using const_reference = const T&;
+        using const_reference = const value_type&;
 
         /**
          * @brief Alias for const iterator to data type used in class

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -752,7 +752,7 @@ namespace dsa
         /**
          * @brief Function removes all elements of List
          */
-        void clear();
+        void clear() noexcept;
 
         /**
          * @brief Function inserts new Node before specified \p pos
@@ -1513,7 +1513,7 @@ namespace dsa
     }
 
     template<typename T>
-    void List<T>::clear()
+    void List<T>::clear() noexcept
     {
         if (m_head && m_head->m_next)
         {

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -37,7 +37,6 @@ namespace dsa
      *
      * @tparam T type of data stored in List Node
      *
-     * @todo add operator<=>
      * @todo add non-member specialized swap function
      * @todo add non-member specialized erase function
      * @todo add non-member specialized erase_if function
@@ -2632,31 +2631,32 @@ namespace dsa
      * @brief The relational operator compares two List objects
      *
      * @tparam T type of data stored in List
-     * @param[in] list1 input container
-     * @param[in] list2 input container
+     * @param[in] lhs input container
+     * @param[in] rhs input container
      * @retval true if containers are equal
      * @retval false if containers are not equal
      */
     template<typename T>
-    auto operator==(const List<T>& list1, const List<T>& list2) -> bool
+    auto operator==(const List<T>& lhs, const List<T>& rhs)
+        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> bool
     {
-        if (list1.size() != list2.size())
+        if (lhs.size() != rhs.size())
         {
             return false;
         }
 
-        auto list1_iter = list1.cbegin();
-        auto list2_iter = list2.cbegin();
+        auto lhs_iter = lhs.cbegin();
+        auto rhs_iter = rhs.cbegin();
 
-        while (list1_iter != list1.cend())
+        while (lhs_iter != lhs.cend())
         {
-            if (*list1_iter != *list2_iter)
+            if (*lhs_iter != *rhs_iter)
             {
                 return false;
             }
 
-            list1_iter++;
-            list2_iter++;
+            lhs_iter++;
+            rhs_iter++;
         }
 
         return true;
@@ -2665,100 +2665,38 @@ namespace dsa
     /**
      * @brief The relational operator compares two List objects
      *
-     * @tparam T type of data stored in List
-     * @param[in] list1 input container
-     * @param[in] list2 input container
-     * @retval true if containers are not equal
-     * @retval false if containers are equal
-     */
-    template<typename T>
-    auto operator!=(const List<T>& list1, const List<T>& list2) -> bool
-    {
-        return !(operator==(list1, list2));
-    }
-
-    /**
-     * @brief The relational operator compares two List objects
+     * Depending on type T, function returns one of following objects:
+     * std::strong_ordering::less / equal / greater
+     * std::weak_ordering::less / equivalent / greater
+     * std::partial_ordering::less / equivalent / greater / unordered
+     * It is best to compare results with 0 to determine if lhs is <, >, or == to rhs
      *
-     * @tparam T type of data stored in List
-     * @param[in] list1 input container
-     * @param[in] list2 input container
-     * @retval true if the content of \p list1 are lexicographically
-     *         less than the content of \p list2
-     * @retval false otherwise
+     * @param[in] lhs input container
+     * @param[in] rhs input container
+     * @return three way comparison result type
      */
     template<typename T>
-    auto operator<(const List<T>& list1, const List<T>& list2) -> bool
+    auto operator<=>(const List<T>& lhs, const List<T>& rhs)
+        noexcept(noexcept(*lhs.begin() == *rhs.begin()))->std::compare_three_way_result_t<T>
     {
-        auto list1_iter = list1.cbegin();
-        auto list2_iter = list2.cbegin();
+        auto lhs_iter = lhs.cbegin();
+        auto rhs_iter = rhs.cbegin();
 
-        while (list1_iter != list1.cend() && list2_iter != list2.cend())
+        while (lhs_iter != lhs.cend() && rhs_iter != rhs.cend())
         {
-            if (*list1_iter > *list2_iter)
+            auto cmp = *lhs_iter <=> *rhs_iter;
+            if (cmp != 0)
             {
-                return false;
-            }
-            if (*list1_iter < *list2_iter)
-            {
-                return true;
+                return cmp;
             }
 
-            list1_iter++;
-            list2_iter++;
+            lhs_iter++;
+            rhs_iter++;
         }
 
         // first n elements are equal
         // check sizes
-        return list1.size() < list2.size();
-    }
-
-    /**
-     * @brief The relational operator compares two List objects
-     *
-     * @tparam T type of data stored in List
-     * @param[in] list1 input container
-     * @param[in] list2 input container
-     * @retval true if the content of \p list1 are lexicographically
-     *         greater than the content of \p list2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator>(const List<T>& list1, const List<T>& list2) -> bool
-    {
-        return operator<(list2, list1);
-    }
-
-    /**
-     * @brief The relational operator compares two List objects
-     *
-     * @tparam T type of data stored in List
-     * @param[in] list1 input container
-     * @param[in] list2 input container
-     * @retval true if the content of \p list1 are lexicographically
-     *         less or equal than the content of \p list2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator<=(const List<T>& list1, const List<T>& list2) -> bool
-    {
-        return !(operator>(list1, list2));
-    }
-
-    /**
-     * @brief The relational operator compares two List objects
-     *
-     * @tparam T type of data stored in List
-     * @param[in] list1 input container
-     * @param[in] list2 input container
-     * @retval true if the content of \p list1 are lexicographically
-     *         greater or equal than the content of \p list2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator>=(const List<T>& list1, const List<T>& list2) -> bool
-    {
-        return !(operator<(list1, list2));
+        return lhs.size() <=> rhs.size();
     }
 }
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -2257,19 +2257,19 @@ namespace dsa
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters,-warnings-as-errors)
     auto List<T>::construct_node(NodeBase* prev_ptr, NodeBase* next_ptr, Args&&... args) -> Node*
     {
-        Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
+        Node* newNode{};
         try
         {
+            newNode = node_alloc_traits::allocate(node_alloc, 1);
             node_alloc_traits::construct(node_alloc, newNode, std::forward<Args>(args)...);
+            newNode->m_prev = prev_ptr;
+            newNode->m_next = next_ptr;
         }
         catch (...)
         {
             node_alloc_traits::deallocate(node_alloc, newNode, 1);
             throw;
         }
-
-        newNode->m_prev = prev_ptr;
-        newNode->m_next = next_ptr;
 
         return newNode;
     }

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1826,8 +1826,8 @@ namespace dsa
             NodeBase* to_move{};
             NodeBase* to_return{};
 
-            NodeBase* sentinel_this{ m_tail->m_prev->m_next };
-            NodeBase* sentinel_other{ other.m_tail->m_prev->m_next };
+            NodeBase* sentinel_this{ m_tail };
+            NodeBase* sentinel_other{ other.m_tail };
 
             while (m_head->m_next && other.m_head->m_next)
             {

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -733,7 +733,7 @@ namespace dsa
          * @retval true if container is empty
          * @retval false if container is not empty
          */
-        [[nodiscard]] auto empty() const -> bool;
+        [[nodiscard]] auto empty() const noexcept -> bool;
 
         /**
          * @brief Function returns List size
@@ -1495,7 +1495,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::empty() const -> bool
+    auto List<T>::empty() const noexcept -> bool
     {
         return m_size == 0;
     }

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -766,8 +766,7 @@ namespace dsa
          *
          * @param[in] pos const_iterator to insert element before
          * @param[in] value element of type T to be inserted before \p pos
-         * @return pointer to List element
-         * @retval iterator to inserted \p value
+         * @retval iterator to inserted element
          * @retval pos if no element was inserted
          */
         auto insert(const const_iterator& pos, const_reference value) -> iterator;
@@ -776,10 +775,19 @@ namespace dsa
          * @brief Function inserts new Node before specified \p pos
          *
          * @param[in] pos const_iterator to insert element before
+         * @param[in] value element of type T to be inserted before \p pos using move semantics
+         * @retval iterator to inserted element
+         * @retval pos if no element was inserted
+         */
+        auto insert(const const_iterator& pos, T&& value) -> iterator;
+
+        /**
+         * @brief Function inserts new Node before specified \p pos
+         *
+         * @param[in] pos const_iterator to insert element before
          * @param[in] count number of elements to insert before \p pos
          * @param[in] value element of type T to be inserted
-         * @return pointer to List element
-         * @retval iterator to inserted \p value
+         * @retval iterator to inserted element
          * @retval pos if no element was inserted
          */
         auto insert(const const_iterator& pos, size_type count, const_reference value) -> iterator;
@@ -1588,15 +1596,28 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::insert(const const_iterator& pos, size_type count, const_reference value) -> typename List<T>::iterator
+    auto List<T>::insert(const const_iterator& pos, T&& value) -> typename List<T>::iterator
     {
-        iterator iter{ pos.m_current_node };
-
         if (!if_valid_iterator(pos))
         {
             return nullptr;
         }
 
+        iterator iter{ pos.m_current_node };
+        iter = emplace(iter, std::move(value));
+
+        return iter;
+    }
+
+    template<typename T>
+    auto List<T>::insert(const const_iterator& pos, size_type count, const_reference value) -> typename List<T>::iterator
+    {
+        if (!if_valid_iterator(pos))
+        {
+            return nullptr;
+        }
+
+        iterator iter{ pos.m_current_node };
         for (size_type i = 0; i < count; i++)
         {
             iter = insert_element_before(iter, value);

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <initializer_list>
 #include <iostream>
 #include <iterator>
@@ -1129,6 +1130,20 @@ namespace dsa
         void sort();
 
         /**
+         * @brief Function sorts the elements and preserves the order of equivalent elements
+         *
+         * @details elements are compared using \p comp
+         *
+         * @tparam Compare
+         * @param[in] comp comparison function object, returns \p true if the first argument is less than second
+         *
+         * @note no iterators or references are invalidated,
+         *       if an exception is thrown, the order of elements is unspecified
+         */
+        template<typename Compare>
+        void sort(Compare comp);
+
+        /**
          * @brief Append elements of another List to base container
          *
          * @tparam T type of data stored in List Node
@@ -1377,20 +1392,26 @@ namespace dsa
          * @details Sorting is implemented using recursive (top-down) algorithm
          *          Sorting is stable and inplace
          *
+         * @tparam Compare
          * @param[in,out] source list to sort
-         * @return NodeBase* of sorted list
+         * @param[in] comp comparison function object
+         * @return NodeBase* of sorted list using \p comp
          */
-        auto merge_sort(NodeBase* source) -> NodeBase*;
+        template<typename Compare>
+        auto merge_sort(NodeBase* source, Compare comp) -> NodeBase*;
 
         /**
          * @brief Helper function for merge_sort to merge two sub-lists
          * @details Merging of sorted sub-lists is performed recursively
          *
+         * @tparam Compare
          * @param[in,out] left first input sub-list
          * @param[in,out] right second input sub-list
-         * @return NodeBase* containing sorted elements from both input lists
+         * @param[in] comp comparison function object
+         * @return NodeBase* containing elements from both input lists sorted using \p comp
          */
-        auto merge(NodeBase* left, NodeBase* right) -> NodeBase*;
+        template<typename Compare>
+        auto merge(NodeBase* left, NodeBase* right, Compare comp) -> NodeBase*;
 
         NodeBase* m_head{};
         NodeBase* m_tail{};
@@ -2384,9 +2405,10 @@ namespace dsa
     }
 
     template<typename T>
+    template<typename Compare>
     // Intentional recursive call for sorting nodes in top-down algorithm implementation
     // NOLINTNEXTLINE(misc-no-recursion)
-    auto List<T>::merge_sort(NodeBase* source) -> NodeBase*
+    auto List<T>::merge_sort(NodeBase* source, Compare comp) -> NodeBase*
     {
         // Stop condition, one element list is already sorted
         if (source == nullptr || source->m_next == nullptr)
@@ -2413,18 +2435,19 @@ namespace dsa
         slow->m_next = nullptr;
 
         // Recursively sort both sub-lists
-        left = merge_sort(left);
-        right = merge_sort(right);
+        left = merge_sort(left, comp);
+        right = merge_sort(right, comp);
 
         // Merge sorted sublists
-        NodeBase* result{ merge(left, right) };
+        NodeBase* result{ merge(left, right, comp) };
         return result;
     }
 
     template<typename T>
+    template<typename Compare>
     // Intentional recursive call for merging nodes in top-down merge_sort algorithm implementation
     // NOLINTNEXTLINE(misc-no-recursion)
-    auto List<T>::merge(NodeBase* left, NodeBase* right) -> NodeBase*
+    auto List<T>::merge(NodeBase* left, NodeBase* right, Compare comp) -> NodeBase*
     {
         // Stop condition, empty element list is already sorted
         if (left == nullptr)
@@ -2442,7 +2465,7 @@ namespace dsa
         if (node_left && node_right)
         {
             // Recursively merge nodes
-            if (node_left->m_value <= node_right->m_value)
+            if (comp(node_left->m_value, node_right->m_value))
             {
                 result = left;
                 result->m_next = merge(left->m_next, right, comp);
@@ -2450,7 +2473,7 @@ namespace dsa
             else
             {
                 result = right;
-                result->m_next = merge(left, right->m_next);
+                result->m_next = merge(left, right->m_next, comp);
             }
             result->m_next->m_prev = result;
         }
@@ -2461,6 +2484,13 @@ namespace dsa
     template<typename T>
     void List<T>::sort()
     {
+        sort(std::less<>());
+    }
+
+    template<typename T>
+    template<typename Compare>
+    void List<T>::sort(Compare comp)
+    {
         if (m_size == 0)
         {
             return;
@@ -2469,7 +2499,7 @@ namespace dsa
         // prevent sorting sentinel node
         m_tail->m_prev->m_next = nullptr;
 
-        m_head = merge_sort(m_head);
+        m_head = merge_sort(m_head, comp);
 
         // find last node to attach sentinel to
         NodeBase* last{ m_head };

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -740,7 +740,7 @@ namespace dsa
          *
          * @return size_type number of elements in container
          */
-        [[nodiscard]] auto size() const -> size_type;
+        [[nodiscard]] auto size() const noexcept -> size_type;
 
         /**
          * @brief Function returns maximum number of elements container can hold
@@ -1501,7 +1501,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::size() const -> size_type
+    auto List<T>::size() const noexcept -> size_type
     {
         return m_size;
     }

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1109,6 +1109,17 @@ namespace dsa
         auto unique() -> size_type;
 
         /**
+         * @brief Function removes consecutive duplicated elements
+         * @details Only the first occurrence of given element in each group is preserved
+         *
+         * @tparam BinaryPred
+         * @param[in] predicate binary predicate which returns \p true if the element should be treated as equal
+         * @return size_type number of elements removed
+         */
+        template<typename BinaryPred>
+        auto unique(BinaryPred predicate) -> size_type;
+
+        /**
          * @brief Append elements of another List to base container
          *
          * @tparam T type of data stored in List Node
@@ -2288,6 +2299,13 @@ namespace dsa
     template<typename T>
     auto List<T>::unique() -> size_type
     {
+        return unique(std::equal_to<>());
+    }
+
+    template<typename T>
+    template<typename BinaryPred>
+    auto List<T>::unique(BinaryPred predicate) -> size_type
+    {
         NodeBase* temp{ m_head };
         NodeBase* prev{};
         NodeBase* next{};
@@ -2306,7 +2324,7 @@ namespace dsa
                 Node* node_temp = dynamic_cast<Node*>(temp);
                 if (node_next && node_temp)
                 {
-                    if (node_next->value() == node_temp->value())
+                    if (predicate(node_next->value(), node_temp->value()))
                     {
                         NodeBase* to_remove = next;
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -892,6 +892,8 @@ namespace dsa
 
         /**
          * @brief Function removes last Node of List
+         *
+         * @note references and iterators to the erased element are invalidated
          */
         void pop_back();
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -747,7 +747,7 @@ namespace dsa
          *
          * @return size_type maximum number of elements
          */
-        [[nodiscard]] auto max_size() const -> size_type;
+        [[nodiscard]] auto max_size() const noexcept -> size_type;
 
         /**
          * @brief Function removes all elements of List
@@ -1507,7 +1507,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::max_size() const -> size_type
+    auto List<T>::max_size() const noexcept -> size_type
     {
         return std::numeric_limits<size_type>::max();
     }

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -212,6 +212,13 @@ namespace dsa
             using value_type = T;
 
             /**
+             * @brief Alias for size type used in class
+             *
+             * @tparam T size type
+             */
+            using size_type = std::size_t;
+
+            /**
              * @brief Alias for pointer to data type used by iterator
              *
              * @tparam T* pointer to data type
@@ -413,6 +420,13 @@ namespace dsa
          * @brief Alias for memory allocator
          */
         using allocator_type = std::allocator<value_type>;
+
+        /**
+         * @brief Alias for size type used in class
+         *
+         * @tparam T size type
+         */
+        using size_type = std::size_t;
 
         /**
          * @brief Alias for pointer to data type used in class

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -640,42 +640,42 @@ namespace dsa
          *
          * @return iterator iterator to List first Node
          */
-        auto begin() -> iterator;
+        auto begin() noexcept -> iterator;
 
         /**
          * @brief Function returns const pointer to List first Node
          *
          * @return const_iterator const iterator to List first Node
          */
-        auto begin() const -> const_iterator;
+        auto begin() const noexcept -> const_iterator;
 
         /**
          * @brief Function returns const pointer to List first Node
          *
          * @return const_iterator const iterator to List first Node
          */
-        [[nodiscard]] auto cbegin() const -> const_iterator;
+        [[nodiscard]] auto cbegin() const noexcept -> const_iterator;
 
         /**
          * @brief Function returns pointer to List last Node
          *
          * @return iterator iterator to List last Node
          */
-        auto end() -> iterator;
+        auto end() noexcept -> iterator;
 
         /**
          * @brief Function returns pointer to List last Node
          *
          * @return const_iterator const iterator to List last Node
          */
-        auto end() const -> const_iterator;
+        auto end() const noexcept -> const_iterator;
 
         /**
          * @brief Function returns pointer to List last Node
          *
          * @return const_iterator const iterator to List last Node
          */
-        [[nodiscard]] auto cend() const -> const_iterator;
+        [[nodiscard]] auto cend() const noexcept -> const_iterator;
 
         /**
          * @brief Function checks if container has no elements
@@ -1373,37 +1373,37 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::begin() -> typename List<T>::iterator
+    auto List<T>::begin() noexcept -> typename List<T>::iterator
     {
         return iterator(m_head);
     }
 
     template<typename T>
-    auto List<T>::begin() const -> typename List<T>::const_iterator
+    auto List<T>::begin() const noexcept -> typename List<T>::const_iterator
     {
         return const_iterator(m_head);
     }
 
     template<typename T>
-    auto List<T>::cbegin() const -> typename List<T>::const_iterator
+    auto List<T>::cbegin() const noexcept -> typename List<T>::const_iterator
     {
         return begin();
     }
 
     template<typename T>
-    auto List<T>::end() -> typename List<T>::iterator
+    auto List<T>::end() noexcept -> typename List<T>::iterator
     {
         return iterator(m_tail);
     }
 
     template<typename T>
-    auto List<T>::end() const -> typename List<T>::const_iterator
+    auto List<T>::end() const noexcept -> typename List<T>::const_iterator
     {
         return const_iterator(m_tail);
     }
 
     template<typename T>
-    auto List<T>::cend() const -> typename List<T>::const_iterator
+    auto List<T>::cend() const noexcept -> typename List<T>::const_iterator
     {
         return end();
     }

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1312,10 +1312,7 @@ namespace dsa
     List<T>::List(const List<T>& other)
         : List()
     {
-        for (size_type i = 0; i < other.size(); i++)
-        {
-            push_back(other.get(i)->value());
-        }
+        assign(other.begin(), other.end());
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -840,30 +840,7 @@ namespace dsa
         * @retval begin iterator if \p pos was first element prior to removal
         * @retval end iterator if \p pos was last element prior to removal
         */
-        auto erase(iterator pos) -> iterator;
-
-        /**
-        * @brief Function erases Node object at specified \p pos
-        *
-        * @param[in] pos iterator to element to erase
-        * @return iterator following erased element
-        * @retval iterator to element following \p pos
-        * @retval begin iterator if \p pos was first element prior to removal
-        * @retval end iterator if \p pos was last element prior to removal
-        */
         auto erase(const_iterator pos) -> iterator;
-
-        /**
-         * @brief Function erases Node objects in range [first, last)
-         *
-         * @param[in] first element to erase
-         * @param[in] last element after last erased element
-         * @return iterator following last erased element
-         * @retval iterator to \p last
-         * @retval end iterator if \p last was end element prior to removal
-         * @retval last iterator if \p first to p\ last is empty range
-         */
-        auto erase(iterator first, iterator last) -> iterator;
 
         /**
          * @brief Function erases Node objects in range [first, last)
@@ -1710,18 +1687,18 @@ namespace dsa
 
 
     template<typename T>
-    auto List<T>::erase(iterator pos) -> typename List<T>::iterator
+    auto List<T>::erase(const_iterator pos) -> typename List<T>::iterator
     {
         if (!if_valid_iterator(pos))
         {
             return nullptr;
         }
 
-        return erase_element(pos);
+        return erase_element(pos.m_current_node);
     }
 
     template<typename T>
-    auto List<T>::erase(iterator first, iterator last) -> typename List<T>::iterator
+    auto List<T>::erase(const_iterator first, const_iterator last) -> typename List<T>::iterator
     {
         if (!if_valid_iterator(first) || !if_valid_iterator(last))
         {
@@ -1731,10 +1708,10 @@ namespace dsa
         const size_type dist = distance(first, last);
         if (dist == 0)
         {
-            return last;
+            return last.m_current_node;
         }
 
-        iterator iter(first.m_current_node);
+        iterator iter{ first.m_current_node };
         for (size_type i = 0; i < dist; i++)
         {
             iter = erase_element(iter);

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1693,7 +1693,8 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::insert(const const_iterator& pos, size_type count, const_reference value) -> typename List<T>::iterator
+    auto List<T>::insert(const const_iterator& pos, size_type count, const_reference value)
+        -> typename List<T>::iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1703,7 +1704,7 @@ namespace dsa
         iterator iter{ pos.m_current_node };
         for (size_type i = 0; i < count; i++)
         {
-            iter = insert_element_before(iter, value);
+            iter = emplace(iter, value);
         }
 
         return iter;

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1134,17 +1134,6 @@ namespace dsa
     private:
 
         /**
-         * @brief Function sets value of specifed Node of List
-         *
-         * @param[in] index index of element to be modified
-         * @param[in] value to overwrite Node at index
-         * @return operation status
-         * @retval true if value of Node was overwritten
-         * @retval false if invalid index
-         */
-        auto set(size_type index, T value) -> bool;
-
-        /**
          * @brief Function add end node located just after last user created data
          * Node is used by iterators indicating end of container
          */
@@ -2258,19 +2247,6 @@ namespace dsa
     }
 
     // definitions of private methods
-
-    template<typename T>
-    auto List<T>::set(size_type index, T value) -> bool
-    {
-        Node* temp = get(index);
-        if (temp)
-        {
-            temp->m_value = value;
-            return true;
-        }
-
-        return false;
-    }
 
     template<typename T>
     void List<T>::init_node()

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -36,10 +36,6 @@ namespace dsa
      *
      * @tparam T type of data stored in List Node
      *
-     * @todo add rbegin
-     * @todo add crbegin
-     * @todo add rend
-     * @todo add crend
      * @todo add emplace
      * @todo add emplace_back
      * @todo add emplace_front
@@ -676,6 +672,60 @@ namespace dsa
          * @return const_iterator const iterator to List last Node
          */
         [[nodiscard]] auto cend() const noexcept -> const_iterator;
+
+        /**
+         * @brief Returns reverse_iterator to the first element of reversed underlaying data structure
+         *
+         * @note If container is empty, returned iterator will be equal to end()
+         *
+         * @return reverse_iterator to the first element
+         */
+        [[nodiscard]] auto rbegin() noexcept -> reverse_iterator;
+
+        /**
+         * @brief Returns const_reverse_iterator to the first element of reversed underlaying data structure
+         *
+         * @note If container is empty, returned iterator will be equal to end()
+         *
+         * @return const_reverse_iterator to the first element
+         */
+        [[nodiscard]] auto rbegin() const noexcept -> const_reverse_iterator;
+
+        /**
+         * @brief Returns const_reverse_iterator to the first element of reversed underlaying data structure
+         *
+         * @note If container is empty, returned iterator will be equal to end()
+         *
+         * @return const_reverse_iterator to the first element
+         */
+        [[nodiscard]] auto crbegin() const noexcept -> const_reverse_iterator;
+
+        /**
+         * @brief Returns reverse_iterator past the last element of reversed underlaying data structure
+         *
+         * @note Iterator act as a sentinel, it is not guaranteed to be dereferencable
+         *
+         * @return reverse_iterator to the element after the last element
+         */
+        [[nodiscard]] auto rend() noexcept -> reverse_iterator;
+
+        /**
+         * @brief Returns const_reverse_iterator past the last element of reversed underlaying data structure
+         *
+         * @note Iterator act as a sentinel, it is not guaranteed to be dereferencable
+         *
+         * @return const_reverse_iterator to the element after the last element
+         */
+        [[nodiscard]] auto rend() const noexcept -> const_reverse_iterator;
+
+        /**
+         * @brief Returns const_reverse_iterator past the last element of reversed underlaying data structure
+         *
+         * @note Iterator act as a sentinel, it is not guaranteed to be dereferencable
+         *
+         * @return const_reverse_iterator to the element after the last element
+         */
+        [[nodiscard]] auto crend() const noexcept -> const_reverse_iterator;
 
         /**
          * @brief Function checks if container has no elements
@@ -1406,6 +1456,42 @@ namespace dsa
     auto List<T>::cend() const noexcept -> typename List<T>::const_iterator
     {
         return end();
+    }
+
+    template<typename T>
+    auto List<T>::rbegin() noexcept -> reverse_iterator
+    {
+        return reverse_iterator(end());
+    }
+
+    template<typename T>
+    auto List<T>::rbegin() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(end());
+    }
+
+    template<typename T>
+    auto List<T>::crbegin() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(end());
+    }
+
+    template<typename T>
+    auto List<T>::rend() noexcept -> reverse_iterator
+    {
+        return reverse_iterator(begin());
+    }
+
+    template<typename T>
+    auto List<T>::rend() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(begin());
+    }
+
+    template<typename T>
+    auto List<T>::crend() const noexcept -> const_reverse_iterator
+    {
+        return const_reverse_iterator(begin());
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -909,6 +909,17 @@ namespace dsa
         void push_front(const_reference value);
 
         /**
+         * @brief Function adds new Node at the beginning of List using move semantics
+         *
+         * @param[in] value element of type T
+         *
+         * @note no iterators or references are invalidated,
+         *       if construction of new element fails or an exception is thrown for any reason
+         *       state of the object does not change and this function has no effect
+         */
+        void push_front(T&& value);
+
+        /**
          * @brief Insert new element at the beginning of the container
          *
          * @tparam ...Args
@@ -1747,6 +1758,28 @@ namespace dsa
         init_node();
 
         Node* newNode = construct_node(nullptr, nullptr, value);
+        if (!m_head->m_next)
+        {
+            newNode->m_next = m_head;
+            m_head = newNode;
+            m_tail->m_prev = m_head;
+        }
+        else
+        {
+            m_head->m_prev = newNode;
+            newNode->m_next = m_head;
+            m_head = newNode;
+        }
+
+        m_size++;
+    }
+
+    template<typename T>
+    void List<T>::push_front(T&& value)
+    {
+        init_node();
+
+        Node* newNode = construct_node(nullptr, nullptr, std::move(value));
         if (!m_head->m_next)
         {
             newNode->m_next = m_head;

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -130,6 +130,16 @@ namespace dsa
             {}
 
             /**
+             * @brief Construct a new Node object with initial value using move semantics
+             * @details \p value will be taken by constructed object
+             *
+             * @param[in] value to store in Node object
+             */
+            Node(T&& value)
+                : m_value{ std::move(value) }
+            {}
+
+            /**
              * @brief Function returns value stored in Node object
              *
              * @return T value stored in Node

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -508,9 +508,9 @@ namespace dsa
         /**
          * @brief Construct a new List object using initializer list
          *
-         * @param[in] init_list initializer list of values of type T
+         * @param[in] ilist initializer list of values of type T
          */
-        List(const std::initializer_list<T>& init_list);
+        List(const std::initializer_list<T>& ilist);
 
         /**
          * @brief Construct a new List object using copy constructor
@@ -543,6 +543,14 @@ namespace dsa
          * @return List&
          */
         auto operator=(List<T>&& other) noexcept -> List&;
+
+        /**
+         * @brief Assign initializer list elements to List object
+         *
+         * @param[in] ilist initializer list to copy elements from
+         * @return List&
+         */
+        auto operator=(std::initializer_list<value_type> ilist) -> List&;
 
         /**
          * @brief Destroy the List object
@@ -1182,12 +1190,9 @@ namespace dsa
     }
 
     template<typename T>
-    List<T>::List(const std::initializer_list<T>& init_list)
+    List<T>::List(const std::initializer_list<T>& ilist)
     {
-        for (const auto& item : init_list)
-        {
-            push_back(item);
-        }
+        operator=(ilist);
     }
 
     template<typename T>
@@ -1239,6 +1244,19 @@ namespace dsa
             other.m_head = temp;
             other.m_tail = other.m_head;
             other.m_size = 0;
+        }
+
+        return *this;
+    }
+
+    template<typename T>
+    auto List<T>::operator=(std::initializer_list<value_type> ilist) -> List&
+    {
+        clear();
+
+        for (const auto& item : ilist)
+        {
+            push_back(item);
         }
 
         return *this;

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -36,7 +36,6 @@ namespace dsa
      *
      * @tparam T type of data stored in List Node
      *
-     * @todo add get_allocator
      * @todo add rbegin
      * @todo add crbegin
      * @todo add rend
@@ -411,6 +410,11 @@ namespace dsa
         using value_type = T;
 
         /**
+         * @brief Alias for memory allocator
+         */
+        using allocator_type = std::allocator<value_type>;
+
+        /**
          * @brief Alias for pointer to data type used in class
          *
          * @tparam T* pointer to data type
@@ -528,6 +532,13 @@ namespace dsa
          * @param[in] init_list values to replace List with
          */
         void assign(const std::initializer_list<T>& init_list);
+
+        /**
+         * @brief Get the allocator object
+         *
+         * @return allocator_type type of memory allocator
+         */
+        [[nodiscard]] auto get_allocator() const noexcept -> allocator_type;
 
         /**
          * @brief Function returns reference to value stored in List first Node
@@ -1051,6 +1062,11 @@ namespace dsa
         NodeBase* m_head{};
         NodeBase* m_tail{};
         size_t m_size{};
+
+        /**
+         * @brief Allocator for memory management
+         */
+        allocator_type m_allocator{};
     };
 
     template<typename T>
@@ -1165,6 +1181,12 @@ namespace dsa
         {
             push_back(item);
         }
+    }
+
+    template<typename T>
+    [[nodiscard]] auto List<T>::get_allocator() const noexcept -> allocator_type
+    {
+        return m_allocator;
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -28,9 +28,6 @@ namespace dsa
     template<typename T>
     class List;
 
-    template<typename T>
-    auto operator+(const List<T>& list1, const List<T>& list2) -> List<T>;
-
     /**
      * @brief Implements List using Node with pointer to adjacent
      *        elements as internal base
@@ -1139,39 +1136,6 @@ namespace dsa
         template<typename Compare>
         void sort(Compare comp);
 
-        /**
-         * @brief Append elements of another List to base container
-         *
-         * @tparam T type of data stored in List Node
-         * @param[in] other List to read elements from
-         * @return List<T>&
-         */
-        auto operator+=(const List<T>& other) -> List<T>&
-        {
-            for (auto it = other.cbegin(); it != other.cend(); ++it)
-            {
-                push_back(*it);
-            }
-
-            return *this;
-        }
-
-        /**
-         * @brief push_back elements of another List to base container
-         *
-         * @param[in] init_list initializer_list to read elements from
-         * @return List<T>&
-         */
-        auto operator+=(const std::initializer_list<T> init_list) -> List<T>&
-        {
-            for (const auto& item : init_list)
-            {
-                push_back(item);
-            }
-
-            return *this;
-        }
-
     private:
 
         /**
@@ -1194,18 +1158,6 @@ namespace dsa
          * @retval false if invalid index
          */
         auto set(size_type index, T value) -> bool;
-
-        /**
-         * @brief Construct new object based on two List objects
-         *
-         * Forward friend declaration of List operator+
-         *
-         * @tparam T type of data stored in List Node
-         * @param[in] list1 input List
-         * @param[in] list2 input List
-         * @return List<T> List<T> with content of two input lists
-         */
-        friend auto operator+<>(const List<T>& list1, const List<T>& list2)->List<T>;
 
         /**
          * @brief Function add end node located just after last user created data
@@ -2575,28 +2527,6 @@ namespace dsa
         }
 
         return false;
-    }
-
-    /**
-     * @brief Construct new object based on two List objects
-     *
-     * @tparam T type of data stored in List Node
-     * @param[in] list1 input List
-     * @param[in] list2 input List
-     * @return List<T> List<T> with content of two input lists
-     */
-    template<typename T>
-    auto operator+(const List<T>& list1, const List<T>& list2) -> List<T>
-    {
-        List<T> temp(list1);
-
-        for (auto iter = list2.cbegin(); iter != list2.cend(); ++iter)
-        {
-            T value = *iter;
-            temp.push_back(value);
-        }
-
-        return temp;
     }
 
     /**

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1704,43 +1704,15 @@ namespace dsa
     {
         init_node();
 
-        Node* newNode = construct_node(nullptr, nullptr, value);
-        if (!m_head->m_next)
-        {
-            newNode->m_next = m_head;
-            m_head = newNode;
-            m_tail->m_prev = m_head;
-        }
-        else
-        {
-            m_head->m_prev = newNode;
-            newNode->m_next = m_head;
-            m_head = newNode;
-        }
-
-        m_size++;
+        emplace_front(value);
     }
 
     template<typename T>
     void List<T>::push_front(T&& value)
     {
         init_node();
+        emplace_front(std::move(value));
 
-        Node* newNode = construct_node(nullptr, nullptr, std::move(value));
-        if (!m_head->m_next)
-        {
-            newNode->m_next = m_head;
-            m_head = newNode;
-            m_tail->m_prev = m_head;
-        }
-        else
-        {
-            m_head->m_prev = newNode;
-            newNode->m_next = m_head;
-            m_head = newNode;
-        }
-
-        m_size++;
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1284,9 +1284,8 @@ namespace dsa
 
     template<typename T>
     List<T>::List(size_type count, const T& value)
+        : List()
     {
-        init_node();
-
         for (size_type i = 0; i < count; i++)
         {
             push_front(value);
@@ -1297,18 +1296,21 @@ namespace dsa
     template<typename InputIt>
         requires std::input_iterator<InputIt>
     List<T>::List(InputIt first, InputIt last)
+        : List()
     {
         assign(first, last);
     }
 
     template<typename T>
     List<T>::List(const std::initializer_list<T>& ilist)
+        : List()
     {
         operator=(ilist);
     }
 
     template<typename T>
     List<T>::List(const List<T>& other)
+        : List()
     {
         for (size_type i = 0; i < other.size(); i++)
         {
@@ -1337,6 +1339,7 @@ namespace dsa
 
     template<typename T>
     List<T>::List(List<T>&& other) noexcept
+        : List()
     {
         operator=(std::move(other));
     }
@@ -1696,17 +1699,13 @@ namespace dsa
     template<typename T>
     void List<T>::push_front(const_reference value)
     {
-        init_node();
-
         emplace_front(value);
     }
 
     template<typename T>
     void List<T>::push_front(T&& value)
     {
-        init_node();
         emplace_front(std::move(value));
-
     }
 
     template<typename T>
@@ -1743,8 +1742,6 @@ namespace dsa
     template<typename T>
     void List<T>::push_back(const_reference value)
     {
-        init_node();
-
         emplace_back(value);
     }
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -983,6 +983,36 @@ namespace dsa
         void merge(List<T>&& other);
 
         /**
+         * @brief Function combines two sorted Lists into one sorted List
+         *
+         * @param[in,out] other container to take elements from
+         * @param[in] comp comparison function object
+         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
+         */
+        template<typename Compare>
+        void merge(List<T>& other, Compare comp);
+
+        /**
+         * @brief Function combines two sorted Lists into one sorted List
+         *
+         * @param[in,out] other container to take elements from
+         * @param[in] comp comparison function object
+         * @details Content of other object will be taken by constructed object
+         *
+         * @note no iterators or references become invalidated,
+         *       iterators or references of objects moved from \p other will
+         *       refer to the same elements of \p this
+         */
+        template<typename Compare>
+        // transfers ownership of nodes, moving entire container is not necessary
+        // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+        void merge(List<T>&& other, Compare comp);
+
+        /**
          * @brief Function moves elements from other List object
          *
          * @param[in] pos const_iterator before which content of other container will be inserted
@@ -1959,84 +1989,100 @@ namespace dsa
     }
 
     template<typename T>
-    // transfers ownership of nodes, moving entire container is not necessary
-    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
     void List<T>::merge(List<T>&& other)
     {
-        if (&other != this)
+        merge(std::move(other), std::less<>());
+    }
+
+    template<typename T>
+    template<typename Compare>
+    void List<T>::merge(List<T>& other, Compare comp)
+    {
+        merge(std::move(other), comp);
+    }
+
+    template<typename T>
+    template<typename Compare>
+    // transfers ownership of nodes, moving entire container is not necessary
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+    void List<T>::merge(List<T>&& other, Compare comp)
+    {
+        if (&other == this)
         {
-            if (m_size != 0)
+            return;
+        }
+
+        if (m_size != 0)
+        {
+            Node* temp_head = construct_node(nullptr, nullptr, 0);
+            NodeBase* temp_tail = temp_head;
+
+            NodeBase* to_move{};
+            NodeBase* to_return{};
+
+            NodeBase* sentinel_this{ m_tail->m_prev->m_next };
+            NodeBase* sentinel_other{ other.m_tail->m_prev->m_next };
+
+            while (m_head->m_next && other.m_head->m_next)
             {
-                Node* temp_head = construct_node(nullptr, nullptr, 0);
-                NodeBase* temp_tail = temp_head;
+                Node* node_this = dynamic_cast<Node*>(m_head);
+                Node* node_other = dynamic_cast<Node*>(other.m_head);
 
-                NodeBase* to_move{};
-                NodeBase* to_return{};
-
-                NodeBase* sentinel_this{ m_tail->m_prev->m_next };
-                NodeBase* sentinel_other{ other.m_tail->m_prev->m_next };
-
-                while (m_head->m_next && other.m_head->m_next)
+                if (node_this && node_other)
                 {
-                    Node* node_this = dynamic_cast<Node*>(m_head);
-                    Node* node_other = dynamic_cast<Node*>(other.m_head);
-
-                    if (node_this && node_other)
+                    if (comp(node_this->value(), node_other->value()))
                     {
-                        if (node_this->value() <= node_other->value())
-                        {
-                            to_move = m_head;
-                            to_move->m_prev = temp_tail;
+                        to_move = m_head;
+                        to_move->m_prev = temp_tail;
 
-                            to_return = to_move->m_next;
-                            temp_tail->m_next = to_move;
-                            m_head = to_return;
-                        }
-                        else
-                        {
-                            to_move = other.m_head;
-                            to_move->m_prev = temp_tail;
-
-                            to_return = to_move->m_next;
-                            temp_tail->m_next = to_move;
-                            other.m_head = to_return;
-                        }
-
-                        temp_tail = temp_tail->m_next;
+                        to_return = to_move->m_next;
+                        temp_tail->m_next = to_move;
+                        m_head = to_return;
                     }
+                    else
+                    {
+                        to_move = other.m_head;
+                        to_move->m_prev = temp_tail;
+
+                        to_return = to_move->m_next;
+                        temp_tail->m_next = to_move;
+                        other.m_head = to_return;
+                    }
+
+                    temp_tail = temp_tail->m_next;
                 }
-
-                NodeBase* last{};
-                if (m_head->m_next == nullptr) // other.m_head attached at the end
-                {
-                    last = sentinel_other->m_prev;
-                    other.m_head->m_prev = temp_tail;
-                    temp_tail->m_next = other.m_head;
-                }
-                else // this.m_head attached at the end
-                {
-                    last = sentinel_this->m_prev;
-                    m_head->m_prev = temp_tail;
-                    temp_tail->m_next = m_head;
-                }
-                last->m_next = sentinel_this;
-                last->m_next->m_prev = last;
-
-                m_head = temp_head->m_next;
-                m_head->m_prev = nullptr;
-                destroy_node(temp_head);
-
-                other.m_head = other.m_tail;
-                other.m_head->m_next = nullptr;
-                other.m_head->m_prev = nullptr;
-
-                m_size += other.m_size;
-                other.m_size = 0;
             }
-            else
+
+            NodeBase* last{};
+            if (m_head->m_next == nullptr) // other.m_head attached at the end
             {
-                swap(other);
+                last = sentinel_other->m_prev;
+                other.m_head->m_prev = temp_tail;
+                temp_tail->m_next = other.m_head;
             }
+            else // this.m_head attached at the end
+            {
+                last = sentinel_this->m_prev;
+                m_head->m_prev = temp_tail;
+                temp_tail->m_next = m_head;
+            }
+            last->m_next = sentinel_this;
+            last->m_next->m_prev = last;
+
+            m_head = temp_head->m_next;
+            m_head->m_prev = nullptr;
+            destroy_node(temp_head);
+
+            other.m_head = other.m_tail;
+            other.m_head->m_next = nullptr;
+            other.m_head->m_prev = nullptr;
+
+            m_size += other.m_size;
+            other.m_size = 0;
+        }
+        else
+        {
+            swap(other);
         }
     }
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1631,33 +1631,27 @@ namespace dsa
     template<typename... Args>
     auto List<T>::emplace(const_iterator pos, Args&&... args) -> iterator
     {
-        Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
-        try
+        const iterator current{ pos.m_current_node };
+
+        Node* newNode{ construct_node(current.m_current_node->m_prev, current.m_current_node->m_next,
+            std::forward<Args>(args)...) };
+
+        if (pos == cbegin())
         {
-            node_alloc_traits::construct(node_alloc, newNode, std::forward<Args>(args)...);
-
-            if (pos == cbegin())
-            {
-                newNode->m_next = m_head;
-                !m_head->m_next ? m_tail->m_prev = newNode : m_head->m_prev = newNode;
-                m_head = newNode;
-            }
-            else
-            {
-                NodeBase* prev_pos{ pos.m_current_node->m_prev };
-                NodeBase* next_pos{ prev_pos->m_next };
-
-                prev_pos->m_next = newNode;
-                newNode->m_prev = prev_pos;
-
-                newNode->m_next = next_pos;
-                next_pos->m_prev = newNode;
-            }
+            newNode->m_next = m_head;
+            !m_head->m_next ? m_tail->m_prev = newNode : m_head->m_prev = newNode;
+            m_head = newNode;
         }
-        catch (...)
+        else
         {
-            node_alloc_traits::deallocate(node_alloc, newNode, 1);
-            throw;
+            NodeBase* prev_pos{ pos.m_current_node->m_prev };
+            NodeBase* next_pos{ prev_pos->m_next };
+
+            prev_pos->m_next = newNode;
+            newNode->m_prev = prev_pos;
+
+            newNode->m_next = next_pos;
+            next_pos->m_prev = newNode;
         }
 
         ++m_size;

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -810,11 +810,11 @@ namespace dsa
          * @brief Function inserts content of initializer list before specified \p pos
          *
          * @param[in] pos const_iterator to insert element before
-         * @param[in] init_list initializer_list with elements to insert before \p pos
+         * @param[in] ilist initializer list with elements to insert before \p pos
          * @retval iterator to first inserted element
          * @retval pos if no element was inserted
          */
-        auto insert(const const_iterator& pos, std::initializer_list<T> init_list) -> iterator;
+        auto insert(const const_iterator& pos, std::initializer_list<T> ilist) -> iterator;
 
         /**
          * @brief Insert new element into the container before \p pos
@@ -1666,21 +1666,9 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::insert(const const_iterator& pos, std::initializer_list<T> init_list) -> typename List<T>::iterator
+    auto List<T>::insert(const const_iterator& pos, std::initializer_list<T> ilist) -> typename List<T>::iterator
     {
-        if (!if_valid_iterator(pos))
-        {
-            return nullptr;
-        }
-
-        iterator iter(pos.m_current_node);
-        for (const auto& val : init_list)
-        {
-            iter = insert_element_before(iter, val);
-            ++iter;
-        }
-
-        return iter;
+        return insert(pos, ilist.begin(), ilist.end());
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -2083,14 +2083,9 @@ namespace dsa
     template<typename T>
     auto operator<<(std::ostream& out, const List<T>& list) -> std::ostream&
     {
-        if (list.empty())
-        {
-            return out;
-        }
-
         for (auto iter = list.cbegin(); iter != list.cend(); ++iter)
         {
-            T value = *iter;
+            const T& value = *iter;
             out << value << ' ';
         }
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -36,7 +36,6 @@ namespace dsa
      *
      * @tparam T type of data stored in List Node
      *
-     * @todo add remove_if
      * @todo add sort
      * @todo add operator<=>
      * @todo add non-member specialized swap function
@@ -1076,8 +1075,23 @@ namespace dsa
          * @brief Function removes all elements equal to \p value
          *
          * @param[in] value value of elements to remove
+         * @return size_type number of elements removed
+         *
+         * @note invalidates only the iterators and references to the removed elements
          */
-        void remove(const_reference value);
+        auto remove(const_reference value) -> size_type;
+
+        /**
+         * @brief Function removes all elements for which \p predicate returns \p true
+         *
+         * @tparam UnaryPred
+         * @param[in] predicate to remove elements
+         * @return size_type number of elements removed
+         *
+         * @note invalidates only the iterators and references to the removed elements
+         */
+        template<typename UnaryPred>
+        auto remove_if(UnaryPred predicate) -> size_type;
 
         /**
          * @brief Function reverts in place Nodes of List
@@ -2192,10 +2206,19 @@ namespace dsa
     }
 
     template<typename T>
-    void List<T>::remove(const_reference value)
+    auto List<T>::remove(const_reference value) -> size_type
+    {
+        return remove_if([value](T node_val) { return node_val == value; });
+    }
+
+    template<typename T>
+    template<typename UnaryPred>
+    auto List<T>::remove_if(UnaryPred predicate) -> size_type
     {
         NodeBase* temp{ m_head };
         NodeBase* next{};
+
+        size_type removed_count{};
 
         while (temp->m_next)
         {
@@ -2203,10 +2226,11 @@ namespace dsa
 
             if (Node* node = dynamic_cast<Node*>(m_head))
             {
-                if (node->value() == value)
+                if (predicate(node->value()))
                 {
                     pop_front();
                     temp = m_head;
+                    removed_count++;
                     continue;
                 }
             }
@@ -2214,15 +2238,18 @@ namespace dsa
             if (next && next != m_tail && next->m_next != nullptr)
             {
                 Node* node = dynamic_cast<Node*>(next);
-                if (node->value() == value)
+                if (predicate(node->value()))
                 {
                     erase(ListIterator<false>(node));
+                    removed_count++;
                     continue;
                 }
             }
 
             temp = temp->m_next;
         }
+
+        return removed_count;
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -562,13 +562,30 @@ namespace dsa
          *
          * @param[in] count new size of the container
          * @param[in] value value to initialize elements of the container with
+         *
+         * @note all iterators, pointers and references to the elements of the container are invalidated
          */
         void assign(size_type count, const_reference value);
+
+        /**
+         * @brief Function assign elements from range [ \p first , \p last ) to List object
+         *
+         * @tparam InputIt
+         * @param[in] first element defining range of elements to insert
+         * @param[in] last element definig range of elements to insert
+         *
+         * @note all iterators, pointers and references to the elements of the container are invalidated
+         */
+        template<typename InputIt>
+            requires std::input_iterator<InputIt>
+        void assign(InputIt first, InputIt last);
 
         /**
          * @brief Function assign values to the List
          *
          * @param[in] init_list values to replace List with
+         *
+         * @note all iterators, pointers and references to the elements of the container are invalidated
          */
         void assign(const std::initializer_list<T>& init_list);
 
@@ -1278,6 +1295,20 @@ namespace dsa
         for (size_type i = 0; i < count; i++)
         {
             push_back(value);
+        }
+    }
+
+    template<typename T>
+    template<typename InputIt>
+        requires std::input_iterator<InputIt>
+    void List<T>::assign(InputIt first, InputIt last)
+    {
+        clear();
+
+        while (first != last)
+        {
+            push_back(*first);
+            ++first;
         }
     }
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -542,10 +542,10 @@ namespace dsa
          * @param[in,out] other List object of type T
          * @return List&
          */
-        auto operator=(List<T>&& other) noexcept -> List&;
+        auto operator=(List<T>&& other) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value)->List&;
 
         /**
-         * @brief Assign initializer list elements to List object
+         * @brief Assign elements from initializer list to List object
          *
          * @param[in] ilist initializer list to copy elements from
          * @return List&
@@ -1230,7 +1230,8 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::operator=(List<T>&& other) noexcept -> List<T>&
+    auto List<T>::operator=(List<T>&& other) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value)
+        ->List&
     {
         if (&other != this)
         {

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -614,7 +614,7 @@ namespace dsa
          *
          * @return reference to data stored in List first Node
          */
-        auto front() -> reference;
+        [[nodiscard]] auto front() -> reference;
 
         /**
          * @brief Function returns const reference value stored in List first Node
@@ -628,7 +628,7 @@ namespace dsa
          *
          * @return reference to data stored in List last Node
          */
-        auto back() -> reference;
+        [[nodiscard]] auto back() -> reference;
 
         /**
          * @brief Function returns const reference value stored in List last Node
@@ -642,14 +642,14 @@ namespace dsa
          *
          * @return iterator iterator to List first Node
          */
-        auto begin() noexcept -> iterator;
+        [[nodiscard]] auto begin() noexcept -> iterator;
 
         /**
          * @brief Function returns const pointer to List first Node
          *
          * @return const_iterator const iterator to List first Node
          */
-        auto begin() const noexcept -> const_iterator;
+        [[nodiscard]] auto begin() const noexcept -> const_iterator;
 
         /**
          * @brief Function returns const pointer to List first Node
@@ -663,14 +663,14 @@ namespace dsa
          *
          * @return iterator iterator to List last Node
          */
-        auto end() noexcept -> iterator;
+        [[nodiscard]] auto end() noexcept -> iterator;
 
         /**
          * @brief Function returns pointer to List last Node
          *
          * @return const_iterator const iterator to List last Node
          */
-        auto end() const noexcept -> const_iterator;
+        [[nodiscard]] auto end() const noexcept -> const_iterator;
 
         /**
          * @brief Function returns pointer to List last Node

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1512,20 +1512,17 @@ namespace dsa
     template<typename T>
     void List<T>::clear() noexcept
     {
-        if (m_head && m_head->m_next)
+        NodeBase* temp{ m_head };
+        while (temp->m_next)
         {
-            NodeBase* temp{ m_head };
-            while (temp->m_next)
-            {
-                m_head->m_prev = nullptr;
-                m_head = temp->m_next;
-                destroy_node(temp);
-                temp = m_head;
-            }
-
-            m_size = 0;
-            m_tail->m_prev = nullptr;
+            m_head->m_prev = nullptr;
+            m_head = temp->m_next;
+            destroy_node(temp);
+            temp = m_head;
         }
+
+        m_size = 0;
+        m_tail->m_prev = nullptr;
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1817,13 +1817,9 @@ namespace dsa
 
         if (m_size != 0)
         {
+            // if temporary node could not be allocated do not modify
+            // object state
             Node* temp_head{ construct_node(nullptr, nullptr, T{}) };
-            if (!temp_head)
-            {
-                // if temporary node could not be allocated
-                // do not modify object state
-                return;
-            }
 
             NodeBase* temp_tail = temp_head;
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1187,15 +1187,7 @@ namespace dsa
          * @brief Function add end node located just after last user created data
          * Node is used by iterators indicating end of container
          */
-        void init_node()
-        {
-            if (m_head == nullptr)
-            {
-                // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-                m_head = new NodeBase;
-                m_tail = m_head;
-            }
-        }
+        void init_node();
 
         /**
          * @brief Function remove next element
@@ -1203,31 +1195,7 @@ namespace dsa
          * @param[in] iterator to element to which will be erased
          * @return iterator to element following \p pos
          */
-        auto erase_element(iterator pos) -> iterator
-        {
-
-            if (pos == begin())
-            {
-                pop_front();
-                return iterator(begin());
-            }
-
-            if (pos == (--end()))
-            {
-                pop_back();
-                return iterator(end());
-            }
-
-            NodeBase* temp{ pos.m_current_node->m_prev };
-            NodeBase* to_remove{ temp->m_next };
-
-            temp->m_next = to_remove->m_next;
-            temp->m_next->m_prev = temp;
-            destroy_node(to_remove);
-
-            m_size--;
-            return iterator(temp->m_next);
-        }
+        auto erase_element(iterator pos) -> iterator;
 
         /**
          * @brief Function allocate and construct List node
@@ -1239,40 +1207,14 @@ namespace dsa
          * @return pointer to created Node
          */
         template<typename... Args>
-        // NOLINTNEXTLINE(bugprone-easily-swappable-parameters,-warnings-as-errors)
-        auto construct_node(NodeBase* prev_ptr, NodeBase* next_ptr, Args&&... args) -> Node*
-        {
-            Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
-            try
-            {
-                node_alloc_traits::construct(node_alloc, newNode, std::forward<Args>(args)...);
-            }
-            catch (...)
-            {
-                node_alloc_traits::deallocate(node_alloc, newNode, 1);
-                throw;
-            }
-
-            newNode->m_prev = prev_ptr;
-            newNode->m_next = next_ptr;
-
-            return newNode;
-        }
+        auto construct_node(NodeBase* prev_ptr, NodeBase* next_ptr, Args&&... args) -> Node*;
 
         /**
          * @brief Function destroys and deallocates memory used by Node
          *
          * @param[in] node_to_destroy pointer to Node to delete
          */
-        void destroy_node(NodeBase* node_to_destroy)
-        {
-            Node* node_dyn = dynamic_cast<Node*>(node_to_destroy);
-            if (node_dyn)
-            {
-                node_alloc_traits::destroy(node_alloc, node_dyn);
-                node_alloc_traits::deallocate(node_alloc, node_dyn, 1);
-            }
-        }
+        void destroy_node(NodeBase* node_to_destroy);
 
         /**
          * @brief Function checks List contains iterator
@@ -1282,25 +1224,7 @@ namespace dsa
          * @return true if \p pos belong to List
          * @return false if otherwise
          */
-        auto if_valid_iterator(const_iterator pos) -> bool
-        {
-            bool valid_iterator{};
-
-            if (pos == cbegin() || pos == cend())
-            {
-                return true;
-            }
-
-            for (auto it = cbegin(); it != cend(); ++it)
-            {
-                if (it == pos)
-                {
-                    valid_iterator = true;
-                    break;
-                }
-            }
-            return valid_iterator;
-        }
+        auto if_valid_iterator(const_iterator pos) -> bool;
 
         /**
          * @brief Function calculate number of elements from first to last
@@ -2105,74 +2029,6 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::distance(const_iterator first, const const_iterator& last) -> size_type
-    {
-        size_type dist{};
-        while (first != last)
-        {
-            ++first;
-            ++dist;
-        }
-
-        return dist;
-    }
-
-    template<typename T>
-    // transfers ownership of nodes, moving entire container is not necessary
-    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
-    void List<T>::transfer(const_iterator pos, List<T>&& other, const_iterator first, const const_iterator& last)
-    {
-        if (&other != this && other.m_size > 0)
-        {
-            const size_type dist = distance(first, last);
-            if (dist == 0)
-            {
-                return;
-            }
-
-            NodeBase* temp_prev{ pos.m_current_node->m_prev }; // to append to
-            NodeBase* last_to_move{ last.m_current_node->m_prev };
-
-            // select fragment from other
-
-            NodeBase* fragment{};
-            NodeBase* fragment_end{ last_to_move->m_next };
-            if (first == other.begin())
-            {
-                fragment = other.m_head;
-                other.m_head = fragment_end;
-                other.m_head->m_prev = nullptr;
-            }
-            else
-            {
-                fragment = first.m_current_node->m_prev->m_next;
-                fragment->m_prev->m_next = fragment_end;
-                fragment->m_prev->m_next->m_prev = first.m_current_node->m_prev;
-                fragment->m_prev = nullptr;
-            }
-
-            // insert fragment into this
-
-            if (pos == begin())
-            {
-                last_to_move->m_next = m_head;
-                last_to_move->m_next->m_prev = last_to_move;
-                m_head = fragment;
-            }
-            else
-            {
-                last_to_move->m_next = temp_prev->m_next;
-                last_to_move->m_next->m_prev = last_to_move;
-                temp_prev->m_next = fragment;
-                temp_prev->m_next->m_prev = temp_prev;
-            }
-
-            m_size += dist;
-            other.m_size -= dist;
-        }
-    }
-
-    template<typename T>
     void List<T>::splice(const const_iterator& pos, List<T>& other)
     {
         transfer(pos, std::move(other), other.begin(), other.end());
@@ -2344,83 +2200,6 @@ namespace dsa
     }
 
     template<typename T>
-    template<typename Compare>
-    // Intentional recursive call for sorting nodes in top-down algorithm implementation
-    // NOLINTNEXTLINE(misc-no-recursion)
-    auto List<T>::merge_sort(NodeBase* source, Compare comp) -> NodeBase*
-    {
-        // Stop condition, one element list is already sorted
-        if (source == nullptr || source->m_next == nullptr)
-        {
-            return source;
-        }
-
-        // Divide list into equal-sized sublists consisting of first and second half of the list
-        NodeBase* left{ source };
-        NodeBase* right{};
-
-        // Use slow and fast pointer to find half of list
-        NodeBase* slow{ source };
-        NodeBase* fast{ source->m_next };
-        while (fast && fast->m_next)
-        {
-            slow = slow->m_next;
-            fast = fast->m_next->m_next;
-        }
-
-        // Split input list into two halfs
-        right = slow->m_next;
-        right->m_prev = nullptr;
-        slow->m_next = nullptr;
-
-        // Recursively sort both sub-lists
-        left = merge_sort(left, comp);
-        right = merge_sort(right, comp);
-
-        // Merge sorted sublists
-        NodeBase* result{ merge(left, right, comp) };
-        return result;
-    }
-
-    template<typename T>
-    template<typename Compare>
-    // Intentional recursive call for merging nodes in top-down merge_sort algorithm implementation
-    // NOLINTNEXTLINE(misc-no-recursion)
-    auto List<T>::merge(NodeBase* left, NodeBase* right, Compare comp) -> NodeBase*
-    {
-        // Stop condition, empty element list is already sorted
-        if (left == nullptr)
-        {
-            return right;
-        }
-        if (right == nullptr)
-        {
-            return left;
-        }
-
-        NodeBase* result{};
-        Node* node_left = dynamic_cast<Node*>(left);
-        Node* node_right = dynamic_cast<Node*>(right);
-        if (node_left && node_right)
-        {
-            // Recursively merge nodes
-            if (comp(node_left->m_value, node_right->m_value))
-            {
-                result = left;
-                result->m_next = merge(left->m_next, right, comp);
-            }
-            else
-            {
-                result = right;
-                result->m_next = merge(left, right->m_next, comp);
-            }
-            result->m_next->m_prev = result;
-        }
-
-        return result;
-    }
-
-    template<typename T>
     void List<T>::sort()
     {
         sort(std::less<>());
@@ -2448,76 +2227,6 @@ namespace dsa
         }
         last->m_next = m_tail;
         m_tail->m_prev = last;
-    }
-
-    template<typename T>
-    auto List<T>::get(size_type index) const -> typename List<T>::Node*
-    {
-        if (index >= m_size)
-        {
-            return nullptr;
-        }
-
-        NodeBase* temp{};
-
-        // select list end to look for selected index
-        enum Mode : std::uint8_t { FRONT, BACK, AUTO };
-        constexpr Mode mode = Mode::AUTO;
-
-
-        if constexpr (mode == FRONT)
-        {
-            // count nodes from front
-            temp = m_head;
-            for (size_type i = 0; i < index; i++)
-            {
-                temp = temp->m_next;
-            }
-        }
-        else if constexpr (mode == BACK)
-        {
-            // count nodes from back
-            temp = m_tail->m_prev;
-            for (size_type i = m_size - 1; i > index; i--)
-            {
-                temp = temp->m_prev;
-            }
-        }
-        else // mode == AUTO
-        {
-            // optimize counting nodes from front or back
-            if (index < m_size / 2)
-            {
-                temp = m_head;
-                for (size_type i = 0; i < index; i++)
-                {
-                    temp = temp->m_next;
-                }
-            }
-            else
-            {
-                temp = m_tail->m_prev;
-                for (size_type i = m_size - 1; i > index; i--)
-                {
-                    temp = temp->m_prev;
-                }
-            }
-        }
-
-        return dynamic_cast<Node*>(temp);
-    }
-
-    template<typename T>
-    auto List<T>::set(size_type index, T value) -> bool
-    {
-        Node* temp = get(index);
-        if (temp)
-        {
-            temp->m_value = value;
-            return true;
-        }
-
-        return false;
     }
 
     /**
@@ -2658,6 +2367,315 @@ namespace dsa
     auto erase_if(List<T>& container, Pred pred) -> List<T>::size_type
     {
         return container.remove_if(pred);
+    }
+
+    // definitions of private methods
+
+    template<typename T>
+    auto List<T>::get(size_type index) const -> typename List<T>::Node*
+    {
+        if (index >= m_size)
+        {
+            return nullptr;
+        }
+
+        NodeBase* temp{};
+
+        // select list end to look for selected index
+        enum Mode : std::uint8_t { FRONT, BACK, AUTO };
+        constexpr Mode mode = Mode::AUTO;
+
+
+        if constexpr (mode == FRONT)
+        {
+            // count nodes from front
+            temp = m_head;
+            for (size_type i = 0; i < index; i++)
+            {
+                temp = temp->m_next;
+            }
+        }
+        else if constexpr (mode == BACK)
+        {
+            // count nodes from back
+            temp = m_tail->m_prev;
+            for (size_type i = m_size - 1; i > index; i--)
+            {
+                temp = temp->m_prev;
+            }
+        }
+        else // mode == AUTO
+        {
+            // optimize counting nodes from front or back
+            if (index < m_size / 2)
+            {
+                temp = m_head;
+                for (size_type i = 0; i < index; i++)
+                {
+                    temp = temp->m_next;
+                }
+            }
+            else
+            {
+                temp = m_tail->m_prev;
+                for (size_type i = m_size - 1; i > index; i--)
+                {
+                    temp = temp->m_prev;
+                }
+            }
+        }
+
+        return dynamic_cast<Node*>(temp);
+    }
+
+    template<typename T>
+    auto List<T>::set(size_type index, T value) -> bool
+    {
+        Node* temp = get(index);
+        if (temp)
+        {
+            temp->m_value = value;
+            return true;
+        }
+
+        return false;
+    }
+
+    template<typename T>
+    void List<T>::init_node()
+    {
+        if (m_head == nullptr)
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+            m_head = new NodeBase;
+            m_tail = m_head;
+        }
+    }
+
+    template<typename T>
+    auto List<T>::erase_element(iterator pos) -> iterator
+    {
+
+        if (pos == begin())
+        {
+            pop_front();
+            return iterator(begin());
+        }
+
+        if (pos == (--end()))
+        {
+            pop_back();
+            return iterator(end());
+        }
+
+        NodeBase* temp{ pos.m_current_node->m_prev };
+        NodeBase* to_remove{ temp->m_next };
+
+        temp->m_next = to_remove->m_next;
+        temp->m_next->m_prev = temp;
+        destroy_node(to_remove);
+
+        m_size--;
+        return iterator(temp->m_next);
+    }
+
+    template<typename T>
+    template<typename... Args>
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters,-warnings-as-errors)
+    auto List<T>::construct_node(NodeBase* prev_ptr, NodeBase* next_ptr, Args&&... args) -> Node*
+    {
+        Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
+        try
+        {
+            node_alloc_traits::construct(node_alloc, newNode, std::forward<Args>(args)...);
+        }
+        catch (...)
+        {
+            node_alloc_traits::deallocate(node_alloc, newNode, 1);
+            throw;
+        }
+
+        newNode->m_prev = prev_ptr;
+        newNode->m_next = next_ptr;
+
+        return newNode;
+    }
+
+    template<typename T>
+    void List<T>::destroy_node(NodeBase* node_to_destroy)
+    {
+        Node* node_dyn = dynamic_cast<Node*>(node_to_destroy);
+        if (node_dyn)
+        {
+            node_alloc_traits::destroy(node_alloc, node_dyn);
+            node_alloc_traits::deallocate(node_alloc, node_dyn, 1);
+        }
+    }
+
+    template<typename T>
+    auto List<T>::if_valid_iterator(const_iterator pos) -> bool
+    {
+        bool valid_iterator{};
+
+        if (pos == cbegin() || pos == cend())
+        {
+            return true;
+        }
+
+        for (auto it = cbegin(); it != cend(); ++it)
+        {
+            if (it == pos)
+            {
+                valid_iterator = true;
+                break;
+            }
+        }
+        return valid_iterator;
+    }
+
+    template<typename T>
+    auto List<T>::distance(const_iterator first, const const_iterator& last) -> size_type
+    {
+        size_type dist{};
+        while (first != last)
+        {
+            ++first;
+            ++dist;
+        }
+
+        return dist;
+    }
+
+    template<typename T>
+    // transfers ownership of nodes, moving entire container is not necessary
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+    void List<T>::transfer(const_iterator pos, List<T>&& other, const_iterator first, const const_iterator& last)
+    {
+        if (&other != this && other.m_size > 0)
+        {
+            const size_type dist = distance(first, last);
+            if (dist == 0)
+            {
+                return;
+            }
+
+            NodeBase* temp_prev{ pos.m_current_node->m_prev }; // to append to
+            NodeBase* last_to_move{ last.m_current_node->m_prev };
+
+            // select fragment from other
+
+            NodeBase* fragment{};
+            NodeBase* fragment_end{ last_to_move->m_next };
+            if (first == other.begin())
+            {
+                fragment = other.m_head;
+                other.m_head = fragment_end;
+                other.m_head->m_prev = nullptr;
+            }
+            else
+            {
+                fragment = first.m_current_node->m_prev->m_next;
+                fragment->m_prev->m_next = fragment_end;
+                fragment->m_prev->m_next->m_prev = first.m_current_node->m_prev;
+                fragment->m_prev = nullptr;
+            }
+
+            // insert fragment into this
+
+            if (pos == begin())
+            {
+                last_to_move->m_next = m_head;
+                last_to_move->m_next->m_prev = last_to_move;
+                m_head = fragment;
+            }
+            else
+            {
+                last_to_move->m_next = temp_prev->m_next;
+                last_to_move->m_next->m_prev = last_to_move;
+                temp_prev->m_next = fragment;
+                temp_prev->m_next->m_prev = temp_prev;
+            }
+
+            m_size += dist;
+            other.m_size -= dist;
+        }
+    }
+
+    template<typename T>
+    template<typename Compare>
+    // Intentional recursive call for sorting nodes in top-down algorithm implementation
+    // NOLINTNEXTLINE(misc-no-recursion)
+    auto List<T>::merge_sort(NodeBase* source, Compare comp) -> NodeBase*
+    {
+        // Stop condition, one element list is already sorted
+        if (source == nullptr || source->m_next == nullptr)
+        {
+            return source;
+        }
+
+        // Divide list into equal-sized sublists consisting of first and second half of the list
+        NodeBase* left{ source };
+        NodeBase* right{};
+
+        // Use slow and fast pointer to find half of list
+        NodeBase* slow{ source };
+        NodeBase* fast{ source->m_next };
+        while (fast && fast->m_next)
+        {
+            slow = slow->m_next;
+            fast = fast->m_next->m_next;
+        }
+
+        // Split input list into two halfs
+        right = slow->m_next;
+        right->m_prev = nullptr;
+        slow->m_next = nullptr;
+
+        // Recursively sort both sub-lists
+        left = merge_sort(left, comp);
+        right = merge_sort(right, comp);
+
+        // Merge sorted sublists
+        NodeBase* result{ merge(left, right, comp) };
+        return result;
+    }
+
+    template<typename T>
+    template<typename Compare>
+    // Intentional recursive call for merging nodes in top-down merge_sort algorithm implementation
+    // NOLINTNEXTLINE(misc-no-recursion)
+    auto List<T>::merge(NodeBase* left, NodeBase* right, Compare comp) -> NodeBase*
+    {
+        // Stop condition, empty element list is already sorted
+        if (left == nullptr)
+        {
+            return right;
+        }
+        if (right == nullptr)
+        {
+            return left;
+        }
+
+        NodeBase* result{};
+        Node* node_left = dynamic_cast<Node*>(left);
+        Node* node_right = dynamic_cast<Node*>(right);
+        if (node_left && node_right)
+        {
+            // Recursively merge nodes
+            if (comp(node_left->m_value, node_right->m_value))
+            {
+                result = left;
+                result->m_next = merge(left->m_next, right, comp);
+            }
+            else
+            {
+                result = right;
+                result->m_next = merge(left, right->m_next, comp);
+            }
+            result->m_next->m_prev = result;
+        }
+
+        return result;
     }
 }
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1251,40 +1251,6 @@ namespace dsa
         }
 
         /**
-        * @brief Function inserts new Node before specified List iterator
-        *
-        * @param[in] pos iterator to insert element before
-        * @param[in] value element of type T to be inserted
-        * @return iterator to list element
-        * @retval iterator to inserted element
-        * @retval iterator to \p pos if no element was inserted
-        */
-        auto insert_element_before(iterator pos, const_reference value) -> iterator
-        {
-            if (pos == begin())
-            {
-                push_front(value);
-                return begin();
-            }
-
-            if (pos == end())
-            {
-                push_back(value);
-                return end().m_current_node->m_prev;
-            }
-
-            NodeBase* temp{ pos.m_current_node->m_prev };
-            Node* newNode = construct_node(temp, temp->m_next, value);
-
-
-            temp->m_next->m_prev = newNode;
-            temp->m_next = newNode;
-
-            m_size++;
-            return iterator(newNode);
-        }
-
-        /**
          * @brief Function checks List contains iterator
          *
          * @param[in] pos iterator to check

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1536,7 +1536,7 @@ namespace dsa
     {
         if (!if_valid_iterator(pos))
         {
-            return nullptr;
+            return pos.m_current_node;
         }
 
         iterator iter{ pos.m_current_node };
@@ -1551,7 +1551,7 @@ namespace dsa
     {
         if (!if_valid_iterator(pos))
         {
-            return nullptr;
+            return pos.m_current_node;
         }
 
         iterator iter{ pos.m_current_node };
@@ -1568,25 +1568,19 @@ namespace dsa
         requires std::input_iterator<InputIt>
     auto List<T>::insert(const const_iterator& pos, InputIt first, InputIt last) -> typename List<T>::iterator
     {
-        if (!if_valid_iterator(pos))
-        {
-            return nullptr;
-        }
-
         iterator iter{};
-        iterator iter_out{};
         while (first != last)
         {
-            iter = insert(pos.m_current_node, *first);
-            if (!iter_out.m_current_node)
+            auto res = insert(pos.m_current_node, *first);
+            if (!iter.m_current_node)
             {
-                iter_out = iter;
+                iter = res;
             }
 
             ++first;
         }
 
-        return iter_out;
+        return iter == nullptr ? pos.m_current_node : iter;
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1096,7 +1096,7 @@ namespace dsa
         /**
          * @brief Function reverts in place Nodes of List
          */
-        void reverse();
+        void reverse() noexcept;
 
         /**
          * @brief Function removes consecutive duplicated elements
@@ -2253,7 +2253,7 @@ namespace dsa
     }
 
     template<typename T>
-    void List<T>::reverse()
+    void List<T>::reverse() noexcept
     {
         if (m_head->m_next == nullptr)
         {

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -37,8 +37,6 @@ namespace dsa
      *
      * @tparam T type of data stored in List Node
      *
-     * @todo add non-member specialized erase function
-     * @todo add non-member specialized erase_if function
      * @todo remove public functions / operators not supported by std::forward_list
      */
     template<typename T>
@@ -2709,6 +2707,36 @@ namespace dsa
     void swap(List<T>& lhs, List<T>& rhs) noexcept(noexcept(lhs.swap(rhs)))
     {
         lhs.swap(rhs);
+    }
+
+    /**
+     * @brief Function erases from container all elements that are equal to \p value
+     *
+     * @tparam T data type stored in containers
+     * @tparam U data type of \p value
+     * @param[in,out] container object to remove erase elements from
+     * @param[in] value value to remove from \p container
+     * @return size_type number of elements removed
+     */
+    template<typename T, typename U>
+    auto erase(List<T>& container, const U& value) -> List<T>::size_type
+    {
+        return erase_if(container, [&value](U node_val) { return node_val == value; });
+    }
+
+    /**
+     * @brief Function erases from container all elements that satisfy the predicate \p pred
+     *
+     * @tparam T data type stored in containers
+     * @tparam Pred predicate to check if element should be erased
+     * @param[in,out] container container object to remove erase elements from
+     * @param[in] pred predicate which returns \p true if the element should be erased
+     * @return size_type number of elements removed
+     */
+    template<typename T, typename Pred>
+    auto erase_if(List<T>& container, Pred pred) -> List<T>::size_type
+    {
+        return container.remove_if(pred);
     }
 }
 

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -464,14 +464,24 @@ namespace dsa
         using const_reference = const value_type&;
 
         /**
+         * @brief Alias for iterator to data type used in class
+         */
+        using iterator = ListIterator<false>;
+
+        /**
          * @brief Alias for const iterator to data type used in class
          */
         using const_iterator = ListIterator<true>;
 
         /**
-         * @brief Alias for iterator to data type used in class
+         * @brief Alias for reverse_iterator to data type used in class
          */
-        using iterator = ListIterator<false>;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+
+        /**
+         * @brief Alias for const reverse_iterator to data type used in class
+         */
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
         /**
          * @brief Construct a new List object

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -506,6 +506,17 @@ namespace dsa
         List(size_type count, const T& value);
 
         /**
+         * @brief Construct a new List object using elements from range [ \p first , \p last )
+         *
+         * @tparam InputIt
+         * @param[in] first element defining range of elements to insert
+         * @param[in] last element definig range of elements to insert
+         */
+        template<typename InputIt>
+            requires std::input_iterator<InputIt>
+        List(InputIt first, InputIt last);
+
+        /**
          * @brief Construct a new List object using initializer list
          *
          * @param[in] ilist initializer list of values of type T
@@ -1204,6 +1215,14 @@ namespace dsa
         {
             push_front(value);
         }
+    }
+
+    template<typename T>
+    template<typename InputIt>
+        requires std::input_iterator<InputIt>
+    List<T>::List(InputIt first, InputIt last)
+    {
+        assign(first, last);
     }
 
     template<typename T>

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1836,7 +1836,9 @@ namespace dsa
 
                 if (node_this && node_other)
                 {
-                    if (comp(node_this->value(), node_other->value()))
+                    // 2nd condition keeps correct order of equal elements
+                    if (comp(node_this->value(), node_other->value()) ||
+                        !comp(node_other->value(), node_this->value()))
                     {
                         to_move = m_head;
                         to_move->m_prev = temp_tail;

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -33,8 +33,6 @@ namespace dsa
      *        elements as internal base
      *
      * @tparam T type of data stored in List Node
-     *
-     * @todo remove public functions / operators not supported by std::forward_list
      */
     template<typename T>
     class List

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -935,6 +935,7 @@ namespace dsa
         {
             if (m_head == nullptr)
             {
+                // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
                 m_head = new NodeBase;
                 m_tail = m_head;
             }
@@ -966,10 +967,55 @@ namespace dsa
 
             temp->m_next = to_remove->m_next;
             temp->m_next->m_prev = temp;
-            delete to_remove;
+            destroy_node(to_remove);
 
             m_size--;
             return iterator(temp->m_next);
+        }
+
+        /**
+         * @brief Function allocate and construct List node
+         *
+         * @tparam ...Args
+         * @param[in] prev_ptr pointer to previous Node
+         * @param[in] next_ptr pointer to next Node
+         * @param[in] args element of type T to be inserted
+         * @return pointer to created Node
+         */
+        template<typename... Args>
+        // NOLINTNEXTLINE(bugprone-easily-swappable-parameters,-warnings-as-errors)
+        auto construct_node(NodeBase* prev_ptr, NodeBase* next_ptr, Args&&... args) -> Node*
+        {
+            Node* newNode = node_alloc_traits::allocate(node_alloc, 1);
+            try
+            {
+                node_alloc_traits::construct(node_alloc, newNode, std::forward<Args>(args)...);
+            }
+            catch (...)
+            {
+                node_alloc_traits::deallocate(node_alloc, newNode, 1);
+                throw;
+            }
+
+            newNode->m_prev = prev_ptr;
+            newNode->m_next = next_ptr;
+
+            return newNode;
+        }
+
+        /**
+         * @brief Function destroys and deallocates memory used by Node
+         *
+         * @param[in] node_to_destroy pointer to Node to delete
+         */
+        void destroy_node(NodeBase* node_to_destroy)
+        {
+            Node* node_dyn = dynamic_cast<Node*>(node_to_destroy);
+            if (node_dyn)
+            {
+                node_alloc_traits::destroy(node_alloc, node_dyn);
+                node_alloc_traits::deallocate(node_alloc, node_dyn, 1);
+            }
         }
 
         /**
@@ -996,10 +1042,8 @@ namespace dsa
             }
 
             NodeBase* temp{ pos.m_current_node->m_prev };
+            Node* newNode = construct_node(temp, temp->m_next, value);
 
-            Node* newNode = new Node(value);
-            newNode->m_next = temp->m_next;
-            newNode->m_prev = temp;
 
             temp->m_next->m_prev = newNode;
             temp->m_next = newNode;
@@ -1067,6 +1111,21 @@ namespace dsa
          * @brief Allocator for memory management
          */
         allocator_type m_allocator{};
+
+        /**
+         * @brief Rebind allocator to create new objects of type Node
+         */
+        using node_allocator = typename std::allocator_traits<std::allocator<T>>::template rebind_alloc<Node>;
+
+        /**
+         * @brief Setup allocator traits used for Node creation and deletion
+         */
+        using node_alloc_traits = std::allocator_traits<node_allocator>;
+
+        /**
+         * @brief Initialize allocator rebind to Node objects
+         */
+        node_allocator node_alloc{};
     };
 
     template<typename T>
@@ -1277,7 +1336,7 @@ namespace dsa
             {
                 m_head->m_prev = nullptr;
                 m_head = temp->m_next;
-                delete temp;
+                destroy_node(temp);
                 temp = m_head;
             }
 
@@ -1368,7 +1427,7 @@ namespace dsa
     {
         init_node();
 
-        Node* newNode = new Node(value);
+        Node* newNode = construct_node(nullptr, nullptr, value);
         if (!m_head->m_next)
         {
             newNode->m_next = m_head;
@@ -1403,7 +1462,7 @@ namespace dsa
         {
             m_head->m_prev = nullptr;
         }
-        delete temp;
+        destroy_node(temp);
 
         m_size--;
     }
@@ -1413,7 +1472,7 @@ namespace dsa
     {
         init_node();
 
-        Node* newNode = new Node(value);
+        Node* newNode = construct_node(nullptr, nullptr, value);
 
         if (!m_head->m_next) // only sentinel exists
         {
@@ -1453,7 +1512,7 @@ namespace dsa
             temp->m_prev->m_next = temp->m_next;
             m_tail->m_prev = temp->m_prev;
         }
-        delete temp;
+        destroy_node(temp);
 
         m_size--;
     }
@@ -1514,7 +1573,7 @@ namespace dsa
         {
             if (m_size != 0)
             {
-                Node* temp_head = new Node(0);
+                Node* temp_head = construct_node(nullptr, nullptr, 0);
                 NodeBase* temp_tail = temp_head;
 
                 NodeBase* to_move{};
@@ -1571,7 +1630,7 @@ namespace dsa
 
                 m_head = temp_head->m_next;
                 m_head->m_prev = nullptr;
-                delete temp_head;
+                destroy_node(temp_head);
 
                 other.m_head = other.m_tail;
                 other.m_head->m_next = nullptr;
@@ -1787,7 +1846,7 @@ namespace dsa
                         }
 
                         prev->m_next = to_remove->m_next;
-                        delete to_remove;
+                        destroy_node(to_remove);
 
                         m_size--;
                         continue;

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -1237,7 +1237,7 @@ namespace dsa
         /**
          * @brief Rebind allocator to create new objects of type Node
          */
-        using node_allocator = typename std::allocator_traits<std::allocator<T>>::template rebind_alloc<Node>;
+        using node_allocator = typename std::allocator_traits<allocator_type>::template rebind_alloc<Node>;
 
         /**
          * @brief Setup allocator traits used for Node creation and deletion

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -332,33 +332,6 @@ namespace dsa
             }
 
             /**
-             * @brief Overload operator[] for ListIterator iterator access
-             *
-             * @param[in] index number of Node to move forward
-             * @return ListIterator to Node pointed by \p index from List front
-             * @retval valid ListIterator if index is valid
-             * @retval nullptr if index is invalid
-             */
-            auto operator[](size_type index) -> ListIterator
-            {
-                NodeBase* temp{ m_current_node };
-
-                for (size_type i = 0; i < index; i++)
-                {
-                    if (temp->m_next)
-                    {
-                        temp = temp->m_next;
-                    }
-                    else
-                    {
-                        return nullptr;
-                    }
-                }
-
-                return temp;
-            }
-
-            /**
              * @brief Overload operator* to dereference Node value / data
              *
              * @return T& reference or const reference to data stored in Node

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -344,11 +344,11 @@ namespace dsa
              * @retval valid ListIterator if index is valid
              * @retval nullptr if index is invalid
              */
-            auto operator[](size_t index) -> ListIterator
+            auto operator[](size_type index) -> ListIterator
             {
                 NodeBase* temp{ m_current_node };
 
-                for (size_t i = 0; i < index; i++)
+                for (size_type i = 0; i < index; i++)
                 {
                     if (temp->m_next)
                     {
@@ -477,7 +477,7 @@ namespace dsa
          *
          * @param[in] count element count
          */
-        List(size_t count);
+        List(size_type count);
 
         /**
          * @brief Construct a new List object of size \p count,
@@ -486,7 +486,7 @@ namespace dsa
          * @param[in] count element count
          * @param[in] value value for all nodes
          */
-        List(size_t count, const T& value);
+        List(size_type count, const T& value);
 
         /**
          * @brief Construct a new List object using initializer list
@@ -538,7 +538,7 @@ namespace dsa
          * @param[in] count new size of the container
          * @param[in] value value to initialize elements of the container with
          */
-        void assign(size_t count, const_reference value);
+        void assign(size_type count, const_reference value);
 
         /**
          * @brief Function assign values to the List
@@ -635,16 +635,16 @@ namespace dsa
         /**
          * @brief Function returns List size
          *
-         * @return size_t number of elements in container
+         * @return size_type number of elements in container
          */
-        [[nodiscard]] auto size() const -> size_t;
+        [[nodiscard]] auto size() const -> size_type;
 
         /**
          * @brief Function returns maximum number of elements container can hold
          *
-         * @return size_t maximum number of elements
+         * @return size_type maximum number of elements
          */
-        [[nodiscard]] auto max_size() const -> size_t;
+        [[nodiscard]] auto max_size() const -> size_type;
 
         /**
          * @brief Function removes all elements of List
@@ -672,7 +672,7 @@ namespace dsa
          * @retval iterator to inserted \p value
          * @retval pos if no element was inserted
          */
-        auto insert(const const_iterator& pos, size_t count, const_reference value) -> iterator;
+        auto insert(const const_iterator& pos, size_type count, const_reference value) -> iterator;
 
         /**
          * @brief Function inserts new Node before specified \p pos
@@ -760,7 +760,7 @@ namespace dsa
          *
          * @param[in] count new size of container
          */
-        void resize(size_t count);
+        void resize(size_type count);
 
         /**
          * @brief Function resize List to specified number of elements
@@ -768,7 +768,7 @@ namespace dsa
          * @param[in] count count new size of container
          * @param[in] value value to initialize new elements
          */
-        void resize(size_t count, const_reference value);
+        void resize(size_type count, const_reference value);
 
         /**
          * @brief Function swaps content of two List objects
@@ -914,7 +914,7 @@ namespace dsa
          * @retval Node* if index is valid
          * @retval nullptr if invalid index
          */
-        [[nodiscard]] auto get(size_t index) const -> Node*;
+        [[nodiscard]] auto get(size_type index) const -> Node*;
 
         /**
          * @brief Function sets value of specifed Node of List
@@ -925,7 +925,7 @@ namespace dsa
          * @retval true if value of Node was overwritten
          * @retval false if invalid index
          */
-        auto set(size_t index, T value) -> bool;
+        auto set(size_type index, T value) -> bool;
 
     private:
 
@@ -1100,9 +1100,9 @@ namespace dsa
          * @tparam T type of input objects
          * @param[in] first const_iterator pointing first element
          * @param[in] last const_iterator pointing to last (inclusive) element
-         * @return size_t number of elements between input elements
+         * @return size_type number of elements between input elements
          */
-        auto distance(const_iterator first, const const_iterator& last) -> size_t;
+        auto distance(const_iterator first, const const_iterator& last) -> size_type;
 
         /**
          * @brief Function moves elements from other List object
@@ -1119,7 +1119,7 @@ namespace dsa
 
         NodeBase* m_head{};
         NodeBase* m_tail{};
-        size_t m_size{};
+        size_type m_size{};
 
         /**
          * @brief Allocator for memory management
@@ -1149,16 +1149,16 @@ namespace dsa
     }
 
     template<typename T>
-    List<T>::List(size_t count)
+    List<T>::List(size_type count)
         : List(count, T{})
     {}
 
     template<typename T>
-    List<T>::List(size_t count, const T& value)
+    List<T>::List(size_type count, const T& value)
     {
         init_node();
 
-        for (size_t i = 0; i < count; i++)
+        for (size_type i = 0; i < count; i++)
         {
             push_front(value);
         }
@@ -1176,7 +1176,7 @@ namespace dsa
     template<typename T>
     List<T>::List(const List<T>& other)
     {
-        for (size_t i = 0; i < other.size(); i++)
+        for (size_type i = 0; i < other.size(); i++)
         {
             push_back(other.get(i)->value());
         }
@@ -1192,7 +1192,7 @@ namespace dsa
                 pop_front();
             }
 
-            for (size_t i = 0; i < other.size(); i++)
+            for (size_type i = 0; i < other.size(); i++)
             {
                 push_back(other.get(i)->value());
             }
@@ -1235,11 +1235,11 @@ namespace dsa
     }
 
     template<typename T>
-    void List<T>::assign(size_t count, const_reference value)
+    void List<T>::assign(size_type count, const_reference value)
     {
         clear();
 
-        for (size_t i = 0; i < count; i++)
+        for (size_type i = 0; i < count; i++)
         {
             push_back(value);
         }
@@ -1329,15 +1329,15 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::size() const -> size_t
+    auto List<T>::size() const -> size_type
     {
         return m_size;
     }
 
     template<typename T>
-    auto List<T>::max_size() const -> size_t
+    auto List<T>::max_size() const -> size_type
     {
-        return std::numeric_limits<size_t>::max();
+        return std::numeric_limits<size_type>::max();
     }
 
     template<typename T>
@@ -1366,7 +1366,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::insert(const const_iterator& pos, size_t count, const_reference value) -> typename List<T>::iterator
+    auto List<T>::insert(const const_iterator& pos, size_type count, const_reference value) -> typename List<T>::iterator
     {
         iterator iter{ pos.m_current_node };
 
@@ -1375,7 +1375,7 @@ namespace dsa
             return nullptr;
         }
 
-        for (size_t i = 0; i < count; i++)
+        for (size_type i = 0; i < count; i++)
         {
             iter = insert_element_before(iter, value);
         }
@@ -1421,14 +1421,14 @@ namespace dsa
             return nullptr;
         }
 
-        const size_t dist = distance(first, last);
+        const size_type dist = distance(first, last);
         if (dist == 0)
         {
             return last;
         }
 
         iterator iter(first.m_current_node);
-        for (size_t i = 0; i < dist; i++)
+        for (size_type i = 0; i < dist; i++)
         {
             iter = erase_element(iter);
         }
@@ -1532,13 +1532,13 @@ namespace dsa
     }
 
     template<typename T>
-    void List<T>::resize(size_t count)
+    void List<T>::resize(size_type count)
     {
         resize(count, T{});
     }
 
     template<typename T>
-    void List<T>::resize(size_t count, const_reference value)
+    void List<T>::resize(size_type count, const_reference value)
     {
         if (count == m_size)
         {
@@ -1661,9 +1661,9 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::distance(const_iterator first, const const_iterator& last) -> size_t
+    auto List<T>::distance(const_iterator first, const const_iterator& last) -> size_type
     {
-        size_t dist{};
+        size_type dist{};
         while (first != last)
         {
             ++first;
@@ -1680,7 +1680,7 @@ namespace dsa
     {
         if (&other != this && other.m_size > 0)
         {
-            const size_t dist = distance(first, last);
+            const size_type dist = distance(first, last);
             if (dist == 0)
             {
                 return;
@@ -1813,7 +1813,7 @@ namespace dsa
         NodeBase* temp = m_head;
         NodeBase* prev{};
 
-        for (size_t i = 0; i < m_size; i++)
+        for (size_type i = 0; i < m_size; i++)
         {
             NodeBase* next = temp->m_next;
             temp->m_next = prev;
@@ -1874,7 +1874,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::get(size_t index) const -> typename List<T>::Node*
+    auto List<T>::get(size_type index) const -> typename List<T>::Node*
     {
         if (index >= m_size)
         {
@@ -1892,7 +1892,7 @@ namespace dsa
         {
             // count nodes from front
             temp = m_head;
-            for (size_t i = 0; i < index; i++)
+            for (size_type i = 0; i < index; i++)
             {
                 temp = temp->m_next;
             }
@@ -1901,7 +1901,7 @@ namespace dsa
         {
             // count nodes from back
             temp = m_tail->m_prev;
-            for (size_t i = m_size - 1; i > index; i--)
+            for (size_type i = m_size - 1; i > index; i--)
             {
                 temp = temp->m_prev;
             }
@@ -1912,7 +1912,7 @@ namespace dsa
             if (index < m_size / 2)
             {
                 temp = m_head;
-                for (size_t i = 0; i < index; i++)
+                for (size_type i = 0; i < index; i++)
                 {
                     temp = temp->m_next;
                 }
@@ -1920,7 +1920,7 @@ namespace dsa
             else
             {
                 temp = m_tail->m_prev;
-                for (size_t i = m_size - 1; i > index; i--)
+                for (size_type i = m_size - 1; i > index; i--)
                 {
                     temp = temp->m_prev;
                 }
@@ -1931,7 +1931,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::set(size_t index, T value) -> bool
+    auto List<T>::set(size_type index, T value) -> bool
     {
         Node* temp = get(index);
         if (temp)

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -793,11 +793,24 @@ namespace dsa
         auto insert(const const_iterator& pos, size_type count, const_reference value) -> iterator;
 
         /**
-         * @brief Function inserts new Node before specified \p pos
+         * @brief Function inserts elements in range [first, last) after \p pos
+         *
+         * @param[in] pos const_iterator to insert element after
+         * @param[in] first element defining range of elements to insert
+         * @param[in] last element definig range of elements to insert
+         * @return pointer to List element
+         * @retval iterator pointer to last inserted element
+         * @retval pos if no element was inserted
+         */
+        template<typename InputIt>
+            requires std::input_iterator<InputIt>
+        auto insert(const const_iterator& pos, InputIt first, InputIt last) -> iterator;
+
+        /**
+         * @brief Function inserts content of initializer list before specified \p pos
          *
          * @param[in] pos const_iterator to insert element before
          * @param[in] init_list initializer_list with elements to insert before \p pos
-         * @return pointer to List element
          * @retval iterator to first inserted element
          * @retval pos if no element was inserted
          */
@@ -1627,15 +1640,40 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::insert(const const_iterator& pos, std::initializer_list<T> init_list) -> typename List<T>::iterator
+    template<typename InputIt>
+        requires std::input_iterator<InputIt>
+    auto List<T>::insert(const const_iterator& pos, InputIt first, InputIt last) -> typename List<T>::iterator
     {
-        iterator iter(pos.m_current_node);
-
         if (!if_valid_iterator(pos))
         {
             return nullptr;
         }
 
+        iterator iter{};
+        iterator iter_out{};
+        while (first != last)
+        {
+            iter = insert(pos.m_current_node, *first);
+            if (!iter_out.m_current_node)
+            {
+                iter_out = iter;
+            }
+
+            ++first;
+        }
+
+        return iter_out;
+    }
+
+    template<typename T>
+    auto List<T>::insert(const const_iterator& pos, std::initializer_list<T> init_list) -> typename List<T>::iterator
+    {
+        if (!if_valid_iterator(pos))
+        {
+            return nullptr;
+        }
+
+        iterator iter(pos.m_current_node);
         for (const auto& val : init_list)
         {
             iter = insert_element_before(iter, val);

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -866,6 +866,17 @@ namespace dsa
         void push_back(const_reference value);
 
         /**
+         * @brief Function adds new Node at the end of List using move semantics
+         *
+         * @param[in] value element of type T
+         *
+         * @note no iterators or references are invalidated,
+         *       if construction of new element fails or an exception is thrown for any reason
+         *       state of the object does not change and this function has no effect
+         */
+        void push_back(T&& value);
+
+        /**
          * @brief Insert new element to the end of the container
          *
          * @tparam ...Args
@@ -1783,6 +1794,28 @@ namespace dsa
         init_node();
 
         Node* newNode = construct_node(nullptr, nullptr, value);
+
+        if (!m_head->m_next) // only sentinel exists
+        {
+            newNode->m_next = m_head;
+            m_head = newNode;
+            m_tail->m_prev = m_head;
+        }
+        else
+        {
+            newNode->m_prev = m_tail->m_prev;
+            newNode->m_next = m_tail->m_prev->m_next;
+            m_tail->m_prev = newNode;
+            m_tail->m_prev->m_prev->m_next = newNode;
+        }
+
+        m_size++;
+    }
+
+    template<typename T>
+    void List<T>::push_back(T&& value)
+    {
+        Node* newNode = construct_node(nullptr, nullptr, std::move(value));
 
         if (!m_head->m_next) // only sentinel exists
         {

--- a/tests/list/CMakeLists.txt
+++ b/tests/list/CMakeLists.txt
@@ -59,3 +59,7 @@ add_test(NAME list_itors_test COMMAND list_itors_test)
 add_executable(list_ranges_test list_ranges_test.cpp ${SRC_DIR}/common.cpp)
 target_link_libraries(list_ranges_test PRIVATE dsa_testing)
 add_test(NAME list_ranges_test COMMAND list_ranges_test)
+
+add_executable(list_sort_test list_sort_test.cpp ${SRC_DIR}/common.cpp)
+target_link_libraries(list_sort_test PRIVATE dsa_testing)
+add_test(NAME list_sort_test COMMAND list_sort_test)

--- a/tests/list/list_ctors_test.cpp
+++ b/tests/list/list_ctors_test.cpp
@@ -15,6 +15,7 @@
 #include <exception>
 #include <initializer_list>
 #include <iostream>
+#include <iterator>
 #include <list>
 #include <utility>
 
@@ -87,6 +88,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected10{ 0, 0, 0, 0, 0 };
         tests::compare("List10", list10, expected10);
 
+        std::cout << "Construct from other List\n";
+        dsa::List<int> temp11 = { 0, 10, 20, 30, 40, 50 };
+        const dsa::List<int> list11(std::next(temp11.begin(), 1), std::next(temp11.begin(), 4));
+        const std::initializer_list<int> expected11{ 10, 20, 30 };
+        tests::compare("List11", list11, expected11);
+
+
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list1;
@@ -123,6 +131,18 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_list7(1, 0);
         std_list7 = std::move(std_temp_2);
         tests::compare("List7 vs std", list7, expected);
+
+        std::list<int> std_temp_8(std_list1);
+        std::list<int> std_list8(1, 0);
+        std_list8 = std::move(std_temp_8);
+        tests::compare("List8 vs std", list8, std_list8);
+
+        const std::list<int> std_list10(5);
+        tests::compare("List10 vs std", list10, std_list10);
+
+        std::list<int> std_temp11 = { 0, 10, 20, 30, 40, 50 };
+        const std::list<int> std_list11(std::next(std_temp11.begin(), 1), std::next(std_temp11.begin(), 4));
+        tests::compare("List11 vs std", list11, std_list11);
 
 
         tests::print_stats();

--- a/tests/list/list_get_test.cpp
+++ b/tests/list/list_get_test.cpp
@@ -16,6 +16,7 @@
 #include <exception>
 #include <initializer_list>
 #include <iostream>
+#include <iterator>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -26,38 +27,19 @@ int main() // NOLINT(modernize-use-trailing-return-type)
     {
         std::cout << "Start list_get_test:\n";
 
-        const dsa::List<int> list1 = dsa::List<int>({ 0, 10, 20 });
-        // Try reading some nodes with invalid indexes
+        dsa::List<int> list1 = dsa::List<int>({ 0, 10, 20 });
         const std::initializer_list<int> expected1 = { 0, 10, 20 };
-        auto indexes = { -1, 0, 1, 2, 100 };
-        for (size_t i = 0; i < indexes.size(); i++)
+        const size_t list1_size = list1.size();
+        for (size_t i = 0; i < list1_size; i++)
         {
-            auto* temp = list1.get(i);
-            if (static_cast<bool>(temp))
-            {
-                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-                tests::compare(temp->value(), expected1.begin()[i]);
-            }
+            const int temp = list1.front();
+            tests::compare("List1", temp, *(std::next(expected1.begin(), static_cast<ptrdiff_t>(i))));
+            list1.pop_front();
         }
-        tests::compare("List1", list1, expected1);
 
-        const dsa::List<int> list2 = dsa::List<int>({ 20, 10, 0 });
-        const std::initializer_list<int> expected2 = { 20, 10, 0 };
-        size_t idx{ 0 };
-        for (const auto& item : expected2)
-        {
-            auto* temp = list2.get(idx);
-            if (static_cast<bool>(temp))
-            {
-                tests::compare(temp->value(), item);
-            }
-            idx++;
-        }
-        tests::compare("List2", list2, expected2);
-
-        const dsa::List<int> list3 = dsa::List<int>({ 0, 10, 20 });
-        tests::compare("List3 front", list3.front(), 0);
-        tests::compare("List3 back", list3.back(), 20);
+        const dsa::List<int> list2 = dsa::List<int>({ 0, 10, 20 });
+        tests::compare("List2 front", list2.front(), 0);
+        tests::compare("List2 back", list2.back(), 20);
 
 
         tests::print_stats();

--- a/tests/list/list_grow_test.cpp
+++ b/tests/list/list_grow_test.cpp
@@ -51,9 +51,11 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list2.push_front(30);
         list2.push_front(20);
         list2.push_front(10);
-        list2.insert(list2.cbegin(), 5, 5);
+        auto list2_it = list2.insert(list2.cbegin(), 5, 5);
         const std::initializer_list<int> expected2 = { 5, 5, 5, 5, 5, 10, 20, 30, 40, 50 };
         tests::compare("List2", list2, expected2);
+        tests::compare("List2 it", *list2_it, *list2.begin());
+        tests::compare("List2 it", *std::next(list2_it), *std::next(list2.begin()));
 
         dsa::List<int> list3 = dsa::List<int>(1, 50);
         list3.push_front(40);
@@ -99,7 +101,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list9.insert(list9.begin(), std::move(ptr9));
         constexpr int expected9{ 1 };
         tests::compare("List9 front()", *list9.front(), expected9);
-        tests::compare("ptr19 == nullptr", ptr9 == nullptr, true);
+        tests::compare("ptr9 == nullptr", ptr9 == nullptr, true);
 
         dsa::List<int> list10{};
         const dsa::List<int> temp10{ 0, 10, 20, 30, 40, 50 };
@@ -169,7 +171,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List18 front", *list18.front(), expected18);
         tests::compare("List18 back", *list18.back(), expected18);
         tests::compare("ptr18 == nullptr", ptr18 == nullptr, true);
-
 
         try
         {
@@ -400,6 +401,32 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected29{ 0, 10, 20 };
         tests::compare("List29", list29, expected29);
         tests::compare("List29 it", list29_it == nullptr, true);
+
+        dsa::List<std::unique_ptr<int>> list30{};
+        auto ptr30 = std::make_unique<int>(1);
+        auto list30_it = list30.insert(list30.end(), std::move(ptr30));
+        tests::compare("List30 it", *list30_it, list30.front());
+
+        dsa::List<std::unique_ptr<int>> list31{};
+        auto ptr31 = std::make_unique<int>(1);
+        list31.insert(std::next(list31.end()), std::move(ptr31));
+        tests::compare("List31 size", list31.size(), static_cast<std::size_t>(0));
+
+        dsa::List<int> list32{ 0, 10, 20 };
+        dsa::List<int> list33{ 30, 40, 50 };
+        auto list32_it = list32.insert(list32.begin(), list33.begin(), std::next(list33.begin()));
+        const std::initializer_list<int> expected32{ 30, 0, 10, 20 };
+        const std::initializer_list<int> expected33{ 30, 40, 50 };
+        tests::compare("List32", list32, expected32);
+        tests::compare("List32 it", *list32_it, list33.front());
+        tests::compare("List33", list33, expected33);
+
+        dsa::List<int> list34{ 0, 10, 20 };
+        const dsa::List<int> temp34{ 30, 40, 50 };
+        auto list34_it = list34.insert(std::next(list34.begin(), 2), temp34.begin(), temp34.begin());
+        const std::initializer_list<int> expected34{ 0, 10, 20 };
+        tests::compare("List34", list34, expected34);
+        tests::compare("List34 it", *list34_it, *(std::next(list34.begin(), 2)));
 
 
         std::cout << "Compare operations results with std container\n\n";

--- a/tests/list/list_grow_test.cpp
+++ b/tests/list/list_grow_test.cpp
@@ -19,6 +19,7 @@
 #include <iterator>
 #include <list>
 #include <memory>
+#include <stdexcept>
 #include <utility>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
@@ -168,6 +169,224 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List18 front", *list18.front(), expected18);
         tests::compare("List18 back", *list18.back(), expected18);
         tests::compare("ptr18 == nullptr", ptr18 == nullptr, true);
+
+
+        try
+        {
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                const tests::ThrowingType throwing_type{};
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "Runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::List<tests::ThrowingType> list19{};
+            const tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                list19.push_front(throwing_type);
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "List19 runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::List<tests::ThrowingType> list20{};
+            tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                // intentional use of moved object
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                list20.push_front(std::move(throwing_type));
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "list20 runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::List<tests::ThrowingType> list21{};
+            const tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                list21.push_back(throwing_type);
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "List21 runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::List<tests::ThrowingType> list22{};
+            tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                // intentional use of moved object
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                list22.push_back(std::move(throwing_type));
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "list22 runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::List<tests::ThrowingType> list23{};
+            const tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                list23.emplace(list23.begin(), throwing_type);
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "List23 runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::List<tests::ThrowingType> list24{};
+            tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                // intentional use of moved object
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                list24.emplace(list24.begin(), std::move(throwing_type));
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "List24 runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::List<tests::ThrowingType> list24{};
+            const tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                list24.emplace_front(throwing_type);
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "List24 runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::List<tests::ThrowingType> list25{};
+            tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                // intentional use of moved object
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                list25.emplace_front(std::move(throwing_type));
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "List25 runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::List<tests::ThrowingType> list26{};
+            const tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                list26.emplace_back(throwing_type);
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "List26 runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::List<tests::ThrowingType> list27{};
+            tests::ThrowingType throwing_type{};
+            for (size_t i = 0; i < tests::throwing_type_size_limit; i++)
+            {
+                // intentional use of moved object
+                // NOLINTNEXTLINE(bugprone-use-after-move)
+                list27.emplace_back(std::move(throwing_type));
+            }
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error& exc)
+        {
+            std::cout << "Error: " << exc.what() << '\n';
+            std::cout << "List27 runtime error exception handled correctly\n\n";
+        }
 
 
         std::cout << "Compare operations results with std container\n\n";

--- a/tests/list/list_grow_test.cpp
+++ b/tests/list/list_grow_test.cpp
@@ -388,6 +388,19 @@ int main() // NOLINT(modernize-use-trailing-return-type)
             std::cout << "List27 runtime error exception handled correctly\n\n";
         }
 
+        dsa::List<int> list28{ 0, 10, 20 };
+        dsa::List<int> temp28{ 30, 40, 50 };
+        auto list28_it = list28.insert(std::next(list28.end(), 1), temp28.begin(), temp28.end());
+        const std::initializer_list<int> expected28{ 0, 10, 20 };
+        tests::compare("List28", list28, expected28);
+        tests::compare("List28 it", list28_it == nullptr, true);
+
+        dsa::List<int> list29{ 0, 10, 20 };
+        auto list29_it = list29.insert(std::next(list29.end(), 1), 30);
+        const std::initializer_list<int> expected29{ 0, 10, 20 };
+        tests::compare("List29", list29, expected29);
+        tests::compare("List29 it", list29_it == nullptr, true);
+
 
         std::cout << "Compare operations results with std container\n\n";
 

--- a/tests/list/list_grow_test.cpp
+++ b/tests/list/list_grow_test.cpp
@@ -17,6 +17,8 @@
 #include <iostream>
 #include <iterator>
 #include <list>
+#include <memory>
+#include <utility>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -90,41 +92,65 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         iter8 = list8.insert(iter8, { 10, 20, 30 });
         tests::compare("iter8 == nullptr", iter8 == nullptr, true);
 
-        dsa::List<int> list9;
-        auto ref9 = list9.emplace_front(30);
-        tests::compare("List9 ref", ref9, list9.front());
-        ref9 = list9.emplace_front(20);
-        tests::compare("List9 ref", ref9, list9.front());
-        list9.emplace_front(10);
-        list9.emplace_front(5);
-        list9.emplace_front(0);
-        const std::initializer_list<int> expected9 = { 0, 5, 10, 20, 30 };
-        tests::compare("List9", list9, expected9);
+        dsa::List<std::unique_ptr<int>> list9{};
+        auto ptr9 = std::make_unique<int>(1);
+        list9.insert(list9.begin(), std::move(ptr9));
+        constexpr int expected9{ 1 };
+        tests::compare("List9 front()", *list9.front(), expected9);
+        tests::compare("ptr19 == nullptr", ptr9 == nullptr, true);
 
-        dsa::List<int> list10{ 0, 10, 20, 30 };
-        auto iter10 = list10.emplace(list10.begin(), -10);
-        tests::compare("List10 iter", *iter10, *list10.begin());
-        const std::initializer_list<int> expected10 = { -10, 0, 10, 20, 30 };
+        dsa::List<int> list10{};
+        const dsa::List<int> temp10{ 0, 10, 20, 30, 40, 50 };
+        auto temp10_it = std::next(temp10.begin(), 1);
+        auto list10_it = list10.insert(
+            list10.begin(), std::next(temp10.begin(), 1), std::next(temp10.begin(), 4));
+        const std::initializer_list<int> expected10{ 10, 20, 30 };
         tests::compare("List10", list10, expected10);
+        tests::compare("List10 it", *list10_it, *temp10_it);
 
-        dsa::List<int> list11{ 0, 10, 20, 30 };
-        auto iter11 = list11.emplace(list11.end(), 40);
-        tests::compare("List11 iter", *iter11, *(--list11.end()));
-        const std::initializer_list<int> expected11 = { 0, 10, 20, 30, 40 };
+        dsa::List<int> list11{ 0, 10, 20 };
+        const dsa::List<int> temp11{ 30, 40, 50 };
+        auto temp11_it = temp11.begin();
+        auto list11_it = list11.insert(std::next(list11.begin(), 2), temp11.begin(), temp11.end());
+        const std::initializer_list<int> expected11{ 0, 10, 30, 40, 50, 20 };
         tests::compare("List11", list11, expected11);
+        tests::compare("List11 it", *list11_it, *temp11_it);
 
-        dsa::List<int> list12{ 0, 10, 20, 30 };
-        auto ref12 = list12.emplace_back(40);
-        tests::compare("List12 ref", ref12, list12.back());
-        const std::initializer_list<int> expected12 = { 0, 10, 20, 30, 40 };
+        dsa::List<int> list12;
+        auto ref12 = list12.emplace_front(30);
+        tests::compare("List12 ref", ref12, list12.front());
+        ref12 = list12.emplace_front(20);
+        tests::compare("List12 ref", ref12, list12.front());
+        list12.emplace_front(10);
+        list12.emplace_front(5);
+        list12.emplace_front(0);
+        const std::initializer_list<int> expected12 = { 0, 5, 10, 20, 30 };
         tests::compare("List12", list12, expected12);
 
-        dsa::List<int> list13;
-        list13.emplace_back(10);
-        list13.emplace_back(20);
-        list13.emplace_back(30);
-        const std::initializer_list<int> expected13 = { 10, 20, 30 };
+        dsa::List<int> list13{ 0, 10, 20, 30 };
+        auto iter13 = list13.emplace(list13.begin(), -10);
+        tests::compare("List13 iter", *iter13, *list13.begin());
+        const std::initializer_list<int> expected13 = { -10, 0, 10, 20, 30 };
         tests::compare("List13", list13, expected13);
+
+        dsa::List<int> list14{ 0, 10, 20, 30 };
+        auto iter14 = list14.emplace(list14.end(), 40);
+        tests::compare("List14 iter", *iter14, *(--list14.end()));
+        const std::initializer_list<int> expected14 = { 0, 10, 20, 30, 40 };
+        tests::compare("List14", list14, expected14);
+
+        dsa::List<int> list15{ 0, 10, 20, 30 };
+        auto ref15 = list15.emplace_back(40);
+        tests::compare("List15 ref", ref15, list15.back());
+        const std::initializer_list<int> expected15 = { 0, 10, 20, 30, 40 };
+        tests::compare("List15", list15, expected15);
+
+        dsa::List<int> list16;
+        list16.emplace_back(10);
+        list16.emplace_back(20);
+        list16.emplace_back(30);
+        const std::initializer_list<int> expected16 = { 10, 20, 30 };
+        tests::compare("List16", list16, expected16);
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -141,35 +167,54 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list7.insert(std_list7.begin(), { 10, 20, 30 });
         tests::compare("List7 vs std", list7, std_list7);
 
-        std::list<int> std_list9;
-        std_list9.emplace_front(30);
-        auto std_ref9 = std_list9.emplace_front(20);
-        tests::compare("List9 ref vs std", ref9, std_ref9);
-        std_list9.emplace_front(10);
-        std_list9.emplace_front(5);
-        std_list9.emplace_front(0);
-        tests::compare("List9 vs std", list9, std_list9);
+        std::list<std::unique_ptr<int>> std_list9{};
+        auto std_ptr9 = std::make_unique<int>(1);
+        std_list9.insert(std_list9.begin(), std::move(std_ptr9));
+        tests::compare("List9 front() vs std", *list9.front(), *std_list9.front());
+        tests::compare("ptr19 == nullptr", ptr9 == std_ptr9, true);
 
-        std::list<int> std_list10{ 0, 10, 20, 30 };
-        auto std_iter10 = std_list10.emplace(std_list10.begin(), -10);
-        tests::compare("List10 iter vs std", *iter10, *std_iter10);
+        std::list<int> std_list10{};
+        const std::list<int> std_temp10{ 0, 10, 20, 30, 40, 50 };
+        auto std_list10_it = std_list10.insert(
+            std_list10.begin(), std::next(std_temp10.begin(), 1), std::next(std_temp10.begin(), 4));
         tests::compare("List10 vs std", list10, std_list10);
+        tests::compare("List10 it vs std", *list10_it, *std_list10_it);
 
-        std::list<int> std_list11{ 0, 10, 20, 30 };
-        auto std_iter11 = std_list11.emplace(std_list11.end(), 40);
-        tests::compare("List11 iter vs std", *std_iter11, *(--std_list11.end()));
+        std::list<int> std_list11{ 0, 10, 20 };
+        const std::list<int> std_temp11{ 30, 40, 50 };
+        auto std_list11_it = std_list11.insert(std::next(std_list11.begin(), 2), std_temp11.begin(), std_temp11.end());
         tests::compare("List11 vs std", list11, std_list11);
+        tests::compare("List11 it vs std", *list11_it, *std_list11_it);
 
-        std::list<int> std_list12{ 0, 10, 20, 30 };
-        auto std_ref12 = std_list12.emplace_back(40);
+        std::list<int> std_list12;
+        std_list12.emplace_front(30);
+        auto std_ref12 = std_list12.emplace_front(20);
         tests::compare("List12 ref vs std", ref12, std_ref12);
+        std_list12.emplace_front(10);
+        std_list12.emplace_front(5);
+        std_list12.emplace_front(0);
         tests::compare("List12 vs std", list12, std_list12);
 
-        std::list<int> std_list13;
-        std_list13.emplace_back(10);
-        std_list13.emplace_back(20);
-        std_list13.emplace_back(30);
+        std::list<int> std_list13{ 0, 10, 20, 30 };
+        auto std_iter13 = std_list13.emplace(std_list13.begin(), -10);
+        tests::compare("List13 iter vs std", *iter13, *std_iter13);
         tests::compare("List13 vs std", list13, std_list13);
+
+        std::list<int> std_list14{ 0, 10, 20, 30 };
+        auto std_iter14 = std_list14.emplace(std_list14.end(), 40);
+        tests::compare("List14 iter vs std", *std_iter14, *(--std_list14.end()));
+        tests::compare("List14 vs std", list14, std_list14);
+
+        std::list<int> std_list15{ 0, 10, 20, 30 };
+        auto std_ref15 = std_list15.emplace_back(40);
+        tests::compare("List15 ref vs std", ref15, std_ref15);
+        tests::compare("List15 vs std", list15, std_list15);
+
+        std::list<int> std_list16;
+        std_list16.emplace_back(10);
+        std_list16.emplace_back(20);
+        std_list16.emplace_back(30);
+        tests::compare("List16 vs std", list16, std_list16);
 
 
         tests::print_stats();

--- a/tests/list/list_grow_test.cpp
+++ b/tests/list/list_grow_test.cpp
@@ -152,6 +152,14 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected16 = { 10, 20, 30 };
         tests::compare("List16", list16, expected16);
 
+        dsa::List<std::unique_ptr<int>> list17{};
+        auto ptr17 = std::make_unique<int>(1);
+        list17.push_back(std::move(ptr17));
+        constexpr int expected17{ 1 };
+        tests::compare("List17 front", *list17.front(), expected17);
+        tests::compare("List17 back", *list17.back(), expected17);
+        tests::compare("ptr17 == nullptr", ptr17 == nullptr, true);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -215,6 +223,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list16.emplace_back(20);
         std_list16.emplace_back(30);
         tests::compare("List16 vs std", list16, std_list16);
+
+        std::list<std::unique_ptr<int>> std_list17{};
+        auto std_ptr17 = std::make_unique<int>(1);
+        std_list17.push_back(std::move(std_ptr17));
+        tests::compare("List17 front vs std", *list17.front(), *std_list17.front());
+        tests::compare("List17 back vs std", *list17.back(), *std_list17.back());
+        tests::compare("ptr17 == nullptr vs std", ptr17 == nullptr, std_ptr17 == nullptr);
 
 
         tests::print_stats();

--- a/tests/list/list_grow_test.cpp
+++ b/tests/list/list_grow_test.cpp
@@ -12,6 +12,7 @@
 #include "common.h"
 #include "dsa/list.h"
 
+#include <cstddef>
 #include <exception>
 #include <initializer_list>
 #include <iostream>
@@ -59,7 +60,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list3.push_front(20);
         iterator = list3.insert(list3.cbegin(), 10);
         list3.insert(iterator, { 1, 2, 3 });
-        list3.insert(list3.cbegin()[list3.size() - 1], 60);
+        list3.insert(std::next(list3.cbegin(), static_cast<ptrdiff_t>(list3.size() - 1)), 60);
         const std::initializer_list<int> expected3 = { 1, 2, 3, 10, 20, 30, 40, 60, 50 };
         tests::compare("List3", list3, expected3);
 

--- a/tests/list/list_grow_test.cpp
+++ b/tests/list/list_grow_test.cpp
@@ -90,6 +90,42 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         iter8 = list8.insert(iter8, { 10, 20, 30 });
         tests::compare("iter8 == nullptr", iter8 == nullptr, true);
 
+        dsa::List<int> list9;
+        auto ref9 = list9.emplace_front(30);
+        tests::compare("List9 ref", ref9, list9.front());
+        ref9 = list9.emplace_front(20);
+        tests::compare("List9 ref", ref9, list9.front());
+        list9.emplace_front(10);
+        list9.emplace_front(5);
+        list9.emplace_front(0);
+        const std::initializer_list<int> expected9 = { 0, 5, 10, 20, 30 };
+        tests::compare("List9", list9, expected9);
+
+        dsa::List<int> list10{ 0, 10, 20, 30 };
+        auto iter10 = list10.emplace(list10.begin(), -10);
+        tests::compare("List10 iter", *iter10, *list10.begin());
+        const std::initializer_list<int> expected10 = { -10, 0, 10, 20, 30 };
+        tests::compare("List10", list10, expected10);
+
+        dsa::List<int> list11{ 0, 10, 20, 30 };
+        auto iter11 = list11.emplace(list11.end(), 40);
+        tests::compare("List11 iter", *iter11, *(--list11.end()));
+        const std::initializer_list<int> expected11 = { 0, 10, 20, 30, 40 };
+        tests::compare("List11", list11, expected11);
+
+        dsa::List<int> list12{ 0, 10, 20, 30 };
+        auto ref12 = list12.emplace_back(40);
+        tests::compare("List12 ref", ref12, list12.back());
+        const std::initializer_list<int> expected12 = { 0, 10, 20, 30, 40 };
+        tests::compare("List12", list12, expected12);
+
+        dsa::List<int> list13;
+        list13.emplace_back(10);
+        list13.emplace_back(20);
+        list13.emplace_back(30);
+        const std::initializer_list<int> expected13 = { 10, 20, 30 };
+        tests::compare("List13", list13, expected13);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -104,6 +140,36 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::List<int> std_list7{ 40 };
         std_list7.insert(std_list7.begin(), { 10, 20, 30 });
         tests::compare("List7 vs std", list7, std_list7);
+
+        std::list<int> std_list9;
+        std_list9.emplace_front(30);
+        auto std_ref9 = std_list9.emplace_front(20);
+        tests::compare("List9 ref vs std", ref9, std_ref9);
+        std_list9.emplace_front(10);
+        std_list9.emplace_front(5);
+        std_list9.emplace_front(0);
+        tests::compare("List9 vs std", list9, std_list9);
+
+        std::list<int> std_list10{ 0, 10, 20, 30 };
+        auto std_iter10 = std_list10.emplace(std_list10.begin(), -10);
+        tests::compare("List10 iter vs std", *iter10, *std_iter10);
+        tests::compare("List10 vs std", list10, std_list10);
+
+        std::list<int> std_list11{ 0, 10, 20, 30 };
+        auto std_iter11 = std_list11.emplace(std_list11.end(), 40);
+        tests::compare("List11 iter vs std", *std_iter11, *(--std_list11.end()));
+        tests::compare("List11 vs std", list11, std_list11);
+
+        std::list<int> std_list12{ 0, 10, 20, 30 };
+        auto std_ref12 = std_list12.emplace_back(40);
+        tests::compare("List12 ref vs std", ref12, std_ref12);
+        tests::compare("List12 vs std", list12, std_list12);
+
+        std::list<int> std_list13;
+        std_list13.emplace_back(10);
+        std_list13.emplace_back(20);
+        std_list13.emplace_back(30);
+        tests::compare("List13 vs std", list13, std_list13);
 
 
         tests::print_stats();

--- a/tests/list/list_grow_test.cpp
+++ b/tests/list/list_grow_test.cpp
@@ -160,6 +160,14 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List17 back", *list17.back(), expected17);
         tests::compare("ptr17 == nullptr", ptr17 == nullptr, true);
 
+        dsa::List<std::unique_ptr<int>> list18{};
+        auto ptr18 = std::make_unique<int>(1);
+        list18.push_front(std::move(ptr18));
+        constexpr int expected18{ 1 };
+        tests::compare("List18 front", *list18.front(), expected18);
+        tests::compare("List18 back", *list18.back(), expected18);
+        tests::compare("ptr18 == nullptr", ptr18 == nullptr, true);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -230,6 +238,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List17 front vs std", *list17.front(), *std_list17.front());
         tests::compare("List17 back vs std", *list17.back(), *std_list17.back());
         tests::compare("ptr17 == nullptr vs std", ptr17 == nullptr, std_ptr17 == nullptr);
+
+        std::list<std::unique_ptr<int>> std_list18{};
+        auto std_ptr18 = std::make_unique<int>(1);
+        std_list18.push_front(std::move(std_ptr18));
+        tests::compare("List18 front vs std", *list18.front(), *std_list18.front());
+        tests::compare("List18 backvs std", *list18.back(), *std_list18.back());
+        tests::compare("ptr18 == nullptr vs std", ptr18 == std_ptr18, true);
 
 
         tests::print_stats();

--- a/tests/list/list_itors_test.cpp
+++ b/tests/list/list_itors_test.cpp
@@ -200,70 +200,187 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("citer11e", *citer11e, 30);
 
         // increment iterator
-        dsa::List<int> list12 = dsa::List<int>{ 10, 20, 30 };
-        std::cout << "List12\t" << list12 << '\n';
-        auto it_12 = list12.begin();
-        tests::compare("it_12", *it_12, 10);
-        it_12++;
-        tests::compare("it_12", *it_12, 20);
-        it_12++;
-        tests::compare("it_12", *it_12, 30);
-        it_12++;
+        dsa::List<int> list12a = dsa::List<int>{ 10, 20, 30 };
+        std::cout << "List12a\t" << list12a << '\n';
+        auto it_12a = list12a.begin();
+        tests::compare("it_12", *it_12a, 10);
+        ++it_12a;
+        tests::compare("it_12a", *it_12a, 20);
+        ++it_12a;
+        tests::compare("it_12a", *it_12a, 30);
+        ++it_12a;
+        ++it_12a;
+        std::cout << '\n';
+
+        dsa::List<int> list12b = dsa::List<int>{ 10, 20, 30 };
+        std::cout << "List12b\t" << list12b << '\n';
+        auto it_12b = list12b.begin();
+        tests::compare("it_12b", *it_12b, 10);
+        it_12b++;
+        tests::compare("it_12", *it_12b, 20);
+        it_12b++;
+        tests::compare("it_12", *it_12b, 30);
+        it_12b++;
+        it_12b++;
         std::cout << '\n';
 
         // increment const_iterator
-        const dsa::List<int> list13 = dsa::List<int>{ 10, 20, 30 };
-        std::cout << "List13\t" << list13 << '\n';
+        const dsa::List<int> list13a = dsa::List<int>{ 10, 20, 30 };
+        std::cout << "List13a\t" << list13a << '\n';
+        auto cit_13a = list13a.cbegin();
+        tests::compare("cit_13a", *cit_13a, 10);
+        ++cit_13a;
+        tests::compare("cit_13a", *cit_13a, 20);
+        ++cit_13a;
+        tests::compare("cit_13a", *cit_13a, 30);
+        ++cit_13a;
+        ++cit_13a;
+        std::cout << '\n';
 
-        auto cit_13 = list13.cbegin();
-        tests::compare("cit_13", *cit_13, 10);
-        cit_13++;
-        tests::compare("cit_13", *cit_13, 20);
-        cit_13++;
-        tests::compare("cit_13", *cit_13, 30);
-        cit_13++;
+        const dsa::List<int> list13b = dsa::List<int>{ 10, 20, 30 };
+        std::cout << "List13b\t" << list13b << '\n';
+        auto cit_13b = list13b.cbegin();
+        tests::compare("cit_13b", *cit_13b, 10);
+        cit_13b++;
+        tests::compare("cit_13b", *cit_13b, 20);
+        cit_13b++;
+        tests::compare("cit_13b", *cit_13b, 30);
+        cit_13b++;
+        cit_13b++;
         std::cout << '\n';
 
         // decrement iterator
-        dsa::List<int> list14 = dsa::List<int>{ 10, 20, 30 };
-        std::cout << "List14\t" << list14 << '\n';
-        auto it_14 = list14.end();
-        it_14--;
-        tests::compare("it_14", *it_14, 30);
-        --it_14;
-        tests::compare("it_14", *it_14, 20);
-        --it_14;
-        tests::compare("it_14", *it_14, 10);
-        --it_14;
+        dsa::List<int> list14a = dsa::List<int>{ 10, 20, 30 };
+        std::cout << "List14a\t" << list14a << '\n';
+        auto it_14a = list14a.end();
+        --it_14a;
+        tests::compare("it_14a", *it_14a, 30);
+        --it_14a;
+        tests::compare("it_14a", *it_14a, 20);
+        --it_14a;
+        tests::compare("it_14a", *it_14a, 10);
+        --it_14a;
+        --it_14a;
+        std::cout << '\n';
+
+        dsa::List<int> list14b = dsa::List<int>{ 10, 20, 30 };
+        std::cout << "List14b\t" << list14b << '\n';
+        auto it_14b = list14b.end();
+        it_14b--;
+        tests::compare("it_14b", *it_14b, 30);
+        it_14b--;
+        tests::compare("it_14b", *it_14b, 20);
+        it_14b--;
+        tests::compare("it_14b", *it_14b, 10);
+        it_14b--;
+        it_14b--;
         std::cout << '\n';
 
         // decrement const_iterator
-        const dsa::List<int> list15 = dsa::List<int>{ 10, 20, 30 };
-        std::cout << "List15\t" << list15 << '\n';
-        auto cit_15 = list15.cend();
-        cit_15--;
-        tests::compare("cit_15", *cit_15, 30);
-        --cit_15;
-        tests::compare("cit_15", *cit_15, 20);
-        --cit_15;
-        tests::compare("cit_15", *cit_15, 10);
-        --cit_15;
+        const dsa::List<int> list15a = dsa::List<int>{ 10, 20, 30 };
+        std::cout << "List15a\t" << list15a << '\n';
+        auto cit_15a = list15a.cend();
+        --cit_15a;
+        tests::compare("cit_15a", *cit_15a, 30);
+        --cit_15a;
+        tests::compare("cit_15a", *cit_15a, 20);
+        --cit_15a;
+        tests::compare("cit_15a", *cit_15a, 10);
+        --cit_15a;
+        --cit_15a;
+
+        const dsa::List<int> list15b = dsa::List<int>{ 10, 20, 30 };
+        std::cout << "List15b\t" << list15b << '\n';
+        auto cit_15b = list15b.cend();
+        cit_15b--;
+        tests::compare("cit_15b", *cit_15b, 30);
+        cit_15b--;
+        tests::compare("cit_15b", *cit_15b, 20);
+        cit_15b--;
+        tests::compare("cit_15b", *cit_15b, 10);
+        cit_15b--;
+        cit_15b--;
 
         // test throwing 'runtime_error' exception from dereferencing invalid iterator
         try
         {
-            const dsa::List<int> list16;
-            std::cout << *list16.begin();
+            const dsa::List<int> list16a;
+            std::cout << *list16a.begin();
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
         }
         catch (const std::runtime_error&)
         {
-            std::cout << "list16 runtime error exception handled correctly\n\n";
+            std::cout << "list16a runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            const dsa::List<int> list16b;
+            std::cout << *list16b.rbegin();
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error&)
+        {
+            std::cout << "list16b runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            const dsa::List<int> list16c;
+            std::cout << *list16c.rend();
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error&)
+        {
+            std::cout << "list16c runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            const dsa::List<int> list16d;
+            std::cout << *list16d.crbegin();
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error&)
+        {
+            std::cout << "list16d runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            const dsa::List<int> list16e;
+            std::cout << *list16e.crend();
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error&)
+        {
+            std::cout << "list16e runtime error exception handled correctly\n\n";
         }
 
         try
         {
             const dsa::List<int> list17{ 1, 2, 3 };
-            std::cout << *list17.end();
+            std::cout << list17.begin().operator->() << '\n';
+            std::cout << list17.end().operator->() << '\n';
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
         }
         catch (const std::runtime_error&)
         {
@@ -272,8 +389,14 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         try
         {
-            const dsa::List<int> list18;
-            std::cout << list18.begin().operator->();
+            dsa::List<int> list18 = dsa::List<int>{};
+            auto it18 = list18.begin();
+            std::advance(it18, 5);
+            std::cout << *it18;
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
         }
         catch (const std::runtime_error&)
         {
@@ -282,9 +405,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         try
         {
-            const dsa::List<int> list19{ 1, 2, 3 };
-            std::cout << list19.begin().operator->();
-            std::cout << list19.end().operator->();
+            const dsa::List<int> list19{};
+            std::cout << list19.front();
+            std::cout << list19.back();
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
         }
         catch (const std::runtime_error&)
         {
@@ -295,11 +422,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto iter20 = list20.begin();
         std::advance(iter20, 1);
         tests::compare("iter20 == nullptr", iter20 == nullptr, true);
-
-
-
-
-
 
         // test iterators traversal
         dsa::List<int> list21 = { 0, 10, 20, 30, 40 };

--- a/tests/list/list_itors_test.cpp
+++ b/tests/list/list_itors_test.cpp
@@ -297,6 +297,49 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("iter20 == nullptr", iter20 == nullptr, true);
 
 
+
+
+
+
+        // test iterators traversal
+        dsa::List<int> list21 = { 0, 10, 20, 30, 40 };
+        const std::list<int> temp21(list21.begin(), list21.end());
+        tests::compare("list21 begin()", *list21.begin(), 0);
+        auto iter21 = list21.begin();
+        std::advance(iter21, 1);
+        tests::compare("list21 begin()++", *iter21, 10);
+        iter21 = list21.end();
+        std::advance(iter21, -1);
+        tests::compare("list21 end()--", *iter21, 40);
+        tests::compare("list21 end()-- == back()", *iter21, list21.back());
+        tests::compare("list21 iter", list21, temp21);
+
+        // test const iterator traversal
+        const auto& list22 = list21;
+        const std::list<int> temp22(list22.cbegin(), list22.cend());
+        tests::compare("list22 cbegin()", *list22.cbegin(), 0);
+        auto citer22 = list22.cbegin();
+        std::advance(citer22, 1);
+        tests::compare("list22 cbegin()++", *citer22, 10);
+        citer22 = list22.cend();
+        std::advance(citer22, -1);
+        tests::compare("list22 cend()--", *citer22, 40);
+        tests::compare("list22 cend() == back()", *citer22, list22.back());
+        tests::compare("list22 const iter", list22, temp22);
+
+        // test reverse iterator traversal
+        dsa::List<int> list23{ 0, 1, 2, 3, 4 };
+        auto iter23 = list23.rend();
+        std::advance(iter23, -1);
+        tests::compare("list23 rend()--", *iter23, 0);
+        iter23 = list23.rbegin();
+        std::advance(iter23, 1);
+        tests::compare("list23 rbegin()++", *iter23, 3);
+        const std::list<int> temp23(list23.rbegin(), list23.rend());
+        const dsa::List<int> reversed23{ 4, 3, 2, 1, 0 };
+        tests::compare("list23 reverse iter", reversed23, temp23);
+
+
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list1{ 0, 10, 20 };

--- a/tests/list/list_merge_test.cpp
+++ b/tests/list/list_merge_test.cpp
@@ -162,6 +162,75 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // NOLINTNEXTLINE(bugprone-use-after-move)
         tests::compare("List28", list28, il_1);
 
+        dsa::List<std::string> list29{ "1a", "1b", "2a" };
+        dsa::List<std::string> list30{ "2b", "1c", "1d" };
+        list29.sort();
+        list30.sort();
+        list29.merge(list30);
+        const std::initializer_list<std::string> expected29{ "1a", "1b", "1c", "1d", "2a", "2b" };
+        tests::compare("List29", list29, expected29);
+        const std::initializer_list<std::string> expected30{};
+        tests::compare("List30", list30, expected30);
+
+        dsa::List<std::string> list31{ "1a", "1b", "2a" };
+        dsa::List<std::string> list32{ "2b", "1c", "1d" };
+        list31.sort(std::less<>());
+        list32.sort(std::less<>());
+        list31.merge(list32, std::less<>());
+        const std::initializer_list<std::string> expected31{ "1a", "1b", "1c", "1d", "2a", "2b" };
+        tests::compare("List31", list31, expected31);
+        const std::initializer_list<std::string> expected32{};
+        tests::compare("List32", list32, expected32);
+
+        dsa::List<std::string> list33{ "1a", "1b", "2a" };
+        dsa::List<std::string> list34{ "2b", "1c", "1d" };
+        list33.sort(std::greater<>());
+        list34.sort(std::greater<>());
+        list33.merge(list34, std::greater<>());
+        const std::initializer_list<std::string> expected33{ "2b", "2a", "1d", "1c", "1b", "1a" };
+        tests::compare("List33", list33, expected33);
+        const std::initializer_list<std::string> expected34{};
+        tests::compare("List34", list34, expected34);
+
+        dsa::List<std::string> list35{ "2a", "1a", "1b" };
+        dsa::List<std::string> list36{};
+        list35.sort(std::less<>());
+        list36.sort(std::less<>());
+        list35.merge(list36, std::less<>());
+        const std::initializer_list<std::string> expected35{ "1a", "1b", "2a" };
+        tests::compare("List35", list35, expected35);
+        const std::initializer_list<std::string> expected36{};
+        tests::compare("List36", list36, expected36);
+
+        dsa::List<std::string> list37{};
+        dsa::List<std::string> list38{ "2a", "1a", "1b" };
+        list37.sort(std::less<>());
+        list38.sort(std::less<>());
+        list37.merge(list38, std::less<>());
+        const std::initializer_list<std::string> expected37{ "1a", "1b", "2a" };
+        tests::compare("List37", list37, expected37);
+        const std::initializer_list<std::string> expected38{};
+        tests::compare("List38", list38, expected38);
+
+        dsa::List<std::string> list39{ "1a", "1b", "2a" };
+        dsa::List<std::string> list40{};
+        list39.sort(std::greater<>());
+        list40.sort(std::greater<>());
+        list40.merge(list39, std::greater<>());
+        const std::initializer_list<std::string> expected39{};
+        tests::compare("List39", list39, expected39);
+        const std::initializer_list<std::string> expected40{ "2a", "1b", "1a" };
+        tests::compare("List40", list40, expected40);
+
+        dsa::List<std::string> list41{};
+        dsa::List<std::string> list42{ "1a", "1b", "2a" };
+        list41.sort(std::greater<>());
+        list42.sort(std::greater<>());
+        list42.merge(list41, std::greater<>());
+        const std::initializer_list<std::string> expected41{};
+        tests::compare("List41", list41, expected41);
+        const std::initializer_list<std::string> expected42{ "2a", "1b", "1a" };
+        tests::compare("List42", list42, expected42);
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -261,6 +330,62 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_list26;
         std_list26.merge(std_list26);
         tests::compare("List26 vs std", list26, std_list26);
+
+        std::list<std::string> std_list29{ "1a", "1b", "2a" };
+        std::list<std::string> std_list30{ "2b", "1c", "1d" };
+        std_list29.sort();
+        std_list30.sort();
+        std_list29.merge(std_list30);
+        tests::compare("List29 vs std", list29, std_list29);
+        tests::compare("List30 vs std", list30, std_list30);
+
+        std::list<std::string> std_list31{ "1a", "1b", "2a" };
+        std::list<std::string> std_list32{ "2b", "1c", "1d" };
+        std_list31.sort(std::less<>());
+        std_list32.sort(std::less<>());
+        std_list31.merge(std_list32, std::less<>());
+        tests::compare("List31 vs std", list31, std_list31);
+        tests::compare("List32 vs std", list32, std_list32);
+
+        std::list<std::string> std_list33{ "1a", "1b", "2a" };
+        std::list<std::string> std_list34{ "2b", "1c", "1d" };
+        std_list33.sort(std::greater<>());
+        std_list34.sort(std::greater<>());
+        std_list33.merge(std_list34, std::greater<>());
+        tests::compare("List33 vs std", list33, std_list33);
+        tests::compare("List34 vs std", list34, std_list34);
+
+        std::list<std::string> std_list35{ "2a", "1a", "1b" };
+        std::list<std::string> std_list36{};
+        std_list35.sort(std::less<>());
+        std_list36.sort(std::less<>());
+        std_list35.merge(std_list36, std::less<>());
+        tests::compare("List35 vs std", list35, std_list35);
+        tests::compare("List36 vs std", list36, std_list36);
+
+        std::list<std::string> std_list37{};
+        std::list<std::string> std_list38{ "2a", "1a", "1b" };
+        std_list37.sort(std::less<>());
+        std_list38.sort(std::less<>());
+        std_list37.merge(std_list38, std::less<>());
+        tests::compare("List37 vs std", list37, std_list37);
+        tests::compare("List38 vs std", list38, std_list38);
+
+        std::list<std::string> std_list39{ "1a", "1b", "2a" };
+        std::list<std::string> std_list40{};
+        std_list39.sort(std::greater<>());
+        std_list40.sort(std::greater<>());
+        std_list40.merge(std_list39, std::greater<>());
+        tests::compare("List39 vs std", list39, std_list39);
+        tests::compare("List40 vs std", list40, std_list40);
+
+        std::list<std::string> std_list41{};
+        std::list<std::string> std_list42{ "1a", "1b", "2a" };
+        std_list41.sort(std::greater<>());
+        std_list42.sort(std::greater<>());
+        std_list42.merge(std_list41, std::greater<>());
+        tests::compare("List41 vs std", list41, std_list41);
+        tests::compare("List42 vs std", list42, std_list42);
 
 
         tests::print_stats();

--- a/tests/list/list_merge_test.cpp
+++ b/tests/list/list_merge_test.cpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <initializer_list>
 #include <iostream>
+#include <iterator>
 #include <list>
 #include <utility>
 
@@ -232,6 +233,42 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<std::string> expected42{ "2a", "1b", "1a" };
         tests::compare("List42", list42, expected42);
 
+        // test order of equal elements
+        dsa::List<int> list43{ 1, 1 };
+        auto addr43_1 = list43.begin();
+        auto addr43_2 = std::next(list43.begin());
+        dsa::List<int> list44{ 1, 2 };
+        auto addr44_1 = list44.begin();
+        auto addr44_2 = std::next(list44.begin());
+        list43.merge(list44);
+        const std::initializer_list<int> expected43 = { 1, 1, 1, 2 };
+        tests::compare("List43", list43, expected43);
+        const std::initializer_list<int> expected44 = {};
+        tests::compare("List44", list44, expected44);
+        tests::compare("List43 it 43_1", list43.begin() == addr43_1, true);
+        tests::compare("List43 it 43_2", std::next(list43.begin(), 1) == addr43_2, true);
+        tests::compare("List43 it 44_1", std::next(list43.begin(), 2) == addr44_1, true);
+        tests::compare("List43 it 44_2", std::next(list43.begin(), 3) == addr44_2, true);
+
+        dsa::List<int> list45{ 1, 1 };
+        list45.sort(std::greater<>());
+        auto addr45_1 = list45.begin();
+        auto addr45_2 = std::next(list45.begin());
+        dsa::List<int> list46{ 1, 2 };
+        list46.sort(std::greater<>());
+        auto addr46_1 = list46.begin();
+        auto addr46_2 = std::next(list46.begin());
+        list45.merge(list46, std::greater<>());
+        const std::initializer_list<int> expected45 = { 2, 1, 1, 1 };
+        tests::compare("List45", list45, expected45);
+        const std::initializer_list<int> expected46 = {};
+        tests::compare("List46", list46, expected46);
+        tests::compare("List45 it 48_1", list45.begin() == addr46_1, true);
+        tests::compare("List45 it 47_1", std::next(list45.begin(), 1) == addr45_1, true);
+        tests::compare("List45 it 47_2", std::next(list45.begin(), 2) == addr45_2, true);
+        tests::compare("List45 it 48_2", std::next(list45.begin(), 3) == addr46_2, true);
+
+
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list1{ il_1 };
@@ -386,6 +423,36 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list42.merge(std_list41, std::greater<>());
         tests::compare("List41 vs std", list41, std_list41);
         tests::compare("List42 vs std", list42, std_list42);
+
+        std::list<int> std_list43{ 1, 1 };
+        auto std_addr43_1 = std_list43.begin();
+        auto std_addr43_2 = std::next(std_list43.begin());
+        std::list<int> std_list44{ 1, 2 };
+        auto std_addr44_1 = std_list44.begin();
+        auto std_addr44_2 = std::next(std_list44.begin());
+        std_list43.merge(std_list44);
+        tests::compare("List43 vs std", list43, std_list43);
+        tests::compare("List44 vs std", list44, std_list44);
+        tests::compare("List43 it 43_1 vs std", std_list43.begin() == std_addr43_1, true);
+        tests::compare("List43 it 43_2 vs std", std::next(std_list43.begin(), 1) == std_addr43_2, true);
+        tests::compare("List43 it 44_1 vs std", std::next(std_list43.begin(), 2) == std_addr44_1, true);
+        tests::compare("List43 it 44_2 vs std", std::next(std_list43.begin(), 3) == std_addr44_2, true);
+
+        std::list<int> std_list45{ 1, 1 };
+        std_list45.sort(std::greater<>());
+        auto std_addr45_1 = std_list45.begin();
+        auto std_addr45_2 = std::next(std_list45.begin());
+        std::list<int> std_list46{ 1, 2 };
+        std_list46.sort(std::greater<>());
+        auto std_addr46_1 = std_list46.begin();
+        auto std_addr46_2 = std::next(std_list46.begin());
+        std_list45.merge(std_list46, std::greater<>());
+        tests::compare("List45 vs std", list45, std_list45);
+        tests::compare("List46 vs std", list46, std_list46);
+        tests::compare("List45 it 46_1 vs std", std_list45.begin() == std_addr46_1, true);
+        tests::compare("List45 it 45_1 vs std", std::next(std_list45.begin(), 1) == std_addr45_1, true);
+        tests::compare("List45 it 45_2 vs std", std::next(std_list45.begin(), 2) == std_addr45_2, true);
+        tests::compare("List45 it 46_2 vs std", std::next(std_list45.begin(), 3) == std_addr46_2, true);
 
 
         tests::print_stats();

--- a/tests/list/list_merge_test.cpp
+++ b/tests/list/list_merge_test.cpp
@@ -13,6 +13,7 @@
 #include "dsa/list.h"
 
 #include <exception>
+#include <functional>
 #include <initializer_list>
 #include <iostream>
 #include <list>
@@ -81,14 +82,77 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // NOLINTNEXTLINE(bugprone-use-after-move)
         tests::compare("List12", list12, expected12);
 
-        // self merge
-        dsa::List<int> list13{ il_1 };
-        list13.merge(list13);
-        tests::compare("List13", list13, il_1);
+        // merging using non default compration argument
 
-        dsa::List<int> list14;
-        list14.merge(list14);
-        tests::compare("List14", list14, {});
+        dsa::List<int> list13 = dsa::List<int>(il_1);
+        dsa::List<int> list14 = dsa::List<int>(il_2);
+        list13.sort(std::greater<>());
+        list14.sort(std::greater<>());
+        list13.merge(list14, std::greater<>());
+        const std::initializer_list<int> expected13 = { 50, 40, 30, 20, 10, 5, 4, 3, 2, 1 };
+        tests::compare("List13", list13, expected13);
+        const std::initializer_list<int> expected14 = {};
+        tests::compare("List14", list14, expected14);
+
+        dsa::List<int> list15 = dsa::List<int>(il_1);
+        dsa::List<int> list16;
+        list15.sort(std::greater<>());
+        list16.sort(std::greater<>());
+        list16.merge(list15, std::greater<>());
+        const std::initializer_list<int> expected15{};
+        tests::compare("List15", list15, expected15);
+        const std::initializer_list<int> expected16{ 5, 4, 3, 2, 1 };
+        tests::compare("List16", list16, expected16);
+
+        dsa::List<int> list17 = dsa::List<int>(il_3);
+        dsa::List<int> list18 = dsa::List<int>(il_4);
+        list17.sort(std::greater<>());
+        list18.sort(std::greater<>());
+        list17.merge(list18, std::greater<>());
+        const std::initializer_list<int> expected17{ 9, 7, 6, 5, 4, 3, 2, 1, 1, 1 };
+        tests::compare("List17", list17, expected17);
+        const std::initializer_list<int> expected18{};
+        tests::compare("List18", list18, expected18);
+
+        dsa::List<int> list19 = dsa::List<int>(il_4);
+        dsa::List<int> list20 = dsa::List<int>(il_3);
+        list19.sort(std::greater<>());
+        list20.sort(std::greater<>());
+        list19.merge(list20, std::greater<>());
+        const std::initializer_list<int> expected19{ 9, 7, 6, 5, 4, 3, 2, 1, 1, 1 };
+        tests::compare("List19", list19, expected19);
+        const std::initializer_list<int> expected20{};
+        tests::compare("List20", list20, expected20);
+
+        dsa::List<int> list21 = dsa::List<int>(il_2);
+        dsa::List<int> list22 = dsa::List<int>(il_3);
+        list21.sort(std::greater<>());
+        list22.sort(std::greater<>());
+        list21.merge(list22, std::greater<>());
+        const std::initializer_list<int> expected21{ 50, 40, 30, 20, 10, 7, 5, 3, 1, 1 };
+        tests::compare("List21", list21, expected21);
+        const std::initializer_list<int> expected22{};
+        tests::compare("List22", list22, expected22);
+
+        dsa::List<int> list23 = dsa::List<int>(il_3);
+        dsa::List<int> list24 = dsa::List<int>(il_2);
+        list23.sort(std::greater<>());
+        list24.sort(std::greater<>());
+        list23.merge(std::move(list24), std::greater<>());
+        const std::initializer_list<int> expected23{ 50, 40, 30, 20, 10, 7, 5, 3, 1, 1 };
+        tests::compare("List23", list23, expected23);
+        const std::initializer_list<int> expected24{};
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        tests::compare("List24", list24, expected24);
+
+        // self merge
+        dsa::List<int> list25{ il_1 };
+        list25.merge(list25);
+        tests::compare("List25", list25, il_1);
+
+        dsa::List<int> list26;
+        list26.merge(list26);
+        tests::compare("List26", list26, {});
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -116,6 +180,79 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list7.merge(std_list8);
         tests::compare("List7 vs std", list7, std_list7);
         tests::compare("List8 vs std", list8, std_list8);
+
+        std::list<int> std_list9{ il_2 };
+        std::list<int> std_list10{ il_3 };
+        std_list9.merge(std_list10);
+        tests::compare("List9 vs std", list9, std_list9);
+        tests::compare("List10 vs std", list10, std_list10);
+
+        std::list<int> std_list11{ il_3 };
+        std::list<int> std_list12{ il_2 };
+        std_list11.merge(std::move(std_list12));
+        tests::compare("List11 vs std", list11, std_list11);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        tests::compare("List12 vs std", list12, std_list12);
+
+        // merging using non default compration argument
+
+        std::list<int> std_list13{ il_1 };
+        std::list<int> std_list14{ il_2 };
+        std_list13.sort(std::greater<>());
+        std_list14.sort(std::greater<>());
+        std_list13.merge(std_list14, std::greater<>());
+        tests::compare("List13 vs std", list13, std_list13);
+        tests::compare("List14 vs std", list14, std_list14);
+
+        std::list<int> std_list15{ il_1 };
+        std::list<int> std_list16;
+        std_list15.sort(std::greater<>());
+        std_list16.sort(std::greater<>());
+        std_list16.merge(std_list15, std::greater<>());
+        tests::compare("List15 vs std", list15, std_list15);
+        tests::compare("List16 vs std", list16, std_list16);
+
+        std::list<int> std_list17{ il_3 };
+        std::list<int> std_list18{ il_4 };
+        std_list17.sort(std::greater<>());
+        std_list18.sort(std::greater<>());
+        std_list17.merge(std_list18, std::greater<>());
+        tests::compare("List17 vs std", list17, std_list17);
+        tests::compare("List18 vs std", list18, std_list18);
+
+        std::list<int> std_list19{ il_4 };
+        std::list<int> std_list20{ il_3 };
+        std_list19.sort(std::greater<>());
+        std_list20.sort(std::greater<>());
+        std_list19.merge(std_list20, std::greater<>());
+        tests::compare("List19 vs std", list19, std_list19);
+        tests::compare("List20 vs std", list20, std_list20);
+
+        std::list<int> std_list21{ il_2 };
+        std::list<int> std_list22{ il_3 };
+        std_list21.sort(std::greater<>());
+        std_list22.sort(std::greater<>());
+        std_list21.merge(std_list22, std::greater<>());
+        tests::compare("List21 vs std", list21, std_list21);
+        tests::compare("List22 vs std", list22, std_list22);
+
+        std::list<int> std_list23{ il_3 };
+        std::list<int> std_list24{ il_2 };
+        std_list23.sort(std::greater<>());
+        std_list24.sort(std::greater<>());
+        std_list23.merge(std::move(std_list24), std::greater<>());
+        tests::compare("List23 vs std", list23, std_list23);
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        tests::compare("List24 vs std", list24, std_list24);
+
+        // self merge
+        std::list<int> std_list25{ il_1 };
+        std_list25.merge(std_list25);
+        tests::compare("List25 vs std", list25, std_list25);
+
+        std::list<int> std_list26;
+        std_list26.merge(std_list26);
+        tests::compare("List26 vs std", list26, std_list26);
 
 
         tests::print_stats();

--- a/tests/list/list_merge_test.cpp
+++ b/tests/list/list_merge_test.cpp
@@ -154,6 +154,14 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list26.merge(list26);
         tests::compare("List26", list26, {});
 
+        // self merge with move semantics should be aborted
+        // compare result with initial input
+        dsa::List<int> list28{ il_1 };
+        list28.merge(std::move(list28), std::greater<>());
+        // intentional use of moved object
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        tests::compare("List28", list28, il_1);
+
 
         std::cout << "Compare operations results with std container\n\n";
 

--- a/tests/list/list_operators_test.cpp
+++ b/tests/list/list_operators_test.cpp
@@ -37,20 +37,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "List2:\t" << list2 << '\n';
         std::cout << "List3:\t" << list3 << "\n\n";
 
-        const dsa::List<int> list4(list1 + list2);
-        const std::initializer_list<int> expected4 = { 1, 2, 3, 1, 2, 6 };
-        tests::compare("List4", list4, expected4);
-
-        dsa::List<int> list5(1, 0);
-        list5 += list2;
-        const std::initializer_list<int> expected5 = { 0, 1, 2, 6 };
-        tests::compare("List5", list5, expected5);
-
-        dsa::List<int> list6(1, 0);
-        list6 += { 1, 2, 6 };
-        const std::initializer_list<int> expected6 = { 0, 1, 2, 6 };
-        tests::compare("List6", list6, expected6);
-
         std::cout << "Compare operators for objects of the same size\n\n";
 
         // intentional self-comparison, an object should be equal to itself

--- a/tests/list/list_operators_test.cpp
+++ b/tests/list/list_operators_test.cpp
@@ -12,10 +12,14 @@
 #include "common.h"
 #include "dsa/list.h"
 
+#include <cassert>
+#include <compare>
 #include <exception>
 #include <initializer_list>
 #include <iostream>
+#include <limits>
 #include <list>
+#include <type_traits>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -67,6 +71,18 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List1 >= list2", list1 >= list2, false);
         tests::compare("List2 >= list1", list2 >= list1, true);
 
+        // test three way comparison
+
+        tests::compare("list1 <=> list2 !=", (list1 <=> list2) != 0, (list1 <=> list2) != 0);
+        tests::compare("list1 <=> list2 <", (list1 <=> list2) < 0, (list1 <=> list2) < 0);
+        tests::compare("list1 <=> list2 >", (list1 <=> list2) > 0, (list1 <=> list2) > 0);
+        tests::compare("list1 <=> list2 <=", (list1 <=> list2) <= 0, (list1 <=> list2) <= 0);
+        tests::compare("list1 <=> list2 >=", (list1 <=> list2) >= 0, (list1 <=> list2) >= 0);
+
+        tests::compare("list1 <=> list2 <", (list1 <=> list2) == std::weak_ordering::less, true);
+        tests::compare("list1 <=> list2 <>", (list1 <=> list2) != std::weak_ordering::equivalent, true);
+        tests::compare("list1 <=> list2 <=", (list1 <=> list2) != std::weak_ordering::greater, true);
+
         std::cout << "Compare operators for objects of different size\n\n";
 
         tests::compare("List1 == list3", list1 == list3, false);
@@ -93,6 +109,37 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List2 >= list3", list2 >= list3, true);
         tests::compare("List3 >= list2", list3 >= list2, false);
 
+        // test three way comparison
+
+        tests::compare("list1 <=> list3 ==", (list1 <=> list3) == 0, false);
+        tests::compare("list1 <=> list3 <", (list1 <=> list3) < 0, true);
+        tests::compare("list1 <=> list3 >", (list1 <=> list3) > 0, false);
+        tests::compare("list1 <=> list3 <=", (list1 <=> list3) <= 0, true);
+        tests::compare("list1 <=> list3 >=", (list1 <=> list3) >= 0, false);
+
+        tests::compare("list1 <=> list3 >=", (list1 <=> list3) != std::weak_ordering::less, false);
+        tests::compare("list1 <=> list3 ==", (list1 <=> list3) == std::weak_ordering::equivalent, false);
+        tests::compare("list1 <=> list3 <=", (list1 <=> list3) != std::weak_ordering::greater, true);
+
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::List<int>>, std::strong_ordering>,
+            "Int list should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::List<double>>, std::partial_ordering>,
+            "Double list should support strong ordering");
+
+        // test partial ordering
+        const dsa::List<double> list7{ 1.0, 2.0, 3.0 };
+        const dsa::List<double> list8{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() };
+        assert((list7 <=> list8) == std::partial_ordering::unordered);
+        tests::compare("list7 <=> list8 weak ordering", (list7 <=> list8) != std::weak_ordering::less, true);
+
+        // test noexcept
+
+        // operators
+        static_assert(!noexcept(dsa::List<tests::ThrowingType>{1} == dsa::List<tests::ThrowingType>{1}));
+        static_assert(!noexcept(dsa::List<tests::ThrowingType>{1} <=> dsa::List<tests::ThrowingType>{1}));
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -117,6 +164,21 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         tests::compare("List1 >= list2 vs std", list1 >= list2, std_list1 >= std_list2);
         tests::compare("List2 >= list1 vs std", list2 >= list1, std_list2 >= std_list1);
+
+        // test three way comparison
+
+        tests::compare("list1 <=> list2 vs std !=", (list1 <=> list2) != 0, (std_list1 <=> std_list2) != 0);
+        tests::compare("list1 <=> list2 vs std <", (list1 <=> list2) < 0, (std_list1 <=> std_list2) < 0);
+        tests::compare("list1 <=> list2 vs std >", (list1 <=> list2) > 0, (std_list1 <=> std_list2) > 0);
+        tests::compare("list1 <=> list2 vs std <=", (list1 <=> list2) <= 0, (std_list1 <=> std_list2) <= 0);
+        tests::compare("list1 <=> list2 vs std >=", (list1 <=> list2) >= 0, (std_list1 <=> std_list2) >= 0);
+
+        tests::compare("list1 <=> list2 vs std <",
+            (list1 <=> list2) == std::weak_ordering::less, (std_list1 <=> std_list2) == std::weak_ordering::less);
+        tests::compare("list1 <=> list2 vs std <>",
+            (list1 <=> list2) != std::weak_ordering::equivalent, (std_list1 <=> std_list2) != std::weak_ordering::equivalent);
+        tests::compare("list1 <=> list2 vs std <=",
+            (list1 <=> list2) != std::weak_ordering::greater, (std_list1 <=> std_list2) != std::weak_ordering::greater);
 
         std::cout << "Compare operators for objects of different size\n\n";
 
@@ -143,6 +205,44 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List3 >= list1 vs std", list3 >= list1, std_list3 >= std_list1);
         tests::compare("List2 >= list3 vs std", list2 >= list3, std_list2 >= std_list3);
         tests::compare("List3 >= list2 vs std", list3 >= list2, std_list3 >= std_list2);
+
+        // test three way comparison
+
+        tests::compare("list1 <=> list3 vs std ==", (list1 <=> list3) == 0, (std_list1 <=> std_list3) == 0);
+        tests::compare("list1 <=> list3 vs std <", (list1 <=> list3) < 0, (std_list1 <=> std_list3) < 0);
+        tests::compare("list1 <=> list3 vs std >", (list1 <=> list3) > 0, (std_list1 <=> std_list3) > 0);
+        tests::compare("list1 <=> list3 vs std <=", (list1 <=> list3) <= 0, (std_list1 <=> std_list3) <= 0);
+        tests::compare("list1 <=> list3 vs std >=", (list1 <=> list3) >= 0, (std_list1 <=> std_list3) >= 0);
+
+        tests::compare("list1 <=> list3 vs std >=",
+            (list1 <=> list3) != std::weak_ordering::less, (std_list1 <=> std_list3) != std::weak_ordering::less);
+        tests::compare("list1 <=> list3 vs std ==",
+            (list1 <=> list3) == std::weak_ordering::equivalent, (std_list1 <=> std_list3) == std::weak_ordering::equivalent);
+        tests::compare("list1 <=> list3 vs std <= ",
+            (list1 <=> list3) != std::weak_ordering::greater, (std_list1 <=> std_list3) != std::weak_ordering::greater);
+
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::list<int>>, std::strong_ordering>,
+            "Int list should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::list<double>>, std::partial_ordering>,
+            "Double list should support strong ordering");
+
+        // test partial ordering
+        const std::list<double> std_list7{ 1.0, 2.0, 3.0 };
+        const std::list<double> std_list8{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() };
+        assert((std_list7 <=> std_list8) == std::partial_ordering::unordered);
+        assert((list7 <=> list8) == (std_list7 <=> std_list8));
+        tests::compare("std_list7 <=> std_list8 weak ordering",
+            (std_list7 <=> std_list8) == std::partial_ordering::unordered, true);
+        tests::compare("(list7 <=> list8) == (std_list7 <=> std_list8)",
+            (list7 <=> list8) == (std_list7 <=> std_list8), true);
+
+        // test noexcept
+
+        // operators
+        static_assert(!noexcept(std::list<tests::ThrowingType>{1} == std::list<tests::ThrowingType>{1}));
+        static_assert(!noexcept(std::list<tests::ThrowingType>{1} <=> std::list<tests::ThrowingType>{1}));
 
 
         tests::print_stats();

--- a/tests/list/list_reverse_test.cpp
+++ b/tests/list/list_reverse_test.cpp
@@ -15,6 +15,7 @@
 #include <exception>
 #include <initializer_list>
 #include <iostream>
+#include <iterator>
 #include <list>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
@@ -27,9 +28,18 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "Start list_reverse_test:\n";
 
         dsa::List<int> list1 = dsa::List<int>({ 0, 10, 20, 30, 40, 50 });
+        auto iter1a = std::next(list1.begin());
+        auto ref1a_front = list1.front();
+        auto ref1a_back = list1.back();
         list1.reverse();
+        auto iter1b = std::next(list1.begin(), 4);
+        auto ref1b_front = list1.front();
+        auto ref1b_back = list1.back();
         const std::initializer_list<int> expected1 = { 50, 40, 30, 20, 10, 0 };
         tests::compare("List1", list1, expected1);
+        tests::compare("List1 iter", *iter1a, *iter1b);
+        tests::compare("List1 ref front-back", ref1a_front, ref1b_back);
+        tests::compare("List1 ref back-front", ref1a_back, ref1b_front);
 
         dsa::List<int> list2 = dsa::List<int>({ 0 });
         list2.reverse();
@@ -45,8 +55,20 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list1{ 0, 10, 20, 30, 40, 50 };
+        auto std_iter1a = std::next(std_list1.begin());
+        auto std_ref1a_front = std_list1.front();
+        auto std_ref1a_back = std_list1.back();
         std_list1.reverse();
+        auto std_iter1b = std::next(std_list1.begin(), 4);
+        auto std_ref1b_front = std_list1.front();
+        auto std_ref1b_back = std_list1.back();
         tests::compare("List1 vs std", list1, std_list1);
+        tests::compare("List1 iter1a vs std", *iter1a, *std_iter1a);
+        tests::compare("List1 iter1b vs std", *iter1b, *std_iter1b);
+        tests::compare("List1 ref front-back vs std", std_ref1a_front, std_ref1b_back);
+        tests::compare("List1 ref back-front vs std", std_ref1a_back, std_ref1b_front);
+        tests::compare("List1 ref front vs std", ref1b_front, std_ref1b_front);
+        tests::compare("List1 ref back vs std", ref1b_back, std_ref1b_back);
 
         std::list<int> std_list2{ 0 };
         std_list2.reverse();

--- a/tests/list/list_set_test.cpp
+++ b/tests/list/list_set_test.cpp
@@ -16,6 +16,7 @@
 #include <exception>
 #include <initializer_list>
 #include <iostream>
+#include <iterator>
 #include <list>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
@@ -53,7 +54,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected5{ 1, 2, 3, 4 };
         dsa::List<int> list5{ 10, 20, 30 };
         list5 = expected5;
-        tests::compare("List4", list5, expected5);
+        tests::compare("List5", list5, expected5);
+
+        dsa::List<int> list6 = dsa::List<int>({ 0, 10, 20 });
+        dsa::List<int> temp6 = dsa::List<int>({ 0, 1, 2, 3, 4, 5 });
+        list6.assign(std::next(temp6.begin(), 1), std::next(temp6.begin(), 4));
+        const std::initializer_list<int> expected6 = { 1, 2, 3 };
+        tests::compare("List6", list6, expected6);
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -72,6 +79,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_list5{ 10, 20, 30 };
         std_list5 = expected5;
         tests::compare("List5 vs std", list5, std_list5);
+
+        std::list<int> std_list6{ 0, 10, 20 };
+        std_list6.assign(std::next(temp6.begin(), 1), std::next(temp6.begin(), 4));
+        tests::compare("List6 vs std", list6, std_list6);
 
 
         tests::print_stats();

--- a/tests/list/list_set_test.cpp
+++ b/tests/list/list_set_test.cpp
@@ -46,6 +46,15 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list3.assign(expected3);
         tests::compare("List3", list3, expected3);
 
+        const std::initializer_list<int> expected4{ 1, 2, 3, 4 };
+        const dsa::List<int> list4 = expected4;
+        tests::compare("List4", list4, expected4);
+
+        const std::initializer_list<int> expected5{ 1, 2, 3, 4 };
+        dsa::List<int> list5{ 10, 20, 30 };
+        list5 = expected5;
+        tests::compare("List4", list5, expected5);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -56,6 +65,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_list3{ 0, 10, 20 };
         std_list3.assign(expected3);
         tests::compare("List3 vs std", list3, std_list3);
+
+        const std::list<int> std_list4 = expected4;
+        tests::compare("List4 vs std", list4, std_list4);
+
+        std::list<int> std_list5{ 10, 20, 30 };
+        std_list5 = expected5;
+        tests::compare("List5 vs std", list5, std_list5);
 
 
         tests::print_stats();

--- a/tests/list/list_set_test.cpp
+++ b/tests/list/list_set_test.cpp
@@ -12,7 +12,6 @@
 #include "common.h"
 #include "dsa/list.h"
 
-#include <cstddef>
 #include <exception>
 #include <initializer_list>
 #include <iostream>
@@ -39,24 +38,31 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List2", list2, expected2);
 
         dsa::List<int> list3 = dsa::List<int>({ 0, 10, 20 });
-        const std::initializer_list<int> expected3 = { 1, 2, 3, 4 };
-        list3.assign(expected3);
+        list3.assign(0, 1);
+        const std::initializer_list<int> expected3 = {};
         tests::compare("List3", list3, expected3);
 
+        dsa::List<int> list4 = dsa::List<int>({ 0, 10, 20 });
         const std::initializer_list<int> expected4{ 1, 2, 3, 4 };
-        const dsa::List<int> list4 = expected4;
+        list4.assign(expected4);
         tests::compare("List4", list4, expected4);
 
-        const std::initializer_list<int> expected5{ 1, 2, 3, 4 };
-        dsa::List<int> list5{ 10, 20, 30 };
-        list5 = expected5;
+        dsa::List<int> list5 = dsa::List<int>({ 0, 10, 20 });
+        dsa::List<int> temp5 = dsa::List<int>({ 0, 1, 2, 3, 4, 5 });
+        list5.assign(std::next(temp5.begin(), 1), std::next(temp5.begin(), 4));
+        const std::initializer_list<int> expected5 = { 1, 2, 3 };
         tests::compare("List5", list5, expected5);
 
         dsa::List<int> list6 = dsa::List<int>({ 0, 10, 20 });
-        dsa::List<int> temp6 = dsa::List<int>({ 0, 1, 2, 3, 4, 5 });
-        list6.assign(std::next(temp6.begin(), 1), std::next(temp6.begin(), 4));
-        const std::initializer_list<int> expected6 = { 1, 2, 3 };
+        constexpr int new_value{ 50 };
+        list6.front() = new_value;
+        const std::initializer_list<int> expected6{ new_value, 10, 20 };
         tests::compare("List6", list6, expected6);
+
+        dsa::List<int> list7 = dsa::List<int>({ 0, 10, 20 });
+        const std::initializer_list<int> expected7 = {};
+        list7.assign(expected7);
+        tests::compare("List7", list7, expected7);
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -70,19 +76,23 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List2 vs std", list2, std_list2);
 
         std::list<int> std_list3{ 0, 10, 20 };
-        std_list3.assign(expected3);
+        std_list3.assign(0, 1);
         tests::compare("List3 vs std", list3, std_list3);
 
         const std::list<int> std_list4 = expected4;
         tests::compare("List4 vs std", list4, std_list4);
 
-        std::list<int> std_list5{ 10, 20, 30 };
-        std_list5 = expected5;
+        std::list<int> std_list5{ 0, 10, 20 };
+        std_list5.assign(std::next(temp5.begin(), 1), std::next(temp5.begin(), 4));
         tests::compare("List5 vs std", list5, std_list5);
 
         std::list<int> std_list6{ 0, 10, 20 };
-        std_list6.assign(std::next(temp6.begin(), 1), std::next(temp6.begin(), 4));
+        std_list6.front() = new_value;
         tests::compare("List6 vs std", list6, std_list6);
+
+        std::list<int> std_list7{ 0, 10, 20 };
+        std_list7.assign(expected7);
+        tests::compare("List7 vs std", list7, std_list7);
 
 
         tests::print_stats();

--- a/tests/list/list_set_test.cpp
+++ b/tests/list/list_set_test.cpp
@@ -29,12 +29,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "Start list_set_test:\n";
 
         dsa::List<int> list1 = dsa::List<int>({ 0, 10, 20 });
-        // Try setting values for nodes with invalid indexes
-        constexpr int new_value{ 50 };
-        list1.set(static_cast<size_t>(-1), new_value);
-        list1.set(1, new_value);
-        list1.set(100, new_value);
-        const std::initializer_list<int> expected1{ 0, 50, 20 };
+        const std::initializer_list<int> expected1{ 0, 1, 2 };
+        list1 = expected1;
         tests::compare("List1", list1, expected1);
 
         dsa::List<int> list2 = dsa::List<int>({ 0, 10, 20 });
@@ -64,6 +60,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
 
         std::cout << "Compare operations results with std container\n\n";
+
+        std::list<int> std_list1{ 0, 10, 20 };
+        std_list1 = expected1;
+        tests::compare("List1 vs std", list1, std_list1);
 
         std::list<int> std_list2{ 0, 10, 20 };
         std_list2.assign(4, 1);

--- a/tests/list/list_shrink_test.cpp
+++ b/tests/list/list_shrink_test.cpp
@@ -163,11 +163,131 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List21", list21, expected21);
         tests::compare("List21 erase_if count", cnt21, std::size_t{ 3 });
 
-        dsa::List<int> list22 = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
-        auto cnt22 = dsa::erase_if(list22, [](int val) { return val <= 5; });
-        const std::initializer_list<int> expected22 = { 10, 7, 9 };
-        tests::compare("List22", list22, expected22);
-        tests::compare("List22 erase_if count", cnt22, std::size_t{ 3 });
+        dsa::List<int> list22a = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22a = dsa::erase_if(list22a, [](int val) { return val == 5; });
+        const std::initializer_list<int> expected22a = { 0, 10, 2, 7, 9 };
+        tests::compare("List22a", list22a, expected22a);
+        tests::compare("List22a erase_if count", cnt22a, std::size_t{ 1 });
+
+        dsa::List<int> list22b = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22b = dsa::erase_if(list22b, [](int val) { return val != 5; });
+        const std::initializer_list<int> expected22b = { 5 };
+        tests::compare("List22b", list22b, expected22b);
+        tests::compare("List22b erase_if count", cnt22b, std::size_t{ 5 });
+
+        dsa::List<int> list22c = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22c = dsa::erase_if(list22c, [](int val) { return val < 5; });
+        const std::initializer_list<int> expected22c = { 10, 5, 7, 9 };
+        tests::compare("List22c", list22c, expected22c);
+        tests::compare("List22c erase_if count", cnt22c, std::size_t{ 2 });
+
+        dsa::List<int> list22d = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22d = dsa::erase_if(list22d, [](int val) { return val > 5; });
+        const std::initializer_list<int> expected22d = { 0, 2, 5 };
+        tests::compare("List22d", list22d, expected22d);
+        tests::compare("List22d erase_if count", cnt22d, std::size_t{ 3 });
+
+        dsa::List<int> list22e = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22e = dsa::erase_if(list22e, [](int val) { return val <= 5; });
+        const std::initializer_list<int> expected22e = { 10, 7, 9 };
+        tests::compare("List22e", list22e, expected22e);
+        tests::compare("List22e erase_if count", cnt22e, std::size_t{ 3 });
+
+        dsa::List<int> list22f = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22f = dsa::erase_if(list22f, [](int val) { return val >= 5; });
+        const std::initializer_list<int> expected22f = { 0, 2 };
+        tests::compare("List22f", list22f, expected22f);
+        tests::compare("List22f erase_if count", cnt22f, std::size_t{ 4 });
+
+        dsa::List<int> list22g = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22g = dsa::erase_if(list22g, [](int val) { return val < (-5); });
+        const std::initializer_list<int> expected22g = { 0, 10, 2, 5, 7, 9 };
+        tests::compare("List22g", list22g, expected22g);
+        tests::compare("List22g erase_if count", cnt22g, std::size_t{ 0 });
+
+        dsa::List<int> list22h = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22h = dsa::erase_if(list22h, [](int val) { return val > (-5); });
+        const std::initializer_list<int> expected22h = { };
+        tests::compare("List22h", list22h, expected22h);
+        tests::compare("List22h erase_if count", cnt22h, std::size_t{ 6 });
+
+        dsa::List<int> list22i = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22i = dsa::erase_if(list22i, [](int val) { return val <= (-5); });
+        const std::initializer_list<int> expected22i = { 0, 10, 2, 5, 7, 9 };
+        tests::compare("List22i", list22i, expected22i);
+        tests::compare("List22i erase_if count", cnt22i, std::size_t{ 0 });
+
+        dsa::List<int> list22j = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22j = dsa::erase_if(list22j, [](int val) { return val >= (-5); });
+        const std::initializer_list<int> expected22j = { };
+        tests::compare("List22j", list22j, expected22j);
+        tests::compare("List22j erase_if count", cnt22j, std::size_t{ 6 });
+
+        dsa::List<int> list22k = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22k = dsa::erase_if(list22k, [](int val) { return val < 100; });
+        const std::initializer_list<int> expected22k = { };
+        tests::compare("List22k", list22k, expected22k);
+        tests::compare("List22k erase_if count", cnt22k, std::size_t{ 6 });
+
+        dsa::List<int> list22l = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22l = dsa::erase_if(list22l, [](int val) { return val > 100; });
+        const std::initializer_list<int> expected22l = { 0, 10, 2, 5, 7, 9 };
+        tests::compare("List22l", list22l, expected22l);
+        tests::compare("List22l erase_if count", cnt22l, std::size_t{ 0 });
+
+        dsa::List<int> list22m = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22m = dsa::erase_if(list22m, [](int val) { return val <= 100; });
+        const std::initializer_list<int> expected22m = { };
+        tests::compare("List22m", list22m, expected22m);
+        tests::compare("List22m erase_if count", cnt22m, std::size_t{ 6 });
+
+        dsa::List<int> list22n = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22n = dsa::erase_if(list22n, [](int val) { return val >= 100; });
+        const std::initializer_list<int> expected22n = { 0, 10, 2, 5, 7, 9 };
+        tests::compare("List22n", list22n, expected22n);
+        tests::compare("List22n erase_if count", cnt22n, std::size_t{ 0 });
+
+        dsa::List<int> list23a{};
+        auto cnt23a = list23a.remove_if([](int val) { return val == 0; });
+        const std::initializer_list<int> expected23a = { };
+        tests::compare("List23a", list23a, expected23a);
+        tests::compare("List23a removed count", cnt23a, std::size_t{ 0 });
+
+        dsa::List<int> list23b{};
+        auto cnt23b = list23b.remove_if([](int val) { return val != 0; });
+        const std::initializer_list<int> expected23b = { };
+        tests::compare("List23b", list23b, expected23b);
+        tests::compare("List23b removed count", cnt23b, std::size_t{ 0 });
+
+        dsa::List<int> list23c{};
+        auto cnt23c = list23c.remove_if([](int val) { return val < 0; });
+        const std::initializer_list<int> expected23c = { };
+        tests::compare("List23c", list23c, expected23c);
+        tests::compare("List23c removed count", cnt23c, std::size_t{ 0 });
+
+        dsa::List<int> list23d{};
+        auto cnt23d = list23d.remove_if([](int val) { return val > 0; });
+        const std::initializer_list<int> expected23d = { };
+        tests::compare("List23d", list23d, expected23d);
+        tests::compare("List23d removed count", cnt23d, std::size_t{ 0 });
+
+        dsa::List<int> list23e{};
+        auto cnt23e = list23e.remove_if([](int val) { return val <= 0; });
+        const std::initializer_list<int> expected23e = { };
+        tests::compare("List23e", list23e, expected23e);
+        tests::compare("List23e removed count", cnt23e, std::size_t{ 0 });
+
+        dsa::List<int> list23f{};
+        auto cnt23f = list23f.remove_if([](int val) { return val >= 0; });
+        const std::initializer_list<int> expected23f = { };
+        tests::compare("List23f", list23f, expected23f);
+        tests::compare("List23f removed count", cnt23f, std::size_t{ 0 });
+
+        dsa::List<int> list24{ 0, 1, 2, 3, 4, 5 };
+        auto iter24 = list24.erase(std::next(list24.end()), std::next(list24.end()));
+        tests::compare("iter24 == nullptr", iter24 == nullptr, true);
+        iter24 = list24.erase(list24.begin(), std::next(list24.end()));
+        tests::compare("iter24 == nullptr", iter24 == nullptr, true);
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -265,11 +385,11 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List21 vs std", list21, std_list21);
         tests::compare("List21 erase_if count vs std", cnt21, std_cnt21);
 
-        std::list<int> std_list22{ 0, 10, 2, 5, 7, 9 };
+        std::list<int> std_list22e{ 0, 10, 2, 5, 7, 9 };
         // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
-        auto std_cnt22 = std::erase_if(std_list22, [](int val) { return val <= 5; });
-        tests::compare("List22 vs std", list22, std_list22);
-        tests::compare("List22 erase_if count vs std", cnt22, std_cnt22);
+        auto std_cnt22e = std::erase_if(std_list22e, [](int val) { return val <= 5; });
+        tests::compare("List22e vs std", list22e, std_list22e);
+        tests::compare("List22e erase_if count vs std", cnt22e, std_cnt22e);
 
 
         tests::print_stats();

--- a/tests/list/list_shrink_test.cpp
+++ b/tests/list/list_shrink_test.cpp
@@ -133,6 +133,42 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected16 = { };
         tests::compare("List16", list16, expected16);
 
+        dsa::List<int> list17 = dsa::List<int>({ 0, 10, 0, 0, 40, 0 });
+        auto cnt17 = dsa::erase(list17, 0);
+        const std::initializer_list<int> expected17 = { 10, 40 };
+        tests::compare("List17", list17, expected17);
+        tests::compare("List17 removed count", cnt17, std::size_t{ 4 });
+
+        dsa::List<int> list18 = dsa::List<int>({ 0, 0, 0, 0, 0, 0 });
+        auto cnt18 = dsa::erase(list18, 0);
+        const std::initializer_list<int> expected18 = { };
+        tests::compare("List18", list18, expected18);
+        tests::compare("List18 erase count", cnt18, std::size_t{ 6 });
+
+        dsa::List<int> list19 = dsa::List<int>({ 0, 10, 0, 0, 40, 0 });
+        auto cnt19 = dsa::erase_if(list19, [](int val) { return val == 0; });
+        const std::initializer_list<int> expected19 = { 10, 40 };
+        tests::compare("List19", list19, expected19);
+        tests::compare("List19 erase count", cnt19, std::size_t{ 4 });
+
+        dsa::List<int> list20 = dsa::List<int>({ 0, 0, 0, 0, 0, 0 });
+        auto cnt20 = dsa::erase_if(list20, [](int val) { return val == 0; });
+        const std::initializer_list<int> expected20 = { };
+        tests::compare("List20", list20, expected20);
+        tests::compare("List20 erase_if count", cnt20, std::size_t{ 6 });
+
+        dsa::List<int> list21 = dsa::List<int>({ 0, 1, 2, 3, 4, 5 });
+        auto cnt21 = dsa::erase_if(list21, [](int val) { return val % 2 == 0; });
+        const std::initializer_list<int> expected21 = { 1, 3, 5 };
+        tests::compare("List21", list21, expected21);
+        tests::compare("List21 erase_if count", cnt21, std::size_t{ 3 });
+
+        dsa::List<int> list22 = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt22 = dsa::erase_if(list22, [](int val) { return val <= 5; });
+        const std::initializer_list<int> expected22 = { 10, 7, 9 };
+        tests::compare("List22", list22, expected22);
+        tests::compare("List22 erase_if count", cnt22, std::size_t{ 3 });
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -197,6 +233,43 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto std_cnt13 = std_list13.remove_if([](int val) { return val <= 5; });
         tests::compare("List13 vs std", list13, std_list13);
         tests::compare("List13 removed count vs std", cnt13, std_cnt13);
+
+        std::list<int> std_list17{ 0, 10, 0, 0, 40, 0 };
+        // Linter do not recognizes that functions std::erase/erase_if are included from std::list in C++20
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt17 = std::erase(std_list17, 0);
+        tests::compare("List17 vs std", list17, std_list17);
+        tests::compare("List17 removed count vs std", cnt17, std_cnt17);
+
+        std::list<int> std_list18{ 0, 0, 0, 0, 0, 0 };
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt18 = std::erase(std_list18, 0);
+        tests::compare("List18 vs std", list18, std_list18);
+        tests::compare("List18 erase count vs std", cnt18, std_cnt18);
+
+        std::list<int> std_list19{ 0, 10, 0, 0, 40, 0 };
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt19 = std::erase_if(std_list19, [](int val) { return val == 0; });
+        tests::compare("List19 vs std", list19, std_list19);
+        tests::compare("List19 erase count vs std", cnt19, std_cnt19);
+
+        std::list<int> std_list20{ 0, 0, 0, 0, 0, 0 };
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt20 = std::erase_if(std_list20, [](int val) { return val == 0; });
+        tests::compare("List20 vs std", list20, std_list20);
+        tests::compare("List20 erase_if count vs std", cnt20, std_cnt20);
+
+        std::list<int> std_list21{ 0, 1, 2, 3, 4, 5 };
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt21 = std::erase_if(std_list21, [](int val) { return val % 2 == 0; });
+        tests::compare("List21 vs std", list21, std_list21);
+        tests::compare("List21 erase_if count vs std", cnt21, std_cnt21);
+
+        std::list<int> std_list22{ 0, 10, 2, 5, 7, 9 };
+        // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
+        auto std_cnt22 = std::erase_if(std_list22, [](int val) { return val <= 5; });
+        tests::compare("List22 vs std", list22, std_list22);
+        tests::compare("List22 erase_if count vs std", cnt22, std_cnt22);
 
 
         tests::print_stats();

--- a/tests/list/list_shrink_test.cpp
+++ b/tests/list/list_shrink_test.cpp
@@ -86,28 +86,52 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected9 = { };
         tests::compare("List9", list9, expected9);
 
-        dsa::List<int> list10 = dsa::List<int>({ 0 });
-        tests::compare(list10.empty(), false);
-        list10.clear();
-        tests::compare(list10.empty(), true);
-        const std::initializer_list<int> expected10 = { };
+        dsa::List<int> list10 = dsa::List<int>({ 0, 10, 0, 0, 40, 0 });
+        auto cnt10 = list10.remove_if([](int val) { return val == 0; });
+        const std::initializer_list<int> expected10 = { 10, 40 };
         tests::compare("List10", list10, expected10);
+        tests::compare("List10 removed count", cnt10, std::size_t{ 4 });
 
-        dsa::List<int> list11 = dsa::List<int>({ 10, 20, 30 });
-        list11.pop_front();
-        list11.pop_front();
-        list11.pop_front();
-        list11.pop_front();
+        dsa::List<int> list11 = dsa::List<int>({ 0, 0, 0, 0, 0, 0 });
+        auto cnt11 = list11.remove_if([](int val) { return val == 0; });
         const std::initializer_list<int> expected11 = { };
         tests::compare("List11", list11, expected11);
+        tests::compare("List11 removed count", cnt11, std::size_t{ 6 });
 
-        dsa::List<int> list12 = dsa::List<int>({ 10, 20, 30 });
-        list12.pop_back();
-        list12.pop_back();
-        list12.pop_back();
-        list12.pop_back();
-        const std::initializer_list<int> expected12 = { };
+        dsa::List<int> list12 = dsa::List<int>({ 0, 1, 2, 3, 4, 5 });
+        auto cnt12 = list12.remove_if([](int val) { return val % 2 == 0; });
+        const std::initializer_list<int> expected12 = { 1, 3, 5 };
         tests::compare("List12", list12, expected12);
+        tests::compare("List12 removed count", cnt12, std::size_t{ 3 });
+
+        dsa::List<int> list13 = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt13 = list13.remove_if([](int val) { return val <= 5; });
+        const std::initializer_list<int> expected13 = { 10, 7, 9 };
+        tests::compare("List13", list13, expected13);
+        tests::compare("List13 removed count", cnt13, std::size_t{ 3 });
+
+        dsa::List<int> list14 = dsa::List<int>({ 0 });
+        tests::compare(list14.empty(), false);
+        list14.clear();
+        tests::compare(list14.empty(), true);
+        const std::initializer_list<int> expected14 = { };
+        tests::compare("List14", list14, expected14);
+
+        dsa::List<int> list15 = dsa::List<int>({ 10, 20, 30 });
+        list15.pop_front();
+        list15.pop_front();
+        list15.pop_front();
+        list15.pop_front();
+        const std::initializer_list<int> expected15 = { };
+        tests::compare("List15", list15, expected15);
+
+        dsa::List<int> list16 = dsa::List<int>({ 10, 20, 30 });
+        list16.pop_back();
+        list16.pop_back();
+        list16.pop_back();
+        list16.pop_back();
+        const std::initializer_list<int> expected16 = { };
+        tests::compare("List16", list16, expected16);
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -153,6 +177,26 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_list9{ 0, 0, 0, 0, 0, 0 };
         std_list9.remove(0);
         tests::compare("List9 vs std", list9, std_list9);
+
+        std::list<int> std_list10{ 0, 10, 0, 0, 40, 0 };
+        auto std_cnt10 = std_list10.remove_if([](int val) { return val == 0; });
+        tests::compare("List10 vs std", list10, std_list10);
+        tests::compare("List10 removed count vs std", cnt10, std_cnt10);
+
+        std::list<int> std_list11{ 0, 0, 0, 0, 0, 0 };
+        auto std_cnt11 = std_list11.remove_if([](int val) { return val == 0; });
+        tests::compare("List11 vs std", list11, std_list11);
+        tests::compare("List11 removed count vs std", cnt11, std_cnt11);
+
+        std::list<int> std_list12{ 0, 1, 2, 3, 4, 5 };
+        auto std_cnt12 = std_list12.remove_if([](int val) { return val % 2 == 0; });
+        tests::compare("List12 vs std", list12, std_list12);
+        tests::compare("List12 removed count vs std", cnt12, std_cnt12);
+
+        std::list<int> std_list13{ 0, 10, 2, 5, 7, 9 };
+        auto std_cnt13 = std_list13.remove_if([](int val) { return val <= 5; });
+        tests::compare("List13 vs std", list13, std_list13);
+        tests::compare("List13 removed count vs std", cnt13, std_cnt13);
 
 
         tests::print_stats();

--- a/tests/list/list_shrink_test.cpp
+++ b/tests/list/list_shrink_test.cpp
@@ -29,33 +29,33 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "Start list_shrink_test:\n";
 
         dsa::List<int> list1 = dsa::List<int>({ 0, 10, 20, 30, 40, 50 });
-        auto iter1 = list1.erase(list1.begin()[list1.size() - 1]);
+        auto iter1 = list1.erase(std::next(list1.begin(), static_cast<ptrdiff_t>(list1.size() - 1)));
         tests::compare("List1 iter", iter1 == list1.end(), true);
         list1.pop_front();
         auto indexes = { 100, 5, 2, 0 };
         for (const auto& idx : indexes)
         {
-            list1.erase(list1.begin()[static_cast<size_t>(idx)]);
+            list1.erase(std::next(list1.begin(), static_cast<ptrdiff_t>(idx)));
         }
         const std::initializer_list<int> expected1 = { 20, 40 };
         tests::compare("List1", list1, expected1);
 
         dsa::List<int> list2 = dsa::List<int>({ 0, 10, 20, 30, 40, 50 });
-        auto iter2 = list2.erase(list2.begin()[1], list2.begin()[3]);
+        auto iter2 = list2.erase(std::next(list2.begin(), 1), std::next(list2.begin(), 3));
         tests::compare("List2 iter", iter2 == std::next(list2.begin(), 1), true);
         const std::initializer_list<int> expected2 = { 0, 30, 40, 50 };
         tests::compare("List2", list2, expected2);
 
         dsa::List<int> list3 = dsa::List<int>({ 0, 10, 20, 30, 40, 50 });
-        auto iter3 = list3.erase(list3.begin()[1]);
+        auto iter3 = list3.erase(std::next(list3.begin(), 1));
         tests::compare("List3 iter", iter3 == std::next(list3.begin(), 1), true);
-        iter3 = list3.erase(list3.begin()[1], list3.begin()[3]);
+        iter3 = list3.erase(std::next(list3.begin(), 1), std::next(list3.begin(), 3));
         const std::initializer_list<int> expected3 = { 0, 40, 50 };
         tests::compare("List3", list3, expected3);
 
         dsa::List<int> list4 = dsa::List<int>({ 0, 10, 20, 30, 40, 50 });
-        list4.erase(list4.begin()[1]);
-        auto iter4 = list4.erase(list4.begin()[1], list4.begin()[4]);
+        list4.erase(std::next(list4.begin(), 1));
+        auto iter4 = list4.erase(std::next(list4.begin(), 1), std::next(list4.begin(), 4));
         tests::compare("List4 iter", iter4 == std::next(list4.begin(), 1), true);
         const std::initializer_list<int> expected4 = { 0, 50 };
         tests::compare("List4", list4, expected4);

--- a/tests/list/list_shrink_test.cpp
+++ b/tests/list/list_shrink_test.cpp
@@ -29,7 +29,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "Start list_shrink_test:\n";
 
         dsa::List<int> list1 = dsa::List<int>({ 0, 10, 20, 30, 40, 50 });
-        list1.erase(list1.begin()[list1.size() - 1]);
+        auto iter1 = list1.erase(list1.begin()[list1.size() - 1]);
+        tests::compare("List1 iter", iter1 == list1.end(), true);
         list1.pop_front();
         auto indexes = { 100, 5, 2, 0 };
         for (const auto& idx : indexes)
@@ -40,19 +41,22 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List1", list1, expected1);
 
         dsa::List<int> list2 = dsa::List<int>({ 0, 10, 20, 30, 40, 50 });
-        list2.erase(list2.begin()[1], list2.begin()[3]);
+        auto iter2 = list2.erase(list2.begin()[1], list2.begin()[3]);
+        tests::compare("List2 iter", iter2 == std::next(list2.begin(), 1), true);
         const std::initializer_list<int> expected2 = { 0, 30, 40, 50 };
         tests::compare("List2", list2, expected2);
 
         dsa::List<int> list3 = dsa::List<int>({ 0, 10, 20, 30, 40, 50 });
-        list3.erase(list3.begin()[1]);
-        list3.erase(list3.begin()[1], list3.begin()[3]);
+        auto iter3 = list3.erase(list3.begin()[1]);
+        tests::compare("List3 iter", iter3 == std::next(list3.begin(), 1), true);
+        iter3 = list3.erase(list3.begin()[1], list3.begin()[3]);
         const std::initializer_list<int> expected3 = { 0, 40, 50 };
         tests::compare("List3", list3, expected3);
 
         dsa::List<int> list4 = dsa::List<int>({ 0, 10, 20, 30, 40, 50 });
         list4.erase(list4.begin()[1]);
-        list4.erase(list4.begin()[1], list4.begin()[4]);
+        auto iter4 = list4.erase(list4.begin()[1], list4.begin()[4]);
+        tests::compare("List4 iter", iter4 == std::next(list4.begin(), 1), true);
         const std::initializer_list<int> expected4 = { 0, 50 };
         tests::compare("List4", list4, expected4);
 
@@ -113,8 +117,9 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto iter_end_2 = std_list2.begin();
         std::advance(iter_start_2, 1);
         std::advance(iter_end_2, 3);
-        std_list2.erase(iter_start_2, iter_end_2);
+        auto std_iter2 = std_list2.erase(iter_start_2, iter_end_2);
         tests::compare("List2 vs std", list2, std_list2);
+        tests::compare("List2 iter vs std", *iter2, *std_iter2);
 
         std::list<int> std_list3{ 0, 10, 20, 30, 40, 50 };
         auto iter_start_3 = std_list3.begin();
@@ -124,8 +129,9 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         iter_start_3 = std_list3.begin();
         std::advance(iter_start_3, 1);
         std::advance(iter_end_3, 3);
-        std_list3.erase(iter_start_3, iter_end_3);
+        auto std_iter3 = std_list3.erase(iter_start_3, iter_end_3);
         tests::compare("List3 vs std", list3, std_list3);
+        tests::compare("List3 iter vs std", *iter3 == *std_iter3, true);
 
         std::list<int> std_list4{ 0, 10, 20, 30, 40, 50 };
         auto iter_start_4 = std_list4.begin();
@@ -136,8 +142,9 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         iter_end_4 = std_list4.begin();
         std::advance(iter_start_4, 1);
         std::advance(iter_end_4, 4);
-        std_list4.erase(iter_start_4, iter_end_4);
+        auto std_iter4 = std_list4.erase(iter_start_4, iter_end_4);
         tests::compare("List4 vs std", list4, std_list4);
+        tests::compare("List4 iter vs std", *iter4, *std_iter4);
 
         std::list<int> std_list8{ 0, 10, 0, 0, 40, 0 };
         std_list8.remove(0);

--- a/tests/list/list_sort_test.cpp
+++ b/tests/list/list_sort_test.cpp
@@ -62,6 +62,22 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected6{ 50, 40, 30, 20, 10, 1, 1, 1, 1, 1 };
         tests::compare("List6", list6, expected6);
 
+        // empty
+        dsa::List<int> list7{};
+        list7.sort();
+        const std::initializer_list<int> expected7{};
+        tests::compare("List7", list7, expected7);
+
+        dsa::List<int> list8{ 1 };
+        list8.sort();
+        const std::initializer_list<int> expected8{ 1 };
+        tests::compare("List8", list8, expected8);
+
+        dsa::List<int> list9{ 0, -10 };
+        list9.sort();
+        const std::initializer_list<int> expected9{ -10, 0 };
+        tests::compare("List9", list9, expected9);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -90,6 +106,19 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_list6{ il_2 };
         std_list6.sort(std::greater<>());
         tests::compare("List6", list6, std_list6);
+
+        // empty
+        std::list<int> std_list7{};
+        std_list7.sort();
+        tests::compare("List7", list7, std_list7);
+
+        std::list<int> std_list8{ 1 };
+        std_list8.sort();
+        tests::compare("List8", list8, std_list8);
+
+        std::list<int> std_list9{ 0, -10 };
+        std_list9.sort();
+        tests::compare("List9", list9, std_list9);
 
 
         tests::print_stats();

--- a/tests/list/list_sort_test.cpp
+++ b/tests/list/list_sort_test.cpp
@@ -13,6 +13,7 @@
 #include "dsa/list.h"
 
 #include <exception>
+#include <functional>
 #include <initializer_list>
 #include <iostream>
 #include <list>
@@ -29,6 +30,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> il_1{ 1, 10, 2, 20, 3, 30, 4, 40, 5, 50 };
         const std::initializer_list<int> il_2{ 1, 10, 1, 20, 1, 30, 1, 40, 1, 50 };
 
+        // ascending
         dsa::List<int> list1 = dsa::List<int>(il_1);
         list1.sort();
         const std::initializer_list<int> expected1{ 1, 2, 3, 4, 5, 10, 20, 30, 40, 50 };
@@ -39,9 +41,31 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected2{ 1, 1, 1, 1, 1, 10, 20, 30, 40, 50 };
         tests::compare("List2", list2, expected2);
 
+        dsa::List<int> list3 = dsa::List<int>(il_1);
+        list3.sort(std::less<>());
+        const std::initializer_list<int> expected3{ 1, 2, 3, 4, 5, 10, 20, 30, 40, 50 };
+        tests::compare("List3", list3, expected3);
+
+        dsa::List<int> list4 = dsa::List<int>(il_2);
+        list4.sort(std::less<>());
+        const std::initializer_list<int> expected4{ 1, 1, 1, 1, 1, 10, 20, 30, 40, 50 };
+        tests::compare("List4", list4, expected4);
+
+        // descending
+        dsa::List<int> list5 = dsa::List<int>(il_1);
+        list5.sort(std::greater<>());
+        const std::initializer_list<int> expected5{ 50, 40, 30, 20, 10, 5, 4, 3, 2, 1 };
+        tests::compare("List5", list5, expected5);
+
+        dsa::List<int> list6 = dsa::List<int>(il_2);
+        list6.sort(std::greater<>());
+        const std::initializer_list<int> expected6{ 50, 40, 30, 20, 10, 1, 1, 1, 1, 1 };
+        tests::compare("List6", list6, expected6);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
+        // ascending
         std::list<int> std_list1{ il_1 };
         std_list1.sort();
         tests::compare("List1 vs std", list1, std_list1);
@@ -49,6 +73,23 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_list2{ il_2 };
         std_list2.sort();
         tests::compare("List2 vs std", list2, std_list2);
+
+        std::list<int> std_list3{ il_1 };
+        std_list3.sort(std::less<>());
+        tests::compare("List3", list3, std_list3);
+
+        std::list<int> std_list4{ il_2 };
+        std_list4.sort(std::less<>());
+        tests::compare("List4", list4, std_list4);
+
+        // descending
+        std::list<int> std_list5{ il_1 };
+        std_list5.sort(std::greater<>());
+        tests::compare("List5", list5, std_list5);
+
+        std::list<int> std_list6{ il_2 };
+        std_list6.sort(std::greater<>());
+        tests::compare("List6", list6, std_list6);
 
 
         tests::print_stats();

--- a/tests/list/list_sort_test.cpp
+++ b/tests/list/list_sort_test.cpp
@@ -1,0 +1,64 @@
+/**
+ * @file list_sort_test.cpp
+ * @brief This file tests functions sorting List objects
+ * @author Michal Zygmunt
+ *
+ * @copyright Copyright (c) 2026 Michal Zygmunt
+ * This project is distributed under the MIT License.
+ * See accompanying LICENSE.txt file or obtain copy at
+ * https://opensource.org/license/mit
+ */
+
+#include "common.h"
+#include "dsa/list.h"
+
+#include <exception>
+#include <initializer_list>
+#include <iostream>
+#include <list>
+
+int main() // NOLINT(modernize-use-trailing-return-type)
+{
+    // tests are based on hardcoded magic numbers for comparison of container content
+    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+
+    try
+    {
+        std::cout << "Start list_sort_test:\n";
+
+        const std::initializer_list<int> il_1{ 1, 10, 2, 20, 3, 30, 4, 40, 5, 50 };
+        const std::initializer_list<int> il_2{ 1, 10, 1, 20, 1, 30, 1, 40, 1, 50 };
+
+        dsa::List<int> list1 = dsa::List<int>(il_1);
+        list1.sort();
+        const std::initializer_list<int> expected1{ 1, 2, 3, 4, 5, 10, 20, 30, 40, 50 };
+        tests::compare("List1", list1, expected1);
+
+        dsa::List<int> list2 = dsa::List<int>(il_2);
+        list2.sort();
+        const std::initializer_list<int> expected2{ 1, 1, 1, 1, 1, 10, 20, 30, 40, 50 };
+        tests::compare("List2", list2, expected2);
+
+
+        std::cout << "Compare operations results with std container\n\n";
+
+        std::list<int> std_list1{ il_1 };
+        std_list1.sort();
+        tests::compare("List1 vs std", list1, std_list1);
+
+        std::list<int> std_list2{ il_2 };
+        std_list2.sort();
+        tests::compare("List2 vs std", list2, std_list2);
+
+
+        tests::print_stats();
+    }
+    catch (...)
+    {
+        return tests::handle_exception(std::current_exception());
+    }
+
+    return tests::failed_count();
+
+    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+}

--- a/tests/list/list_splice_test.cpp
+++ b/tests/list/list_splice_test.cpp
@@ -12,6 +12,7 @@
 #include "common.h"
 #include "dsa/list.h"
 
+#include <cstddef>
 #include <exception>
 #include <initializer_list>
 #include <iostream>
@@ -43,7 +44,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list3 = dsa::List<int>(il_1);
         dsa::List<int> list4 = dsa::List<int>(il_2);
-        list3.splice(list3.begin()[3], list4);
+        list3.splice(std::next(list3.begin(), 3), list4);
         const std::initializer_list<int> expected3 = { 1, 2, 3, 10, 20, 30, 40, 50, 4, 5 };
         tests::compare("List3", list3, expected3);
         const std::initializer_list<int> expected4 = {};
@@ -51,7 +52,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list5 = dsa::List<int>(il_1);
         dsa::List<int> list6 = dsa::List<int>(il_2);
-        list5.splice(list5.begin()[list5.size() - 1], list6);
+        list5.splice(std::next(list5.begin(), static_cast<ptrdiff_t>(list5.size() - 1)), list6);
         const std::initializer_list<int> expected5 = { 1, 2, 3, 4, 10, 20, 30, 40, 50, 5 };
         tests::compare("List5", list5, expected5);
         const std::initializer_list<int> expected6 = {};
@@ -62,7 +63,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list7 = dsa::List<int>(il_1);
         dsa::List<int> list8;
-        list7.splice(list7.begin()[list7.size() - 1], list8);
+        list7.splice(std::next(list7.begin(), static_cast<ptrdiff_t>(list7.size() - 1)), list8);
         const std::initializer_list<int> expected7 = il_1;
         tests::compare("List7", list7, expected7);
         const std::initializer_list<int> expected8 = {};
@@ -81,7 +82,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list11 = dsa::List<int>(il_1);
         dsa::List<int> list12 = dsa::List<int>(il_2);
-        list11.splice(list11.begin(), list12, list12.begin()[2]);
+        list11.splice(list11.begin(), list12, std::next(list12.begin(), 2));
         const std::initializer_list<int> expected11 = { 30, 1, 2, 3, 4, 5 };
         tests::compare("List11", list11, expected11);
         const std::initializer_list<int> expected12 = { 10, 20, 40, 50 };
@@ -89,7 +90,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list13 = dsa::List<int>(il_1);
         dsa::List<int> list14 = dsa::List<int>(il_2);
-        list13.splice(list13.begin(), list14, list14.begin()[list14.size() - 2]);
+        list13.splice(list13.begin(), list14, std::next(list14.begin(), static_cast<ptrdiff_t>(list14.size() - 2)));
         const std::initializer_list<int> expected13 = { 40, 1, 2, 3, 4, 5 };
         tests::compare("List13", list13, expected13);
         const std::initializer_list<int> expected14 = { 10, 20, 30, 50 };
@@ -98,7 +99,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list15 = dsa::List<int>(il_1);
         dsa::List<int> list16 = dsa::List<int>(il_2);
-        list15.splice(list15.begin()[3], list16, list16.begin());
+        list15.splice(std::next(list15.begin(), 3), list16, list16.begin());
         const std::initializer_list<int> expected15 = { 1, 2, 3, 10, 4, 5 };
         tests::compare("List15", list15, expected15);
         const std::initializer_list<int> expected16 = { 20, 30, 40, 50 };
@@ -106,7 +107,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list17 = dsa::List<int>(il_1);
         dsa::List<int> list18 = dsa::List<int>(il_2);
-        list17.splice(list17.begin()[3], list18, list18.begin()[2]);
+        list17.splice(std::next(list17.begin(), 3), list18, std::next(list18.begin(), 2));
         const std::initializer_list<int> expected17 = { 1, 2, 3, 30, 4, 5 };
         tests::compare("List17", list17, expected17);
         const std::initializer_list<int> expected18 = { 10, 20, 40, 50 };
@@ -114,7 +115,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list19 = dsa::List<int>(il_1);
         dsa::List<int> list20 = dsa::List<int>(il_2);
-        list19.splice(list19.begin()[3], list20, list20.begin()[list20.size() - 2]);
+        list19.splice(std::next(list19.begin(), 3),
+            list20, std::next(list20.begin(), static_cast<ptrdiff_t>(list20.size() - 2)));
         const std::initializer_list<int> expected19 = { 1, 2, 3, 40, 4, 5 };
         tests::compare("List19", list19, expected19);
         const std::initializer_list<int> expected20 = { 10, 20, 30, 50 };
@@ -123,7 +125,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list21 = dsa::List<int>(il_1);
         dsa::List<int> list22 = dsa::List<int>(il_2);
-        list21.splice(list21.begin()[list21.size() - 1], list22, list22.begin());
+        list21.splice(std::next(list21.begin(), static_cast<ptrdiff_t>(list21.size() - 1)), list22, list22.begin());
         const std::initializer_list<int> expected21 = { 1, 2, 3, 4, 10, 5 };
         tests::compare("List21", list21, expected21);
         const std::initializer_list<int> expected22 = { 20, 30, 40, 50 };
@@ -131,7 +133,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list23 = dsa::List<int>(il_1);
         dsa::List<int> list24 = dsa::List<int>(il_2);
-        list23.splice(list23.begin()[list23.size() - 1], list24, list24.begin()[3]);
+        list23.splice(std::next(list23.begin(), static_cast<ptrdiff_t>(list23.size() - 1)), list24, std::next(list24.begin(), 3));
         const std::initializer_list<int> expected23 = { 1, 2, 3, 4, 40, 5 };
         tests::compare("List23", list23, expected23);
         const std::initializer_list<int> expected24 = { 10, 20, 30, 50 };
@@ -139,7 +141,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list25 = dsa::List<int>(il_1);
         dsa::List<int> list26 = dsa::List<int>(il_2);
-        list25.splice(list25.begin()[list25.size() - 1], list26, list26.begin()[list26.size() - 2]);
+        list25.splice(std::next(list25.begin(), static_cast<ptrdiff_t>(list25.size() - 1)),
+            list26, std::next(list26.begin(), static_cast<ptrdiff_t>(list26.size() - 2)));
         const std::initializer_list<int> expected25 = { 1, 2, 3, 4, 40, 5 };
         tests::compare("List25", list25, expected25);
         const std::initializer_list<int> expected26 = { 10, 20, 30, 50 };
@@ -150,7 +153,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list27 = dsa::List<int>(il_1);
         dsa::List<int> list28 = dsa::List<int>(il_2);
-        list27.splice(list27.begin(), list28, list28.begin(), list28.begin()[1]);
+        list27.splice(list27.begin(), list28, list28.begin(), std::next(list28.begin(), 1));
         const std::initializer_list<int> expected27 = { 10, 1, 2, 3, 4, 5 };
         tests::compare("List27", list27, expected27);
         const std::initializer_list<int> expected28 = { 20, 30, 40, 50 };
@@ -158,7 +161,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list29 = dsa::List<int>(il_1);
         dsa::List<int> list30 = dsa::List<int>(il_2);
-        list29.splice(list29.begin(), list30, list30.begin()[1], list30.begin()[3]);
+        list29.splice(list29.begin(), list30, std::next(list30.begin(), 1), std::next(list30.begin(), 3));
         const std::initializer_list<int> expected29 = { 20, 30, 1, 2, 3, 4, 5 };
         tests::compare("List29", list29, expected29);
         const std::initializer_list<int> expected30 = { 10, 40, 50 };
@@ -166,7 +169,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list31 = dsa::List<int>(il_1);
         dsa::List<int> list32 = dsa::List<int>(il_2);
-        list31.splice(list31.begin(), list32, list32.begin(), list32.begin()[list32.size() - 1]);
+        list31.splice(list31.begin(),
+            list32, list32.begin(), std::next(list32.begin(), static_cast<ptrdiff_t>(list32.size() - 1)));
         const std::initializer_list<int> expected31 = { 10, 20, 30, 40, 1, 2, 3, 4, 5 };
         tests::compare("List31", list31, expected31);
         const std::initializer_list<int> expected32 = { 50 };
@@ -175,7 +179,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list33 = dsa::List<int>(il_1);
         dsa::List<int> list34 = dsa::List<int>(il_2);
-        list33.splice(list33.begin()[2], list34, list34.begin(), list34.begin()[1]);
+        list33.splice(std::next(list33.begin(), 2), list34, list34.begin(), std::next(list34.begin(), 1));
         const std::initializer_list<int> expected33 = { 1, 2, 10, 3, 4, 5 };
         tests::compare("List33", list33, expected33);
         const std::initializer_list<int> expected34 = { 20, 30, 40, 50 };
@@ -183,7 +187,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list35 = dsa::List<int>(il_1);
         dsa::List<int> list36 = dsa::List<int>(il_2);
-        list35.splice(list35.begin()[2], list36, list36.begin()[1], list36.begin()[3]);
+        list35.splice(std::next(list35.begin(), 2), list36, std::next(list36.begin(), 1), std::next(list36.begin(), 3));
         const std::initializer_list<int> expected35 = { 1, 2, 20, 30, 3, 4, 5 };
         tests::compare("List35", list35, expected35);
         const std::initializer_list<int> expected36 = { 10, 40, 50 };
@@ -191,7 +195,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list37 = dsa::List<int>(il_1);
         dsa::List<int> list38 = dsa::List<int>(il_2);
-        list37.splice(list37.begin()[2], list38, list38.begin(), list38.begin()[list38.size() - 1]);
+        list37.splice(std::next(list37.begin(), 2),
+            list38, list38.begin(), std::next(list38.begin(), static_cast<ptrdiff_t>(list38.size() - 1)));
         const std::initializer_list<int> expected37 = { 1, 2, 10, 20, 30, 40, 3, 4, 5 };
         tests::compare("List37", list37, expected37);
         const std::initializer_list<int> expected38 = { 50 };
@@ -200,7 +205,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list39 = dsa::List<int>(il_1);
         dsa::List<int> list40 = dsa::List<int>(il_2);
-        list39.splice(list39.begin()[list39.size() - 1], list40, list40.begin(), list40.begin()[1]);
+        list39.splice(std::next(list39.begin(), static_cast<ptrdiff_t>(list39.size() - 1)),
+            list40, list40.begin(), std::next(list40.begin(), 1));
         const std::initializer_list<int> expected39 = { 1, 2, 3, 4, 10, 5 };
         tests::compare("List39", list39, expected39);
         const std::initializer_list<int> expected40 = { 20, 30, 40, 50 };
@@ -208,7 +214,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list41 = dsa::List<int>(il_1);
         dsa::List<int> list42 = dsa::List<int>(il_2);
-        list41.splice(list41.begin()[list41.size() - 1], list42, list42.begin()[1], list42.begin()[3]);
+        list41.splice(std::next(list41.begin(), static_cast<ptrdiff_t>(list41.size() - 1)),
+            list42, std::next(list42.begin(), 1), std::next(list42.begin(), 3));
         const std::initializer_list<int> expected41 = { 1, 2, 3, 4, 20, 30, 5 };
         tests::compare("List41", list41, expected41);
         const std::initializer_list<int> expected42 = { 10, 40, 50 };
@@ -216,7 +223,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list43 = dsa::List<int>(il_1);
         dsa::List<int> list44 = dsa::List<int>(il_2);
-        list43.splice(list43.begin()[list43.size() - 1], list44, list44.begin(), list44.begin()[list44.size() - 1]);
+        list43.splice(std::next(list43.begin(), static_cast<ptrdiff_t>(list43.size() - 1)),
+            list44, list44.begin(), std::next(list44.begin(), static_cast<ptrdiff_t>(list44.size() - 1)));
         const std::initializer_list<int> expected43 = { 1, 2, 3, 4, 10, 20, 30, 40, 5 };
         tests::compare("List43", list43, expected43);
         const std::initializer_list<int> expected44 = { 50 };
@@ -224,7 +232,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list45 = dsa::List<int>(il_1);
         dsa::List<int> list46 = dsa::List<int>(il_2);
-        list45.splice(list45.begin()[list45.size()], list46, list46.begin(), list46.begin()[list46.size() - 1]);
+        list45.splice(std::next(list45.begin(), static_cast<ptrdiff_t>(list45.size())),
+            list46, list46.begin(), std::next(list46.begin(), static_cast<ptrdiff_t>(list46.size() - 1)));
         const std::initializer_list<int> expected45 = { 1, 2, 3, 4, 5, 10, 20, 30, 40 };
         tests::compare("List45", list45, expected45);
         const std::initializer_list<int> expected46 = { 50 };
@@ -232,7 +241,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list47 = dsa::List<int>(il_1);
         dsa::List<int> list48 = dsa::List<int>(il_2);
-        list47.splice(list47.begin()[list47.size() - 1], list48, list48.begin(), list48.begin()[list48.size()]);
+        list47.splice(std::next(list47.begin(), static_cast<ptrdiff_t>(list47.size() - 1)),
+            list48, list48.begin(), std::next(list48.begin(), static_cast<ptrdiff_t>(list48.size())));
         const std::initializer_list<int> expected47 = { 1, 2, 3, 4, 10, 20, 30, 40, 50, 5 };
         tests::compare("List47", list47, expected47);
         const std::initializer_list<int> expected48 = {};
@@ -240,7 +250,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list49 = dsa::List<int>(il_1);
         dsa::List<int> list50 = dsa::List<int>(il_2);
-        list49.splice(list49.begin()[list49.size()], list50, list50.begin(), list50.begin()[list50.size()]);
+        list49.splice(std::next(list49.begin(), static_cast<ptrdiff_t>(list49.size())),
+            list50, list50.begin(), std::next(list50.begin(), static_cast<ptrdiff_t>(list50.size())));
         const std::initializer_list<int> expected49 = { 1, 2, 3, 4, 5, 10, 20, 30, 40, 50 };
         tests::compare("List49", list49, expected49);
         const std::initializer_list<int> expected50 = {};
@@ -335,7 +346,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list65 = dsa::List<int>(il_1);
         dsa::List<int> list66;
-        list65.splice(list65.begin()[list65.size() - 1], std::move(list66));
+        list65.splice(std::next(list65.begin(), static_cast<ptrdiff_t>(list65.size() - 1)), std::move(list66));
         const std::initializer_list<int> expected65 = il_1;
         tests::compare("List65", list65, expected65);
         const std::initializer_list<int> expected66 = {};
@@ -357,7 +368,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list69 = dsa::List<int>(il_1);
         dsa::List<int> list70 = dsa::List<int>(il_2);
-        list69.splice(list69.begin(), std::move(list70), list70.begin(), list70.begin()[1]);
+        list69.splice(list69.begin(), std::move(list70), list70.begin(), std::next(list70.begin(), 1));
         const std::initializer_list<int> expected69 = { 10, 1, 2, 3, 4, 5 };
         tests::compare("List69", list69, expected69);
         const std::initializer_list<int> expected70 = { 20, 30, 40, 50 };

--- a/tests/list/list_splice_test.cpp
+++ b/tests/list/list_splice_test.cpp
@@ -375,6 +375,11 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // NOLINTNEXTLINE(bugprone-use-after-move)
         tests::compare("List70", list70, expected70);
 
+        dsa::List<int> list71{ il_1 };
+        list71.splice(list71.begin(), list71, list71.begin());
+        const std::initializer_list<int> expected71 = { 1, 2, 3, 4, 5 };
+        tests::compare("List71", list71, expected71);
+
 
         tests::print_stats();
     }

--- a/tests/list/list_swap_test.cpp
+++ b/tests/list/list_swap_test.cpp
@@ -16,6 +16,7 @@
 #include <initializer_list>
 #include <iostream>
 #include <list>
+#include <utility>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -45,6 +46,29 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected4 = { 1, 2, 3, 4, 5 };
         tests::compare("List4", list4, expected4);
 
+        dsa::List<int> list5 = dsa::List<int>(il_1);
+        dsa::List<int> list6 = dsa::List<int>(il_2);
+        dsa::swap(list5, list6);
+        const std::initializer_list<int> expected5 = il_2;
+        tests::compare("List5", list5, expected5);
+        const std::initializer_list<int> expected6 = il_1;
+        tests::compare("List6", list6, expected6);
+
+        dsa::List<int> list7 = dsa::List<int>(il_1);
+        dsa::List<int> list8;
+        dsa::swap(list7, list8);
+        const std::initializer_list<int> expected7 = { };
+        tests::compare("List7", list7, expected7);
+        const std::initializer_list<int> expected8 = il_1;
+        tests::compare("List8", list8, expected8);
+
+        // swap safe type
+        static_assert(noexcept(swap(std::declval<dsa::List<int>&>(),
+            std::declval<dsa::List<int>&>())));
+        // swap throwing type
+        static_assert(noexcept(swap(std::declval<dsa::List<tests::ThrowingType>&>(),
+            std::declval<dsa::List<tests::ThrowingType>&>())));
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -59,6 +83,25 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list3.swap(std_list4);
         tests::compare("List3 vs std", list3, std_list3);
         tests::compare("List4 vs std", list4, std_list4);
+
+        std::list<int> std_list5(il_1);
+        std::list<int> std_list6(il_2);
+        std::swap(std_list5, std_list6);
+        tests::compare("List5 vs std", list5, std_list5);
+        tests::compare("List6 vs std", list6, std_list6);
+
+        std::list<int> std_list7(il_1);
+        std::list<int> std_list8;
+        std::swap(std_list7, std_list8);
+        tests::compare("List7 vs std", list7, std_list7);
+        tests::compare("List8 vs std", list8, std_list8);
+
+        // swap safe type
+        static_assert(noexcept(swap(std::declval<std::list<int>&>(),
+            std::declval<std::list<int>&>())));
+        // swap throwing type
+        static_assert(noexcept(swap(std::declval<std::list<tests::ThrowingType>&>(),
+            std::declval<std::list<tests::ThrowingType>&>())));
 
 
         tests::print_stats();

--- a/tests/list/list_unique_test.cpp
+++ b/tests/list/list_unique_test.cpp
@@ -12,6 +12,7 @@
 #include "common.h"
 #include "dsa/list.h"
 
+#include <cmath>
 #include <cstddef>
 #include <exception>
 #include <initializer_list>
@@ -69,6 +70,24 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List7", list7, expected7);
         tests::compare("List7 removed", removed7, size_t{ 0 });
 
+        // find unique values using predicate
+        auto predicate = [](const int& input_a, const int& input_b)
+            {
+                return std::abs(input_a - input_b) <= 5;
+            };
+
+        dsa::List<int> list8 = dsa::List<int>({ 1, 5, 7, 15, 25 });
+        auto removed8 = list8.unique(predicate);
+        const std::initializer_list<int> expected8 = { 1, 7, 15, 25 };
+        tests::compare("List8", list8, expected8);
+        tests::compare("List8 removed", removed8, size_t{ 1 });
+
+        dsa::List<int> list9 = dsa::List<int>({ 1, 4, 12, 13, 12, 14, 3, 15, 1 });
+        auto removed9 = list9.unique(predicate);
+        const std::initializer_list<int> expected9 = { 1, 12, 3, 15, 1 };
+        tests::compare("List9", list9, expected9);
+        tests::compare("List9 removed", removed9, size_t{ 4 });
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -106,6 +125,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto std_removed7 = std_list7.unique();
         tests::compare("List7 vs std", list7, std_list7);
         tests::compare("List7 removed vs std", removed7, std_removed7);
+
+        std::list<int> std_list8{ 1, 5, 7, 15, 25 };
+        auto std_removed8 = std_list8.unique(predicate);
+        tests::compare("List8 vs std", list8, std_list8);
+        tests::compare("List8 removed vs std", removed8, std_removed8);
+
+        std::list<int> std_list9{ 1, 4, 12, 13, 12, 14, 3, 15, 1 };
+        auto std_removed9 = std_list9.unique(predicate);
+        tests::compare("List9 vs std", list9, std_list9);
+        tests::compare("List9 removed vs std", removed9, std_removed9);
 
 
         tests::print_stats();

--- a/tests/list/list_unique_test.cpp
+++ b/tests/list/list_unique_test.cpp
@@ -12,6 +12,7 @@
 #include "common.h"
 #include "dsa/list.h"
 
+#include <cstddef>
 #include <exception>
 #include <initializer_list>
 #include <iostream>
@@ -27,70 +28,84 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << "Start list_unique_test:\n";
 
         dsa::List<int> list1 = dsa::List<int>({ 1, 2, 3, 4, 5 });
-        list1.unique();
+        auto removed1 = list1.unique();
         const std::initializer_list<int> expected1 = { 1, 2, 3, 4, 5 };
-        tests::compare("list1", list1, expected1);
+        tests::compare("List1", list1, expected1);
+        tests::compare("List1 removed", removed1, size_t{ 0 });
 
         dsa::List<int> list2 = dsa::List<int>({ 1, 4, 2, 3, 2, 4, 3, 5, 1 });
-        list2.unique();
+        auto removed2 = list2.unique();
         const std::initializer_list<int> expected2 = { 1, 4, 2, 3, 2, 4, 3, 5, 1 };
-        tests::compare("list2", list2, expected2);
+        tests::compare("List2", list2, expected2);
+        tests::compare("List2 removed", removed2, size_t{ 0 });
 
         dsa::List<int> list3 = dsa::List<int>({ 1, 1, 2, 4, 2, 1, 3, 1, 1 });
-        list3.unique();
+        auto removed3 = list3.unique();
         const std::initializer_list<int> expected3 = { 1, 2, 4, 2, 1, 3, 1 };
-        tests::compare("list3", list3, expected3);
+        tests::compare("List3", list3, expected3);
+        tests::compare("List3 removed", removed3, size_t{ 2 });
 
         dsa::List<int> list4 = dsa::List<int>({ 1, 1, 1, 2, 2, 2, 1, 1, 1 });
-        list4.unique();
+        auto removed4 = list4.unique();
         const std::initializer_list<int> expected4 = { 1, 2, 1 };
-        tests::compare("list4", list4, expected4);
+        tests::compare("List4", list4, expected4);
+        tests::compare("List4 removed", removed4, size_t{ 6 });
 
         dsa::List<int> list5 = dsa::List<int>({ 0, 0, 0, 0, 0, 0 });
-        list5.unique();
+        auto removed5 = list5.unique();
         const std::initializer_list<int> expected5 = { 0 };
-        tests::compare("list5", list5, expected5);
+        tests::compare("List5", list5, expected5);
+        tests::compare("List5 removed", removed5, size_t{ 5 });
 
         dsa::List<int> list6 = dsa::List<int>();
-        list6.unique();
+        auto removed6 = list6.unique();
         const std::initializer_list<int> expected6 = { };
-        tests::compare("list6", list6, expected6);
+        tests::compare("List6", list6, expected6);
+        tests::compare("List6 removed", removed6, size_t{ 0 });
 
         dsa::List<int> list7;
-        list7.unique();
+        auto removed7 = list7.unique();
         const std::initializer_list<int> expected7 = {};
-        tests::compare("list7", list7, expected7);
+        tests::compare("List7", list7, expected7);
+        tests::compare("List7 removed", removed7, size_t{ 0 });
 
 
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list1{ 1, 2, 3, 4, 5 };
-        std_list1.unique();
-        tests::compare("list1 vs std", list1, std_list1);
+        auto std_removed1 = std_list1.unique();
+        tests::compare("List1 vs std", list1, std_list1);
+        tests::compare("List1 removed vs std", removed1, std_removed1);
 
         std::list<int> std_list2{ 1, 4, 2, 3, 2, 4, 3, 5, 1 };
-        std_list2.unique();
-        tests::compare("list2 vs std", list2, std_list2);
+        auto std_removed2 = std_list2.unique();
+        tests::compare("List2 vs std", list2, std_list2);
+        tests::compare("List2 removed vs std", removed2, std_removed2);
 
         std::list<int> std_list3{ 1, 1, 2, 4, 2, 1, 3, 1, 1 };
-        std_list3.unique();
-        tests::compare("list3 vs std", list3, std_list3);
+        auto std_removed3 = std_list3.unique();
+        tests::compare("List3 vs std", list3, std_list3);
+        tests::compare("List3 removed vs std", removed3, std_removed3);
 
         std::list<int> std_list4{ 1, 1, 1, 2, 2, 2, 1, 1, 1 };
-        std_list4.unique();
-        tests::compare("list4 vs std", list4, std_list4);
+        auto std_removed4 = std_list4.unique();
+        tests::compare("List4 vs std", list4, std_list4);
+        tests::compare("List4 removed vs std", removed4, std_removed4);
 
         std::list<int> std_list5{ 0, 0, 0, 0, 0, 0 };
-        std_list5.unique();
-        tests::compare("list5 vs std", list5, std_list5);
+        auto std_removed5 = std_list5.unique();
+        tests::compare("List5 vs std", list5, std_list5);
+        tests::compare("List5 removed vs std", removed5, std_removed5);
 
         std::list<int> std_list6 = std::list<int>();
-        std_list6.unique();
-        tests::compare("list6 vs std", list6, std_list6);
+        auto std_removed6 = std_list6.unique();
+        tests::compare("List6 vs std", list6, std_list6);
+        tests::compare("List6 removed vs std", removed6, std_removed6);
 
         std::list<int> std_list7;
-        std_list7.unique();
-        tests::compare("list7 vs std", list7, std_list7);
+        auto std_removed7 = std_list7.unique();
+        tests::compare("List7 vs std", list7, std_list7);
+        tests::compare("List7 removed vs std", removed7, std_removed7);
 
 
         tests::print_stats();


### PR DESCRIPTION
Update dsa::List class to better match std::list API and behaviour.

Closes https://github.com/michal-zygmunt/dsa/issues/31

## Checklist

- [x] provide the same member types and methods as std::list, including:

  * get_allocator, emplace, emplace, emplace_front, emplace_back
  * rbegin, crbegin, rend, crend
  * assign using input iterator
  * ctor using iterators
  * insert_after using iterators and move semantics
  * push_front using move semantics
  * merge function using comparison function object
  * unique function using comparison function object
  * operator<=>
  * add member functions: remove, remove_if, sort
  * add non-member specialised functions: swap, erase, erase_if

- [x] remove public functions / operators not supported by std::list

  * get, set
  * operator+, operator+= used for merging objects
  * operator[] for class iterators, use std::next, std::advance for iterator traversal

- [x] update tests to match features provided by updated implementation
- [x] separate function declarations and definitions (move method implementation outside class, where possible)
- [x] updated [[nodiscard]] attributes