### PR TITLE
Update ForwardList class to improve maintainability

### DIFF
--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1633,7 +1633,9 @@ namespace dsa
 
                 if (node_this && node_other)
                 {
-                    if (comp(node_this->value(), node_other->value()))
+                    // 2nd condition keeps correct order of equal elements
+                    if (comp(node_this->value(), node_other->value()) ||
+                        !comp(node_other->value(), node_this->value()))
                     {
                         to_move = m_head->m_next;
                         to_return = to_move->m_next;

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -514,7 +514,7 @@ namespace dsa
          *
          * @return allocator_type type of memory allocator
          */
-        [[nodiscard]] constexpr auto get_allocator() const -> allocator_type;
+        [[nodiscard]] auto get_allocator() const noexcept -> allocator_type;
 
         /**
          * @brief Function returns reference to value stored in ForwardList first Node
@@ -1269,7 +1269,7 @@ namespace dsa
     }
 
     template<typename T>
-    [[nodiscard]] constexpr auto ForwardList<T>::get_allocator() const -> allocator_type
+    [[nodiscard]] auto ForwardList<T>::get_allocator() const noexcept -> allocator_type
     {
         return m_allocator;
     }

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -484,6 +484,8 @@ namespace dsa
          *
          * @param[in] count new size of the container
          * @param[in] value value to initialize elements of the container with
+         *
+         * @note all iterators, pointers and references to the elements of the container are invalidated
          */
         void assign(size_type count, const_reference value);
 
@@ -493,6 +495,8 @@ namespace dsa
          * @tparam InputIt
          * @param[in] first element defining range of elements to insert
          * @param[in] last element definig range of elements to insert
+         *
+         * @note all iterators, pointers and references to the elements of the container are invalidated
          */
         template<typename InputIt>
             requires std::input_iterator<InputIt>
@@ -502,6 +506,8 @@ namespace dsa
          * @brief Function assign values to the ForwardList
          *
          * @param[in] init_list values to replace ForwardList with
+         *
+         * @note all iterators, pointers and references to the elements of the container are invalidated
          */
         void assign(const std::initializer_list<T>& init_list);
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1620,7 +1620,10 @@ namespace dsa
 
         if (m_size != 0)
         {
+            // if temporary node could not be allocated do not modify
+            // object state
             Node* temp_head{ construct_node(nullptr, T{}) };
+
             NodeBase* temp_tail{ temp_head };
 
             NodeBase* to_move{};

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1826,7 +1826,7 @@ namespace dsa
     template<typename T>
     void ForwardList<T>::sort()
     {
-        m_head->m_next = merge_sort(m_head->m_next, std::less<>());
+        sort(std::less<>());
     }
 
     template<typename T>

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -618,9 +618,8 @@ namespace dsa
          *
          * @param[in] pos const_iterator to insert element after
          * @param[in] value element of type T to be inserted after \p pos
-         * @return pointer to ForwardList element
-         * @retval iterator to inserted \p value
-         * @retval pos if no element was inserted
+         * @retval iterator to inserted element
+         * @retval iterator to \p pos if no element was inserted
          */
         auto insert_after(const const_iterator& pos, const_reference value) -> iterator;
 
@@ -629,9 +628,8 @@ namespace dsa
          *
          * @param[in] pos const_iterator to insert element after
          * @param[in] value element of type T to be inserted after \p pos
-         * @return pointer to ForwardList element
-         * @retval iterator to inserted \p value
-         * @retval pos if no element was inserted
+         * @retval iterator to inserted element
+         * @retval iterator to \p pos if no element was inserted
          */
         auto insert_after(const const_iterator& pos, T&& value) -> iterator;
 
@@ -641,9 +639,8 @@ namespace dsa
          * @param[in] pos const_iterator to insert element after
          * @param[in] count number of elements to insert after \p pos
          * @param[in] value element of type T to be inserted
-         * @return pointer to ForwardList element
-         * @retval iterator pointer to last inserted element
-         * @retval pos if no element was inserted
+         * @retval iterator to last inserted element
+         * @retval iterator to \p pos if no element was inserted
          */
         auto insert_after(const const_iterator& pos, size_type count, const_reference value) -> iterator;
 
@@ -653,9 +650,8 @@ namespace dsa
          * @param[in] pos const_iterator to insert element after
          * @param[in] first element defining range of elements to insert
          * @param[in] last element definig range of elements to insert
-         * @return pointer to ForwardList element
-         * @retval iterator pointer to last inserted element
-         * @retval pos if no element was inserted
+         * @retval iterator to last inserted element
+         * @retval iterator to \p pos if no element was inserted
          */
         template<typename InputIt>
             requires std::input_iterator<InputIt>
@@ -666,9 +662,8 @@ namespace dsa
          *
          * @param[in] pos const_iterator to insert element after
          * @param[in] init_list initializer_list with elements to insert after \p pos
-         * @return pointer to the last inserted element
          * @retval iterator to last inserted element
-         * @retval pos if no element was inserted
+         * @retval iterator to \p pos if no element was inserted
          */
         auto insert_after(const const_iterator& pos, std::initializer_list<T> init_list) -> iterator;
 
@@ -1386,7 +1381,7 @@ namespace dsa
     {
         if (!if_valid_iterator(pos))
         {
-            return nullptr;
+            return pos.m_current_node;
         }
 
         iterator iter{ pos.m_current_node };
@@ -1401,7 +1396,7 @@ namespace dsa
     {
         if (!if_valid_iterator(pos))
         {
-            return nullptr;
+            return pos.m_current_node;
         }
 
         iterator iter{ pos.m_current_node };
@@ -1421,7 +1416,7 @@ namespace dsa
     {
         if (!if_valid_iterator(pos))
         {
-            return nullptr;
+            return pos.m_current_node;
         }
 
         iterator iter{ pos.m_current_node };
@@ -1440,13 +1435,13 @@ namespace dsa
     {
         if (!if_valid_iterator(pos))
         {
-            return nullptr;
+            return pos.m_current_node;
         }
 
         iterator iter{ pos.m_current_node };
-        for (const auto val : init_list)
+        for (const auto item : init_list)
         {
-            iter = emplace_after(iter, val);
+            iter = emplace_after(iter, item);
         }
 
         return iter;

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1584,7 +1584,7 @@ namespace dsa
     void ForwardList<T>::swap(ForwardList<T>& other)
         noexcept(std::allocator_traits<allocator_type>::is_always_equal::value)
     {
-        std::swap(m_head->m_next, other.m_head->m_next);
+        std::swap(m_head, other.m_head);
         std::swap(m_size, other.m_size);
     }
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1138,9 +1138,8 @@ namespace dsa
 
     template<typename T>
     ForwardList<T>::ForwardList(size_type count, const T& value)
+        : ForwardList()
     {
-        init_node();
-
         for (size_type i = 0; i < count; i++)
         {
             push_front(value);
@@ -1151,17 +1150,15 @@ namespace dsa
     template<typename InputIt>
         requires std::input_iterator<InputIt>
     ForwardList<T>::ForwardList(InputIt first, InputIt last)
+        : ForwardList()
     {
-        init_node();
-
         assign(first, last);
     }
 
     template<typename T>
     ForwardList<T>::ForwardList(const std::initializer_list<T>& init_list)
+        : ForwardList()
     {
-        init_node();
-
         auto iter = before_begin();
         for (const auto& item : init_list)
         {
@@ -1171,9 +1168,8 @@ namespace dsa
 
     template<typename T>
     ForwardList<T>::ForwardList(const ForwardList<T>& other)
+        : ForwardList()
     {
-        init_node();
-
         auto iter = before_begin();
         for (const auto& item : other)
         {
@@ -1184,8 +1180,6 @@ namespace dsa
     template<typename T>
     auto ForwardList<T>::operator=(const ForwardList<T>& other) -> ForwardList<T>&
     {
-        init_node();
-
         if (&other != this)
         {
             while (m_head->m_next)
@@ -1205,6 +1199,7 @@ namespace dsa
 
     template<typename T>
     ForwardList<T>::ForwardList(ForwardList<T>&& other) noexcept
+        : ForwardList()
     {
         operator=(std::move(other));
     }
@@ -1215,7 +1210,6 @@ namespace dsa
         if (&other != this)
         {
             clear();
-            init_node();
 
             m_head->m_next = other.m_head->m_next;
             m_size = other.m_size;
@@ -1558,8 +1552,6 @@ namespace dsa
     template<typename T>
     void ForwardList<T>::resize(size_type count, const_reference value)
     {
-        init_node();
-
         if (count == m_size)
         {
             return;
@@ -1996,11 +1988,8 @@ namespace dsa
     template<typename T>
     void ForwardList<T>::init_node()
     {
-        if (m_head == nullptr)
-        {
-            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-            m_head = new NodeBase;
-        }
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        m_head = new NodeBase;
     }
 
     template<typename T>

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1107,7 +1107,7 @@ namespace dsa
         /**
          * @brief Rebind allocator to create new objects of type Node
          */
-        using node_allocator = typename std::allocator_traits<std::allocator<T>>::template rebind_alloc<Node>;
+        using node_allocator = typename std::allocator_traits<allocator_type>::template rebind_alloc<Node>;
 
         /**
          * @brief Setup allocator traits used for Node creation and deletion

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -620,8 +620,7 @@ namespace dsa
          *
          * @param[in] pos const_iterator to insert element after
          * @param[in] value element of type T to be inserted after \p pos
-         * @retval iterator to inserted element
-         * @retval iterator to \p pos if no element was inserted
+         * @return iterator to last inserted element, or \p pos if no element was inserted
          */
         auto insert_after(const const_iterator& pos, const_reference value) -> iterator;
 
@@ -630,8 +629,7 @@ namespace dsa
          *
          * @param[in] pos const_iterator to insert element after
          * @param[in] value element of type T to be inserted after \p pos
-         * @retval iterator to inserted element
-         * @retval iterator to \p pos if no element was inserted
+         * @return iterator to last inserted element, or \p pos if no element was inserted
          */
         auto insert_after(const const_iterator& pos, T&& value) -> iterator;
 
@@ -641,8 +639,7 @@ namespace dsa
          * @param[in] pos const_iterator to insert element after
          * @param[in] count number of elements to insert after \p pos
          * @param[in] value element of type T to be inserted
-         * @retval iterator to last inserted element
-         * @retval iterator to \p pos if no element was inserted
+         * @return iterator to last inserted element, or \p pos if no element was inserted
          */
         auto insert_after(const const_iterator& pos, size_type count, const_reference value) -> iterator;
 
@@ -652,8 +649,7 @@ namespace dsa
          * @param[in] pos const_iterator to insert element after
          * @param[in] first element defining range of elements to insert
          * @param[in] last element definig range of elements to insert
-         * @retval iterator to last inserted element
-         * @retval iterator to \p pos if no element was inserted
+         * @return iterator to last inserted element, or \p pos if no element was inserted
          */
         template<typename InputIt>
             requires std::input_iterator<InputIt>
@@ -664,8 +660,7 @@ namespace dsa
          *
          * @param[in] pos const_iterator to insert element after
          * @param[in] init_list initializer_list with elements to insert after \p pos
-         * @retval iterator to last inserted element
-         * @retval iterator to \p pos if no element was inserted
+         * @return iterator to last inserted element, or \p pos if no element was inserted
          */
         auto insert_after(const const_iterator& pos, std::initializer_list<T> init_list) -> iterator;
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -764,7 +764,7 @@ namespace dsa
          *
          * @param[in,out] other object to swap content with
          */
-        void swap(ForwardList<T>& other) noexcept(std::is_nothrow_swappable_v<T>);
+        void swap(ForwardList<T>& other) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value);
 
         /**
          * @brief Function combines two sorted ForwardLists into one sorted ForwardList
@@ -1579,7 +1579,8 @@ namespace dsa
     }
 
     template<typename T>
-    void ForwardList<T>::swap(ForwardList<T>& other) noexcept(std::is_nothrow_swappable_v<T>)
+    void ForwardList<T>::swap(ForwardList<T>& other)
+        noexcept(std::allocator_traits<allocator_type>::is_always_equal::value)
     {
         std::swap(m_head->m_next, other.m_head->m_next);
         std::swap(m_size, other.m_size);

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1845,14 +1845,9 @@ namespace dsa
     template<typename T>
     auto operator<<(std::ostream& out, const ForwardList<T>& list) -> std::ostream&
     {
-        if (list.empty())
-        {
-            return out;
-        }
-
         for (auto it = list.cbegin(); it != list.cend(); ++it)
         {
-            T value = *it;
+            const T& value = *it;
             out << value << ' ';
         }
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -356,43 +356,39 @@ namespace dsa
 
         /**
          * @brief Alias for size type used in class
-         *
-         * @tparam T size type
          */
         using size_type = std::size_t;
 
         /**
          * @brief Alias for pointer difference type used in class
-         *
-         * @tparam T pointer size type
          */
         using difference_type = std::ptrdiff_t;
 
         /**
          * @brief Alias for pointer to data type used in class
          *
-         * @tparam T* pointer to data type
+         * @tparam value_type* pointer to data type
          */
         using pointer = value_type*;
 
         /**
          * @brief Alias for const pointer to data type used in class
          *
-         * @tparam T* pointer to data type
+         * @tparam value_type* pointer to data type
          */
         using const_pointer = const value_type*;
 
         /**
          * @brief Alias for reference to data type used in class
          *
-         * @tparam T& reference to data type
+         * @tparam value_type& reference to data type
          */
         using reference = value_type&;
 
         /**
          * @brief Alias for const reference to data type used in class
          *
-         * @tparam T& const reference to data type
+         * @tparam value_type& const reference to data type
          */
         using const_reference = const value_type&;
 

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1361,19 +1361,16 @@ namespace dsa
     template<typename T>
     void ForwardList<T>::clear()
     {
-        if (m_head)
+        NodeBase* temp{ m_head->m_next };
+        while (temp)
         {
-            NodeBase* temp{ m_head->m_next };
-            while (temp)
-            {
-                m_head->m_next = temp->m_next;
-                destroy_node(temp);
-                temp = m_head->m_next;
-            }
-
-            m_size = 0;
-            m_head->m_next = nullptr;
+            m_head->m_next = temp->m_next;
+            destroy_node(temp);
+            temp = m_head->m_next;
         }
+
+        m_size = 0;
+        m_head->m_next = nullptr;
     }
 
     template<typename T>

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -1733,12 +1733,8 @@ namespace dsa
             {
                 if (predicate(node->value()))
                 {
-                    NodeBase* to_remove = temp->m_next;
-                    temp->m_next = to_remove->m_next;
-                    destroy_node(to_remove);
-
+                    erase_element_after(ForwardListIterator<false>(temp));
                     removed_count++;
-                    m_size--;
                     continue;
                 }
             }

--- a/tests/forward_list/forward_list_get_test.cpp
+++ b/tests/forward_list/forward_list_get_test.cpp
@@ -16,6 +16,7 @@
 #include <exception>
 #include <initializer_list>
 #include <iostream>
+#include <iterator>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -32,8 +33,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         for (size_t i = 0; i < list1_size; i++)
         {
             const int temp = list1.front();
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            tests::compare("ForwardList1", temp, expected1.begin()[i]);
+            tests::compare("ForwardList1", temp, *std::next(expected1.begin(), static_cast<ptrdiff_t>(i)));
             list1.pop_front();
         }
 

--- a/tests/forward_list/forward_list_grow_test.cpp
+++ b/tests/forward_list/forward_list_grow_test.cpp
@@ -51,9 +51,11 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list2.push_front(30);
         list2.push_front(20);
         list2.push_front(10);
-        list2.insert_after(list2.cbegin(), 5, 5);
+        auto list2_it = list2.insert_after(list2.cbegin(), 5, 5);
         const std::initializer_list<int> expected2 = { 10, 5, 5, 5, 5, 5, 20, 30, 40, 50 };
         tests::compare("ForwardList2", list2, expected2);
+        tests::compare("ForwardList2 it", *list2_it, *std::next(list2.begin(), 5));
+        tests::compare("ForwardList2 it", *std::next(list2_it), *std::next(list2.begin(), 6));
 
         dsa::ForwardList<int> list3 = dsa::ForwardList<int>(1, 50);
         list3.push_front(40);
@@ -254,16 +256,23 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::ForwardList<std::unique_ptr<int>> list23{};
         auto ptr23 = std::make_unique<int>(1);
         auto list23_it = list23.insert_after(list23.end(), std::move(ptr23));
+        tests::compare("ForwardList23 size", list23.size(), static_cast<std::size_t>(0));
         tests::compare("ForwardList23 it", list23_it == nullptr, true);
 
         dsa::ForwardList<int> list24{ 0, 10, 20 };
         dsa::ForwardList<int> list25{ 30, 40, 50 };
         auto list24_it = list24.insert_after(list24.begin(), list25.begin(), std::next(list25.begin()));
         const std::initializer_list<int> expected24{ 0, 30, 10, 20 };
-        const std::initializer_list<int> expected28{ 30, 40, 50 };
+        const std::initializer_list<int> expected25{ 30, 40, 50 };
         tests::compare("ForwardList24", list24, expected24);
         tests::compare("ForwardList24 it", *list24_it, list25.front());
-        tests::compare("ForwardList25", list25, expected28);
+        tests::compare("ForwardList25", list25, expected25);
+
+        dsa::ForwardList<int> list26{ 40 };
+        auto list26_it = list26.insert_after(list26.begin(), {});
+        const std::initializer_list<int> expected26 = { 40 };
+        tests::compare("ForwardList26", list26, expected26);
+        tests::compare("ForwardList26 it", list26_it == list26.begin(), true);
 
 
         std::cout << "Compare operations results with std container\n\n";

--- a/tests/forward_list/forward_list_itors_test.cpp
+++ b/tests/forward_list/forward_list_itors_test.cpp
@@ -205,55 +205,124 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("citer11e", citer11e == dsa::ForwardList<int>::const_iterator(nullptr), true);
 
         // increment iterator
-        dsa::ForwardList<int> list12 = dsa::ForwardList<int>{ 10, 20, 30 };
-        std::cout << "ForwardList12\t" << list12 << '\n';
-        auto it_12 = list12.begin();
-        tests::compare("it_12", *it_12, 10);
-        it_12++;
-        tests::compare("it_12", *it_12, 20);
-        it_12++;
-        tests::compare("it_12", *it_12, 30);
-        it_12++;
+        dsa::ForwardList<int> list12a = dsa::ForwardList<int>{ 10, 20, 30 };
+        std::cout << "List12a\t" << list12a << '\n';
+        auto it_12a = list12a.begin();
+        tests::compare("it_12", *it_12a, 10);
+        ++it_12a;
+        tests::compare("it_12a", *it_12a, 20);
+        ++it_12a;
+        tests::compare("it_12a", *it_12a, 30);
+        ++it_12a;
+        ++it_12a;
+        std::cout << '\n';
+
+        dsa::ForwardList<int> list12b = dsa::ForwardList<int>{ 10, 20, 30 };
+        std::cout << "List12b\t" << list12b << '\n';
+        auto it_12b = list12b.begin();
+        tests::compare("it_12b", *it_12b, 10);
+        it_12b++;
+        tests::compare("it_12", *it_12b, 20);
+        it_12b++;
+        tests::compare("it_12", *it_12b, 30);
+        it_12b++;
+        it_12b++;
         std::cout << '\n';
 
         // increment const_iterator
-        const dsa::ForwardList<int> list13 = dsa::ForwardList<int>{ 10, 20, 30 };
-        std::cout << "ForwardList13\t" << list13 << '\n';
-
-        auto cit_13 = list13.cbegin();
-        tests::compare("cit_13", *cit_13, 10);
-        cit_13++;
-        tests::compare("cit_13", *cit_13, 20);
-        cit_13++;
-        tests::compare("cit_13", *cit_13, 30);
-        cit_13++;
+        const dsa::ForwardList<int> list13a = dsa::ForwardList<int>{ 10, 20, 30 };
+        std::cout << "List13a\t" << list13a << '\n';
+        auto cit_13a = list13a.cbegin();
+        tests::compare("cit_13a", *cit_13a, 10);
+        ++cit_13a;
+        tests::compare("cit_13a", *cit_13a, 20);
+        ++cit_13a;
+        tests::compare("cit_13a", *cit_13a, 30);
+        ++cit_13a;
+        ++cit_13a;
         std::cout << '\n';
 
-        // test throwing 'runtime_error' exception from dereferencing invalid iterator
+        const dsa::ForwardList<int> list13b = dsa::ForwardList<int>{ 10, 20, 30 };
+        std::cout << "List13b\t" << list13b << '\n';
+        auto cit_13b = list13b.cbegin();
+        tests::compare("cit_13b", *cit_13b, 10);
+        cit_13b++;
+        tests::compare("cit_13b", *cit_13b, 20);
+        cit_13b++;
+        tests::compare("cit_13b", *cit_13b, 30);
+        cit_13b++;
+        cit_13b++;
+        std::cout << '\n';
+
         try
         {
-            const dsa::ForwardList<int> list14;
-            std::cout << *list14.begin();
+            const dsa::ForwardList<int> list14a;
+            std::cout << *list14a.begin();
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
         }
         catch (const std::runtime_error&)
         {
-            std::cout << "list14 runtime error exception handled correctly\n\n";
+            std::cout << "list14a runtime error exception handled correctly\n\n";
         }
 
         try
         {
-            const dsa::ForwardList<int> list15{ 1, 2, 3 };
-            std::cout << *list15.end();
+            const dsa::ForwardList<int> list14b;
+            std::cout << list14b.begin().operator->();
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
         }
         catch (const std::runtime_error&)
         {
-            std::cout << "list15 runtime error exception handled correctly\n\n";
+            std::cout << "list14b runtime error exception handled correctly\n\n";
         }
 
         try
         {
-            const dsa::ForwardList<int> list16;
-            std::cout << list16.begin().operator->();
+            const dsa::ForwardList<int> list15a{ 1, 2, 3 };
+            std::cout << *list15a.end();
+            std::cout << list15a.begin().operator->() << '\n';
+            std::cout << list15a.end().operator->() << '\n';
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error&)
+        {
+            std::cout << "list15a runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            const dsa::ForwardList<int> list15b{ 1, 2, 3 };
+            std::cout << *list15b.begin().operator->();
+            std::cout << *list15b.end().operator->();
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
+        }
+        catch (const std::runtime_error&)
+        {
+            std::cout << "list15b runtime error exception handled correctly\n\n";
+        }
+
+        try
+        {
+            dsa::ForwardList<int> list16 = dsa::ForwardList<int>{};
+            auto it16 = list16.begin();
+            std::advance(it16, 5);
+            std::cout << *it16;
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
         }
         catch (const std::runtime_error&)
         {
@@ -262,9 +331,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         try
         {
-            const dsa::ForwardList<int> list17{ 1, 2, 3 };
-            std::cout << *list17.begin().operator->();
-            std::cout << *list17.end().operator->();
+            const dsa::ForwardList<int> list17{};
+            std::cout << list17.front();
+
+            // command should not be reached
+            tests::failed_count()++;
+            std::cout << "ThrowingType should throw error\n\n";
         }
         catch (const std::runtime_error&)
         {

--- a/tests/forward_list/forward_list_merge_test.cpp
+++ b/tests/forward_list/forward_list_merge_test.cpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <initializer_list>
 #include <iostream>
+#include <iterator>
 #include <utility>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
@@ -240,6 +241,41 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<std::string> expected42{ "2a", "1b", "1a" };
         tests::compare("ForwardList42", list42, expected42);
 
+        // test order of equal elements
+        dsa::ForwardList<int> list43{ 1, 1 };
+        auto addr43_1 = list43.begin();
+        auto addr43_2 = std::next(list43.begin());
+        dsa::ForwardList<int> list44{ 1, 2 };
+        auto addr44_1 = list44.begin();
+        auto addr44_2 = std::next(list44.begin());
+        list43.merge(list44);
+        const std::initializer_list<int> expected43 = { 1, 1, 1, 2 };
+        tests::compare("ForwardList43", list43, expected43);
+        const std::initializer_list<int> expected44 = {};
+        tests::compare("ForwardList44", list44, expected44);
+        tests::compare("ForwardList43 it 43_1", list43.begin() == addr43_1, true);
+        tests::compare("ForwardList43 it 43_2", std::next(list43.begin(), 1) == addr43_2, true);
+        tests::compare("ForwardList43 it 44_1", std::next(list43.begin(), 2) == addr44_1, true);
+        tests::compare("ForwardList43 it 44_2", std::next(list43.begin(), 3) == addr44_2, true);
+
+        dsa::ForwardList<int> list45{ 1, 1 };
+        list45.sort(std::greater<>());
+        auto addr45_1 = list45.begin();
+        auto addr45_2 = std::next(list45.begin());
+        dsa::ForwardList<int> list46{ 1, 2 };
+        list46.sort(std::greater<>());
+        auto addr46_1 = list46.begin();
+        auto addr46_2 = std::next(list46.begin());
+        list45.merge(list46, std::greater<>());
+        const std::initializer_list<int> expected45 = { 2, 1, 1, 1 };
+        tests::compare("ForwardList45", list45, expected45);
+        const std::initializer_list<int> expected46 = {};
+        tests::compare("ForwardList46", list46, expected46);
+        tests::compare("ForwardList45 it 48_1", list45.begin() == addr46_1, true);
+        tests::compare("ForwardList45 it 47_1", std::next(list45.begin(), 1) == addr45_1, true);
+        tests::compare("ForwardList45 it 47_2", std::next(list45.begin(), 2) == addr45_2, true);
+        tests::compare("ForwardList45 it 48_2", std::next(list45.begin(), 3) == addr46_2, true);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -395,6 +431,36 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list42.merge(std_list41, std::greater<>());
         tests::compare("ForwardList41 vs std", list41, std_list41);
         tests::compare("ForwardList42 vs std", list42, std_list42);
+
+        std::forward_list<int> std_list43{ 1, 1 };
+        auto std_addr43_1 = std_list43.begin();
+        auto std_addr43_2 = std::next(std_list43.begin());
+        std::forward_list<int> std_list44{ 1, 2 };
+        auto std_addr44_1 = std_list44.begin();
+        auto std_addr44_2 = std::next(std_list44.begin());
+        std_list43.merge(std_list44);
+        tests::compare("ForwardList43 vs std", list43, std_list43);
+        tests::compare("ForwardList44 vs std", list44, std_list44);
+        tests::compare("ForwardList43 it 43_1 vs std", std_list43.begin() == std_addr43_1, true);
+        tests::compare("ForwardList43 it 43_2 vs std", std::next(std_list43.begin(), 1) == std_addr43_2, true);
+        tests::compare("ForwardList43 it 44_1 vs std", std::next(std_list43.begin(), 2) == std_addr44_1, true);
+        tests::compare("ForwardList43 it 44_2 vs std", std::next(std_list43.begin(), 3) == std_addr44_2, true);
+
+        std::forward_list<int> std_list45{ 1, 1 };
+        std_list45.sort(std::greater<>());
+        auto std_addr45_1 = std_list45.begin();
+        auto std_addr45_2 = std::next(std_list45.begin());
+        std::forward_list<int> std_list46{ 1, 2 };
+        std_list46.sort(std::greater<>());
+        auto std_addr46_1 = std_list46.begin();
+        auto std_addr46_2 = std::next(std_list46.begin());
+        std_list45.merge(std_list46, std::greater<>());
+        tests::compare("ForwardList45 vs std", list45, std_list45);
+        tests::compare("ForwardList46 vs std", list46, std_list46);
+        tests::compare("ForwardList45 it 46_1 vs std", std_list45.begin() == std_addr46_1, true);
+        tests::compare("ForwardList45 it 45_1 vs std", std::next(std_list45.begin(), 1) == std_addr45_1, true);
+        tests::compare("ForwardList45 it 45_2 vs std", std::next(std_list45.begin(), 2) == std_addr45_2, true);
+        tests::compare("ForwardList45 it 46_2 vs std", std::next(std_list45.begin(), 3) == std_addr46_2, true);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_merge_test.cpp
+++ b/tests/forward_list/forward_list_merge_test.cpp
@@ -170,6 +170,76 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // NOLINTNEXTLINE(bugprone-use-after-move)
         tests::compare("ForwardList28", list28, il_1);
 
+        dsa::ForwardList<std::string> list29{ "1a", "1b", "2a" };
+        dsa::ForwardList<std::string> list30{ "2b", "1c", "1d" };
+        list29.sort();
+        list30.sort();
+        list29.merge(list30);
+        const std::initializer_list<std::string> expected29{ "1a", "1b", "1c", "1d", "2a", "2b" };
+        tests::compare("ForwardList29", list29, expected29);
+        const std::initializer_list<std::string> expected30{};
+        tests::compare("ForwardList30", list30, expected30);
+
+        dsa::ForwardList<std::string> list31{ "1a", "1b", "2a" };
+        dsa::ForwardList<std::string> list32{ "2b", "1c", "1d" };
+        list31.sort(std::less<>());
+        list32.sort(std::less<>());
+        list31.merge(list32, std::less<>());
+        const std::initializer_list<std::string> expected31{ "1a", "1b", "1c", "1d", "2a", "2b" };
+        tests::compare("ForwardList31", list31, expected31);
+        const std::initializer_list<std::string> expected32{};
+        tests::compare("ForwardList32", list32, expected32);
+
+        dsa::ForwardList<std::string> list33{ "1a", "1b", "2a" };
+        dsa::ForwardList<std::string> list34{ "2b", "1c", "1d" };
+        list33.sort(std::greater<>());
+        list34.sort(std::greater<>());
+        list33.merge(list34, std::greater<>());
+        const std::initializer_list<std::string> expected33{ "2b", "2a", "1d", "1c", "1b", "1a" };
+        tests::compare("ForwardList33", list33, expected33);
+        const std::initializer_list<std::string> expected34{};
+        tests::compare("ForwardList34", list34, expected34);
+
+        dsa::ForwardList<std::string> list35{ "2a", "1a", "1b" };
+        dsa::ForwardList<std::string> list36{};
+        list35.sort(std::less<>());
+        list36.sort(std::less<>());
+        list35.merge(list36, std::less<>());
+        const std::initializer_list<std::string> expected35{ "1a", "1b", "2a" };
+        tests::compare("ForwardList35", list35, expected35);
+        const std::initializer_list<std::string> expected36{};
+        tests::compare("ForwardList36", list36, expected36);
+
+        dsa::ForwardList<std::string> list37{};
+        dsa::ForwardList<std::string> list38{ "2a", "1a", "1b" };
+        list37.sort(std::less<>());
+        list38.sort(std::less<>());
+        list37.merge(list38, std::less<>());
+        const std::initializer_list<std::string> expected37{ "1a", "1b", "2a" };
+        tests::compare("ForwardList37", list37, expected37);
+        const std::initializer_list<std::string> expected38{};
+        tests::compare("ForwardList38", list38, expected38);
+
+        dsa::ForwardList<std::string> list39{ "1a", "1b", "2a" };
+        dsa::ForwardList<std::string> list40{};
+        list39.sort(std::greater<>());
+        list40.sort(std::greater<>());
+        list40.merge(list39, std::greater<>());
+        const std::initializer_list<std::string> expected39{};
+        tests::compare("ForwardList39", list39, expected39);
+        const std::initializer_list<std::string> expected40{ "2a", "1b", "1a" };
+        tests::compare("ForwardList40", list40, expected40);
+
+        dsa::ForwardList<std::string> list41{};
+        dsa::ForwardList<std::string> list42{ "1a", "1b", "2a" };
+        list41.sort(std::greater<>());
+        list42.sort(std::greater<>());
+        list42.merge(list41, std::greater<>());
+        const std::initializer_list<std::string> expected41{};
+        tests::compare("ForwardList41", list41, expected41);
+        const std::initializer_list<std::string> expected42{ "2a", "1b", "1a" };
+        tests::compare("ForwardList42", list42, expected42);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -269,6 +339,62 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::forward_list<int> std_list26;
         std_list26.merge(std_list26);
         tests::compare("ForwardList26 vs std", list26, std_list26);
+
+        std::forward_list<std::string> std_list29{ "1a", "1b", "2a" };
+        std::forward_list<std::string> std_list30{ "2b", "1c", "1d" };
+        std_list29.sort();
+        std_list30.sort();
+        std_list29.merge(std_list30);
+        tests::compare("ForwardList29 vs std", list29, std_list29);
+        tests::compare("ForwardList30 vs std", list30, std_list30);
+
+        std::forward_list<std::string> std_list31{ "1a", "1b", "2a" };
+        std::forward_list<std::string> std_list32{ "2b", "1c", "1d" };
+        std_list31.sort(std::less<>());
+        std_list32.sort(std::less<>());
+        std_list31.merge(std_list32, std::less<>());
+        tests::compare("ForwardList31 vs std", list31, std_list31);
+        tests::compare("ForwardList32 vs std", list32, std_list32);
+
+        std::forward_list<std::string> std_list33{ "1a", "1b", "2a" };
+        std::forward_list<std::string> std_list34{ "2b", "1c", "1d" };
+        std_list33.sort(std::greater<>());
+        std_list34.sort(std::greater<>());
+        std_list33.merge(std_list34, std::greater<>());
+        tests::compare("ForwardList33 vs std", list33, std_list33);
+        tests::compare("ForwardList34 vs std", list34, std_list34);
+
+        std::forward_list<std::string> std_list35{ "2a", "1a", "1b" };
+        std::forward_list<std::string> std_list36{};
+        std_list35.sort(std::less<>());
+        std_list36.sort(std::less<>());
+        std_list35.merge(std_list36, std::less<>());
+        tests::compare("ForwardList35 vs std", list35, std_list35);
+        tests::compare("ForwardList36 vs std", list36, std_list36);
+
+        std::forward_list<std::string> std_list37{};
+        std::forward_list<std::string> std_list38{ "2a", "1a", "1b" };
+        std_list37.sort(std::less<>());
+        std_list38.sort(std::less<>());
+        std_list37.merge(std_list38, std::less<>());
+        tests::compare("ForwardList37 vs std", list37, std_list37);
+        tests::compare("ForwardList38 vs std", list38, std_list38);
+
+        std::forward_list<std::string> std_list39{ "1a", "1b", "2a" };
+        std::forward_list<std::string> std_list40{};
+        std_list39.sort(std::greater<>());
+        std_list40.sort(std::greater<>());
+        std_list40.merge(std_list39, std::greater<>());
+        tests::compare("ForwardList39 vs std", list39, std_list39);
+        tests::compare("ForwardList40 vs std", list40, std_list40);
+
+        std::forward_list<std::string> std_list41{};
+        std::forward_list<std::string> std_list42{ "1a", "1b", "2a" };
+        std_list41.sort(std::greater<>());
+        std_list42.sort(std::greater<>());
+        std_list42.merge(std_list41, std::greater<>());
+        tests::compare("ForwardList41 vs std", list41, std_list41);
+        tests::compare("ForwardList42 vs std", list42, std_list42);
 
 
         tests::print_stats();

--- a/tests/forward_list/forward_list_merge_test.cpp
+++ b/tests/forward_list/forward_list_merge_test.cpp
@@ -154,6 +154,22 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list26.merge(list26);
         tests::compare("ForwardList26", list26, {});
 
+        // self merge with move semantics should be aborted
+        // compare result with initial input
+        dsa::ForwardList<int> list27{ il_1 };
+        list27.merge(std::move(list27));
+        // intentional use of moved object
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        tests::compare("ForwardList27", list27, il_1);
+
+        // self merge with move semantics should be aborted
+        // compare result with initial input
+        dsa::ForwardList<int> list28{ il_1 };
+        list28.merge(std::move(list28), std::greater<>());
+        // intentional use of moved object
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        tests::compare("ForwardList28", list28, il_1);
+
 
         std::cout << "Compare operations results with std container\n\n";
 

--- a/tests/forward_list/forward_list_operators_test.cpp
+++ b/tests/forward_list/forward_list_operators_test.cpp
@@ -224,6 +224,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("(list7 <=> list8) == (std_list7 <=> std_list8)",
             (list7 <=> list8) == (std_list7 <=> std_list8), true);
 
+        // test noexcept
+
+        // operators
+        static_assert(!noexcept(std::forward_list<tests::ThrowingType>{1} == std::forward_list<tests::ThrowingType>{1}));
+        static_assert(!noexcept(std::forward_list<tests::ThrowingType>{1} <=> std::forward_list<tests::ThrowingType>{1}));
+
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_set_test.cpp
+++ b/tests/forward_list/forward_list_set_test.cpp
@@ -56,11 +56,11 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::ForwardList<int> list6 = dsa::ForwardList<int>({ 0, 10, 20 });
         constexpr int new_value{ 50 };
         list6.front() = new_value;
-        const std::initializer_list<int> expected6{ 50, 10, 20 };
+        const std::initializer_list<int> expected6{ new_value, 10, 20 };
         tests::compare("ForwardList6", list6, expected6);
 
         dsa::ForwardList<int> list7 = dsa::ForwardList<int>({ 0, 10, 20 });
-        const std::initializer_list<int> expected7 = { 1, 2, 3, 4 };
+        const std::initializer_list<int> expected7 = {};
         list7.assign(expected7);
         tests::compare("ForwardList7", list7, expected7);
 

--- a/tests/forward_list/forward_list_shrink_test.cpp
+++ b/tests/forward_list/forward_list_shrink_test.cpp
@@ -141,17 +141,137 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList18", list18, expected18);
         tests::compare("ForwardList18 erase_if count", cnt18, std::size_t{ 3 });
 
-        dsa::ForwardList<int> list19 = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
-        auto cnt19 = dsa::erase_if(list19, [](int val) { return val <= 5; });
-        const std::initializer_list<int> expected19 = { 10, 7, 9 };
-        tests::compare("ForwardList19", list19, expected19);
-        tests::compare("ForwardList19 erase_if count", cnt19, std::size_t{ 3 });
+        dsa::ForwardList<int> list19{ 0, 1, 2, 3, 4, 5 };
+        auto iter19 = list19.erase_after(std::next(list19.end()), std::next(list19.end()));
+        tests::compare("iter19 == nullptr", iter19 == nullptr, true);
+        iter19 = list19.erase_after(list19.begin(), std::next(list19.end()));
+        tests::compare("iter19 == nullptr", iter19 == nullptr, true);
 
-        dsa::ForwardList<int> list20{ 0, 1, 2, 3, 4, 5 };
-        auto iter20 = list20.erase_after(std::next(list20.end()), std::next(list20.end()));
-        tests::compare("iter20 == nullptr", iter20 == nullptr, true);
-        iter20 = list20.erase_after(list20.begin(), std::next(list20.end()));
-        tests::compare("iter20 == nullptr", iter20 == nullptr, true);
+        dsa::ForwardList<int> list20a = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20a = dsa::erase_if(list20a, [](int val) { return val == 5; });
+        const std::initializer_list<int> expected20a = { 0, 10, 2, 7, 9 };
+        tests::compare("ForwardList20a", list20a, expected20a);
+        tests::compare("ForwardList20a erase_if count", cnt20a, std::size_t{ 1 });
+
+        dsa::ForwardList<int> list20b = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20b = dsa::erase_if(list20b, [](int val) { return val != 5; });
+        const std::initializer_list<int> expected20b = { 5 };
+        tests::compare("ForwardList20b", list20b, expected20b);
+        tests::compare("ForwardList20b erase_if count", cnt20b, std::size_t{ 5 });
+
+        dsa::ForwardList<int> list20c = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20c = dsa::erase_if(list20c, [](int val) { return val < 5; });
+        const std::initializer_list<int> expected20c = { 10, 5, 7, 9 };
+        tests::compare("ForwardList20c", list20c, expected20c);
+        tests::compare("ForwardList20c erase_if count", cnt20c, std::size_t{ 2 });
+
+        dsa::ForwardList<int> list20d = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20d = dsa::erase_if(list20d, [](int val) { return val > 5; });
+        const std::initializer_list<int> expected20d = { 0, 2, 5 };
+        tests::compare("ForwardList20d", list20d, expected20d);
+        tests::compare("ForwardList20d erase_if count", cnt20d, std::size_t{ 3 });
+
+        dsa::ForwardList<int> list20e = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20e = dsa::erase_if(list20e, [](int val) { return val <= 5; });
+        const std::initializer_list<int> expected20e = { 10, 7, 9 };
+        tests::compare("ForwardList20e", list20e, expected20e);
+        tests::compare("ForwardList20e erase_if count", cnt20e, std::size_t{ 3 });
+
+        dsa::ForwardList<int> list20f = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20f = dsa::erase_if(list20f, [](int val) { return val >= 5; });
+        const std::initializer_list<int> expected20f = { 0, 2 };
+        tests::compare("ForwardList20f", list20f, expected20f);
+        tests::compare("ForwardList20f erase_if count", cnt20f, std::size_t{ 4 });
+
+        dsa::ForwardList<int> list20g = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20g = dsa::erase_if(list20g, [](int val) { return val < (-5); });
+        const std::initializer_list<int> expected20g = { 0, 10, 2, 5, 7, 9 };
+        tests::compare("ForwardList20g", list20g, expected20g);
+        tests::compare("ForwardList20g erase_if count", cnt20g, std::size_t{ 0 });
+
+        dsa::ForwardList<int> list20h = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20h = dsa::erase_if(list20h, [](int val) { return val > (-5); });
+        const std::initializer_list<int> expected20h = { };
+        tests::compare("ForwardList20h", list20h, expected20h);
+        tests::compare("ForwardList20h erase_if count", cnt20h, std::size_t{ 6 });
+
+        dsa::ForwardList<int> list20i = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20i = dsa::erase_if(list20i, [](int val) { return val <= (-5); });
+        const std::initializer_list<int> expected20i = { 0, 10, 2, 5, 7, 9 };
+        tests::compare("ForwardList20i", list20i, expected20i);
+        tests::compare("ForwardList20i erase_if count", cnt20i, std::size_t{ 0 });
+
+        dsa::ForwardList<int> list20j = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20j = dsa::erase_if(list20j, [](int val) { return val >= (-5); });
+        const std::initializer_list<int> expected20j = { };
+        tests::compare("ForwardList20j", list20j, expected20j);
+        tests::compare("ForwardList20j erase_if count", cnt20j, std::size_t{ 6 });
+
+        dsa::ForwardList<int> list20k = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20k = dsa::erase_if(list20k, [](int val) { return val < 100; });
+        const std::initializer_list<int> expected20k = { };
+        tests::compare("ForwardList20k", list20k, expected20k);
+        tests::compare("ForwardList20k erase_if count", cnt20k, std::size_t{ 6 });
+
+        dsa::ForwardList<int> list20l = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20l = dsa::erase_if(list20l, [](int val) { return val > 100; });
+        const std::initializer_list<int> expected20l = { 0, 10, 2, 5, 7, 9 };
+        tests::compare("ForwardList20l", list20l, expected20l);
+        tests::compare("ForwardList20l erase_if count", cnt20l, std::size_t{ 0 });
+
+        dsa::ForwardList<int> list20m = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20m = dsa::erase_if(list20m, [](int val) { return val <= 100; });
+        const std::initializer_list<int> expected20m = { };
+        tests::compare("ForwardList20m", list20m, expected20m);
+        tests::compare("ForwardList20m erase_if count", cnt20m, std::size_t{ 6 });
+
+        dsa::ForwardList<int> list20n = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt20n = dsa::erase_if(list20n, [](int val) { return val >= 100; });
+        const std::initializer_list<int> expected20n = { 0, 10, 2, 5, 7, 9 };
+        tests::compare("ForwardList20n", list20n, expected20n);
+        tests::compare("ForwardList20n erase_if count", cnt20n, std::size_t{ 0 });
+
+        dsa::ForwardList<int> list21a{};
+        auto cnt21a = list21a.remove_if([](int val) { return val == 0; });
+        const std::initializer_list<int> expected21a = { };
+        tests::compare("ForwardList21a", list21a, expected21a);
+        tests::compare("ForwardList21a removed count", cnt21a, std::size_t{ 0 });
+
+        dsa::ForwardList<int> list21b{};
+        auto cnt21b = list21b.remove_if([](int val) { return val != 0; });
+        const std::initializer_list<int> expected21b = { };
+        tests::compare("ForwardList21b", list21b, expected21b);
+        tests::compare("ForwardList21b removed count", cnt21b, std::size_t{ 0 });
+
+        dsa::ForwardList<int> list21c{};
+        auto cnt21c = list21c.remove_if([](int val) { return val < 0; });
+        const std::initializer_list<int> expected21c = { };
+        tests::compare("ForwardList21c", list21c, expected21c);
+        tests::compare("ForwardList21c removed count", cnt21c, std::size_t{ 0 });
+
+        dsa::ForwardList<int> list21d{};
+        auto cnt21d = list21d.remove_if([](int val) { return val > 0; });
+        const std::initializer_list<int> expected21d = { };
+        tests::compare("ForwardList21d", list21d, expected21d);
+        tests::compare("ForwardList21d removed count", cnt21d, std::size_t{ 0 });
+
+        dsa::ForwardList<int> list21e{};
+        auto cnt21e = list21e.remove_if([](int val) { return val <= 0; });
+        const std::initializer_list<int> expected21e = { };
+        tests::compare("ForwardList21e", list21e, expected21e);
+        tests::compare("ForwardList21e removed count", cnt21e, std::size_t{ 0 });
+
+        dsa::ForwardList<int> list21f{};
+        auto cnt21f = list21f.remove_if([](int val) { return val >= 0; });
+        const std::initializer_list<int> expected21f = { };
+        tests::compare("ForwardList21f", list21f, expected21f);
+        tests::compare("ForwardList21f removed count", cnt21f, std::size_t{ 0 });
+
+        dsa::ForwardList<int> list22{ 0, 1, 2, 3, 4, 5 };
+        auto iter22 = list22.erase_after(std::next(list22.end()), std::next(list22.end()));
+        tests::compare("iter22 == nullptr", iter22 == nullptr, true);
+        iter22 = list22.erase_after(list22.begin(), std::next(list22.end()));
+        tests::compare("iter22 == nullptr", iter22 == nullptr, true);
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -248,12 +368,11 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList18 vs std", list18, std_list18);
         tests::compare("ForwardList18 erase_if count vs std", cnt18, std_cnt18);
 
-        std::forward_list<int> std_list19{ 0, 10, 2, 5, 7, 9 };
+        std::forward_list<int> std_list20a{ 0, 10, 2, 5, 7, 9 };
         // NOLINTNEXTLINE(misc-include-cleaner,-warnings-as-errors)
-        auto std_cnt19 = std::erase_if(std_list19, [](int val) { return val <= 5; });
-        tests::compare("ForwardList19 vs std", list19, std_list19);
-        tests::compare("ForwardList19 erase_if count vs std", cnt19, std_cnt19);
-
+        auto std_cnt20a = std::erase_if(std_list20a, [](int val) { return val == 5; });
+        tests::compare("ForwardList20a vs std", list20a, std_list20a);
+        tests::compare("ForwardList20a erase_if count vs std", cnt20a, std_cnt20a);
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_sort_test.cpp
+++ b/tests/forward_list/forward_list_sort_test.cpp
@@ -81,6 +81,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         std::cout << "Compare operations results with std container\n\n";
 
+        // ascending
         std::forward_list<int> std_list1{ il_1 };
         std_list1.sort();
         tests::compare("ForwardList1 vs std", list1, std_list1);
@@ -106,6 +107,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list6.sort(std::greater<>());
         tests::compare("ForwardList6", list6, std_list6);
 
+        // empty
         std::forward_list<int> std_list7{};
         std_list7.sort();
         tests::compare("ForwardList7", list7, std_list7);

--- a/tests/forward_list/forward_list_swap_test.cpp
+++ b/tests/forward_list/forward_list_swap_test.cpp
@@ -66,7 +66,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         static_assert(noexcept(swap(std::declval<dsa::ForwardList<int>&>(),
             std::declval<dsa::ForwardList<int>&>())));
         // swap throwing type
-        static_assert(!noexcept(swap(std::declval<dsa::ForwardList<tests::ThrowingType>&>(),
+        static_assert(noexcept(swap(std::declval<dsa::ForwardList<tests::ThrowingType>&>(),
             std::declval<dsa::ForwardList<tests::ThrowingType>&>())));
 
 
@@ -83,6 +83,25 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list3.swap(std_list4);
         tests::compare("ForwardList3 vs std", list3, std_list3);
         tests::compare("ForwardList4 vs std", list4, std_list4);
+
+        std::forward_list<int> std_list5(il_1);
+        std::forward_list<int> std_list6(il_2);
+        std::swap(std_list5, std_list6);
+        tests::compare("ForwardList5 vs std", list5, std_list5);
+        tests::compare("ForwardList6 vs std", list6, std_list6);
+
+        std::forward_list<int> std_list7(il_1);
+        std::forward_list<int> std_list8;
+        std::swap(std_list7, std_list8);
+        tests::compare("ForwardList7 vs std", list7, std_list7);
+        tests::compare("ForwardList8 vs std", list8, std_list8);
+
+        // swap safe type
+        static_assert(noexcept(swap(std::declval<std::forward_list<int>&>(),
+            std::declval<std::forward_list<int>&>())));
+        // swap throwing type
+        static_assert(noexcept(swap(std::declval<std::forward_list<tests::ThrowingType>&>(),
+            std::declval<std::forward_list<tests::ThrowingType>&>())));
 
 
         tests::print_stats();


### PR DESCRIPTION
Update implementation of `dsa::ForwardList` to improve consistency, maintainability, and standards compliance with `dsa::List` class.

Closes #41 

## Checklist

- [x] improve initialisation of sentinel node
- [x] improve allocation/deallocation of nodes
- [x] fix order of equal elements in public method `merge`
- [x] fix sentinel address in public method `swap`
- [x] fix attributes of `get_allocator()`
- [x] update tests to match features provided by updated implementation