### PR TITLE
Compare containers content in forward and reverse direction

### DIFF
--- a/tests/common.h
+++ b/tests/common.h
@@ -210,6 +210,14 @@ namespace tests
     }
 
     /**
+     * @brief Template used to detect underlying data type of template
+     *
+     * @tparam T type checked agains the template
+     */
+    template<typename T>
+    using element_type_t = std::remove_cvref_t<decltype(*std::begin(std::declval<const T&>()))>;
+
+    /**
      * @brief Concept that checks if an object of type T allows calling public `front()` method
      *
      * @tparam T type checked agains the concept

--- a/tests/common.h
+++ b/tests/common.h
@@ -215,13 +215,12 @@ namespace tests
     };
 
     /**
-     * @brief Concept that checks if T type provides pop_front() member function
+     * @brief Concept that defines the requirements of a type that allows iteration over elements
      *
-     * Concept is satisfied if an object of type T allows calling public `pop_front()` method
+     * Concept is satisfied if an object of type T provides an iterator and sentinel that denote
+     * the elements of the range
      *
      * @tparam T type checked agains the concept
-     *
-     * @see requires
      */
     template <typename T>
     concept has_ranges = std::ranges::range<T>;

--- a/tests/common.h
+++ b/tests/common.h
@@ -200,9 +200,33 @@ namespace tests
     }
 
     /**
-     * @brief Concept that checks if T type provides pop_front() member function
+     * @brief Concept that checks if an object of type T allows calling public `front()` method
      *
-     * Concept is satisfied if an object of type T allows calling public `pop_front()` method
+     * @tparam T type checked agains the concept
+     *
+     * @see requires
+     */
+    template <typename T>
+    concept has_front = requires(T type)
+    {
+        type.front();
+    };
+
+    /**
+     * @brief Concept that checks if an object of type T allows calling public `pop()` method
+     *
+     * @tparam T type checked agains the concept
+     *
+     * @see requires
+     */
+    template <typename T>
+    concept has_pop = requires(T type)
+    {
+        type.pop();
+    };
+
+    /**
+     * @brief Concept that checks if an object of type T allows calling public `pop_front()` method
      *
      * @tparam T type checked agains the concept
      *
@@ -224,6 +248,32 @@ namespace tests
      */
     template <typename T>
     concept has_ranges = std::ranges::range<T>;
+
+    /**
+     * @brief Concept that checks if an object of type T allows calling public `size()` method
+     *
+     * @tparam T type checked agains the concept
+     *
+     * @see requires
+     */
+    template <typename T>
+    concept has_size = requires(T type)
+    {
+        type.size();
+    };
+
+    /**
+     * @brief Concept that checks if an object of type T allows calling public `top()` method
+     *
+     * @tparam T type checked agains the concept
+     *
+     * @see requires
+     */
+    template <typename T>
+    concept has_top = requires(T type)
+    {
+        type.top();
+    };
 
     /**
      * @brief Function print error message

--- a/tests/common.h
+++ b/tests/common.h
@@ -360,6 +360,115 @@ namespace tests
     }
 
     /**
+     * @brief Function iterates over input container elements to check if they are equal
+     *
+     * @tparam T type of input container
+     * @tparam U type of input container with expected content
+     * @param[in] container input container
+     * @param[in] test_values input container with expected content
+     * @return flag if elements of compared containers are equal
+     */
+    template<typename T, typename U>
+    auto compare_elements(const T& container, const U& test_values) -> bool
+    {
+        if constexpr (has_ranges<T> && has_ranges<U>)
+        {
+            auto iter = container.begin();
+
+            for (const auto& item : test_values)
+            {
+                if (if_error(*iter, item))
+                {
+                    return true;
+                }
+
+                ++iter;
+            }
+        }
+        else if constexpr (has_top<T> && has_pop<T>)
+        {
+            T container_copy{ container };
+            if constexpr (has_ranges<U>)
+            {
+                // handle dsa::Stack and std::stack comparison
+
+                for (const auto& item : test_values)
+                {
+                    if (if_error(container_copy.top(), item))
+                    {
+                        return true;
+                    }
+                    container_copy.pop();
+                }
+            }
+            else if constexpr (has_top<U> && has_pop<U>)
+            {
+                // handle dsa::Stack or std::stack and std::initializer_list comparison
+
+                U test_values_copy{ test_values };
+                for (size_t i = 0; i < test_values.size(); i++)
+                {
+                    if (if_error(container_copy.top(), test_values_copy.top()))
+                    {
+                        return true;
+                    }
+                    container_copy.pop();
+                    test_values_copy.pop();
+                }
+            }
+            else
+            {
+                std::cout << "No constexpr condition was used for elements comparison\n";
+                return true;
+            }
+        }
+        else if constexpr (has_front<T> && has_pop<T>)
+        {
+            T container_copy{ container };
+            if constexpr (has_ranges<U>)
+            {
+                // handle dsa::Queue or std::queue and std::initializer_list comparison
+
+                for (const auto& item : test_values)
+                {
+                    if (if_error(container_copy.front(), item))
+                    {
+                        return true;
+                    }
+                    container_copy.pop();
+                }
+            }
+            else if constexpr (has_front<U> && has_pop<U>)
+            {
+                // handle dsa::Queue and std::queue comparison
+
+                U test_values_copy{ test_values };
+                for (size_t i = 0; i < test_values.size(); i++)
+                {
+                    if (if_error(container_copy.front(), test_values_copy.front()))
+                    {
+                        return true;
+                    }
+                    container_copy.pop();
+                    test_values_copy.pop();
+                }
+            }
+            else
+            {
+                std::cout << "No constexpr condition was used for elements comparison\n";
+                return true;
+            }
+        }
+        else
+        {
+            std::cout << "No constexpr condition was used for elements comparison\n";
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * @brief Function compares two values
      *
      * @tparam T type of compared objects
@@ -421,16 +530,9 @@ namespace tests
             }
         }
 
-        auto iter = container.begin();
-
-        for (const auto& item : test_values)
+        if (compare_elements(container, test_values))
         {
-            if (if_error(*iter, item))
-            {
-                return true;
-            }
-
-            ++iter;
+            return true;
         }
 
         return false;
@@ -480,37 +582,9 @@ namespace tests
             }
         }
 
-        if constexpr (has_top<T> && has_top<U> && has_pop<T> && has_pop<U>)
+        if (compare_elements(container, test_values))
         {
-            // handle dsa::Stack and std::stack comparison
-
-            T container_copy{ container };
-            U test_values_copy{ test_values };
-            for (size_t i = 0; i < test_values.size(); i++)
-            {
-                if (if_error(container_copy.top(), test_values_copy.top()))
-                {
-                    return true;
-                }
-                container_copy.pop();
-                test_values_copy.pop();
-            }
-        }
-        else if constexpr (has_front<T> && has_front<U> && has_pop<T> && has_pop<U>)
-        {
-            // handle dsa::Queue and std::queue comparison
-
-            T container_copy{ container };
-            U test_values_copy{ test_values };
-            for (size_t i = 0; i < test_values.size(); i++)
-            {
-                if (if_error(container_copy.front(), test_values_copy.front()))
-                {
-                    return true;
-                }
-                container_copy.pop();
-                test_values_copy.pop();
-            }
+            return true;
         }
 
         return false;
@@ -560,16 +634,9 @@ namespace tests
             }
         }
 
-        auto array_iter = array.begin();
-
-        for (const auto& item : test_values)
+        if (compare_elements(array, test_values))
         {
-            if (if_error(*array_iter, item))
-            {
-                return true;
-            }
-
-            ++array_iter;
+            return true;
         }
 
         return false;
@@ -619,16 +686,9 @@ namespace tests
             }
         }
 
-        auto array_iter = array.begin();
-
-        for (const auto& item : test_values)
+        if (compare_elements(array, test_values))
         {
-            if (if_error(*array_iter, item))
-            {
-                return true;
-            }
-
-            ++array_iter;
+            return true;
         }
 
         return false;
@@ -677,16 +737,9 @@ namespace tests
             }
         }
 
-        auto vector_iter = list.begin();
-
-        for (const auto& item : test_values)
+        if (compare_elements(list, test_values))
         {
-            if (if_error(*vector_iter, item))
-            {
-                return true;
-            }
-
-            ++vector_iter;
+            return true;
         }
 
         return false;
@@ -735,16 +788,9 @@ namespace tests
             }
         }
 
-        auto vector_iter = vector.begin();
-
-        for (const auto& item : test_values)
+        if (compare_elements(vector, test_values))
         {
-            if (if_error(*vector_iter, item))
-            {
-                return true;
-            }
-
-            ++vector_iter;
+            return true;
         }
 
         return false;

--- a/tests/common.h
+++ b/tests/common.h
@@ -870,23 +870,6 @@ namespace tests
     }
 
     /**
-     * @brief Function compares content of two containers
-     *
-     * @tparam T input container
-     * @tparam U type of data stored in array
-     * @param[in] container_name container name to print
-     * @param[in] container input container
-     * @param[in] expected expected content of input container, stored as array
-     */
-    template<typename T, typename U, size_t N>
-    void compare(const std::string& container_name, const T& container, const std::array<U, N>& expected)
-    {
-        print_containers(container_name, container, "Expected", expected);
-        const bool res = cmp(container, expected);
-        std::cout << (res == 0 ? "PASS" : "FAIL") << "\n\n";
-    }
-
-    /**
      * @brief Function compares two values
      *
      * @tparam T type of compared objects

--- a/tests/common.h
+++ b/tests/common.h
@@ -610,33 +610,6 @@ namespace tests
     }
 
     /**
-     * @brief Function compares values of class supporting ranges iterators and initializer list.
-     *        Both classes must use the same underlying data type.
-     *
-     * @tparam T type of class
-     * @tparam U type of underlying data type
-     * @param[in] container input list
-     * @param[in] test_values input initializer list
-     * @return true if compared containers are different
-     * @return false if containers are equal
-     */
-    template<typename T, typename U>
-    auto cmp(const T& container, const std::initializer_list<U>& test_values) -> Status
-    {
-        if (compare_size(container, test_values) != Status::OK)
-        {
-            return Status::Error;
-        }
-
-        if (compare_elements(container, test_values) != Status::OK)
-        {
-            return Status::Error;
-        }
-
-        return Status::OK;
-    }
-
-    /**
      * @brief Function compares values of two classes
      *
      * @tparam T type of input container
@@ -655,108 +628,6 @@ namespace tests
         }
 
         if (compare_elements(container, test_values) != Status::OK)
-        {
-            return Status::Error;
-        }
-
-        return Status::OK;
-    }
-
-    /**
-     * @brief Function compares values of Array and array
-     *
-     * @tparam T type of elements to compare
-     * @tparam N number of elements in Array
-     * @param[in] array input Array
-     * @param[in] test_values input array
-     * @return true if compared containers are different
-     * @return false if containers are equal
-     */
-    template<typename T, size_t N>
-    auto cmp(const dsa::Array<T, N>& array, const std::array<T, N>& test_values) -> Status
-    {
-        if (compare_size(array, test_values) != Status::OK)
-        {
-            return Status::Error;
-        }
-
-        if (compare_elements(array, test_values) != Status::OK)
-        {
-            return Status::Error;
-        }
-
-        return Status::OK;
-    }
-
-    /**
-     * @brief Function compares values of Array and vector
-     *
-     * @tparam T type of elements to compare
-     * @tparam N number of elements in Array
-     * @param[in] array input Array
-     * @param[in] test_values input vector
-     * @return true if compared containers are different
-     * @return false if containers are equal
-     */
-    template<typename T, size_t N>
-    auto cmp(const dsa::Array<T, N>& array, const std::vector<T>& test_values) -> Status
-    {
-        if (compare_size(array, test_values) != Status::OK)
-        {
-            return Status::Error;
-        }
-
-        if (compare_elements(array, test_values) != Status::OK)
-        {
-            return Status::Error;
-        }
-
-        return Status::OK;
-    }
-
-    /**
-     * @brief Function compares values of List and list
-     *
-     * @tparam T type of elements to compare
-     * @param[in] list input container
-     * @param[in] test_values input expected values
-     * @return true if compared containers are different
-     * @return false if containers are equal
-     */
-    template<typename T>
-    auto cmp(const dsa::List<T>& list, const std::list<T>& test_values) -> Status
-    {
-        if (compare_size(list, test_values) != Status::OK)
-        {
-            return Status::Error;
-        }
-
-        if (compare_elements(list, test_values) != Status::OK)
-        {
-            return Status::Error;
-        }
-
-        return Status::OK;
-    }
-
-    /**
-     * @brief Function compares values of Vector and vector
-     *
-     * @tparam T type of elements to compare
-     * @param[in] vector input Vector
-     * @param[in] test_values input vector
-     * @return true if compared containers are different
-     * @return false if containers are equal
-     */
-    template<typename T>
-    auto cmp(const dsa::Vector<T>& vector, const std::vector<T>& test_values) -> Status
-    {
-        if (compare_size(vector, test_values) != Status::OK)
-        {
-            return Status::Error;
-        }
-
-        if (compare_elements(vector, test_values) != Status::OK)
         {
             return Status::Error;
         }
@@ -895,23 +766,6 @@ namespace tests
         print_containers(container_name, container, "Expected", expected);
         const Status res = cmp(container, expected);
         result(res);
-    }
-
-    /**
-     * @brief Function compares content of two containers
-     *
-     * @tparam T input container
-     * @tparam U type of data stored in initializer list
-     * @param[in] container_name container name to print
-     * @param[in] container input container
-     * @param[in] expected expected content of input container, stored as elements of initializer list
-     */
-    template<typename T, typename U>
-    void compare(const std::string& container_name, const T& container, const std::initializer_list<U>& expected)
-    {
-        print_containers(container_name, container, "Expected", expected);
-        const Status res = cmp(container, expected);
-        print_status(res);
     }
 
     /**

--- a/tests/common.h
+++ b/tests/common.h
@@ -239,6 +239,19 @@ namespace tests
     };
 
     /**
+     * @brief Concept that checks if an object provide printable range for not-string-like types
+     *
+     * @tparam T type checked agains the concept
+     *
+     * @see requires
+     */
+    template <typename T>
+    concept has_printable_range = std::ranges::range<T> &&
+        !std::same_as<std::remove_cvref_t<T>, std::string> &&
+        !std::same_as<std::remove_cvref_t<T>, std::string_view> &&
+        !std::is_convertible_v<T, const char*>;
+
+    /**
      * @brief Concept that defines the requirements of a type that allows iteration over elements
      *
      * Concept is satisfied if an object of type T provides an iterator and sentinel that denote

--- a/tests/common.h
+++ b/tests/common.h
@@ -816,89 +816,18 @@ namespace tests
     }
 
     /**
-     * @brief Function overloads out operator to print all elements of initializer list
+     * @brief Function overloads out operator to print all elements of iterable not-string-like type
      *
-     * @tparam T type of initializer list elements
+     * @tparam T type of not-string-like type
      * @param[in,out] out reference to output stream
-     * @param[in] std_init_list input container of type T
+     * @param[in] container input container of type T
      * @return std::ostream&
      */
     template<typename T>
-    auto operator<<(std::ostream& out, const std::initializer_list<T>& std_init_list) -> std::ostream&
+        requires has_printable_range<T>
+    auto operator<<(std::ostream& out, const T& container) -> std::ostream&
     {
-        for (const auto& item : std_init_list)
-        {
-            out << item << ' ';
-        }
-        return out;
-    }
-
-    /**
-     * @brief Function overloads out operator to print all elements of initializer list
-     *
-     * @tparam T type of initializer list elements
-     * @param[in,out] out reference to output stream
-     * @param[in] std_forward_list input container of type T
-     * @return std::ostream&
-     */
-    template<typename T>
-    auto operator<<(std::ostream& out, const std::forward_list<T>& std_forward_list) -> std::ostream&
-    {
-        for (const auto& item : std_forward_list)
-        {
-            out << item << ' ';
-        }
-        return out;
-    }
-
-    /**
-     * @brief Function overloads out operator to print all elements of list
-     *
-     * @tparam T type of list elements
-     * @param[in,out] out reference to output stream
-     * @param[in] std_list input container of type T
-     * @return std::ostream&
-     */
-    template<typename T>
-    auto operator<<(std::ostream& out, const std::list<T>& std_list) -> std::ostream&
-    {
-        for (const auto& item : std_list)
-        {
-            out << item << ' ';
-        }
-        return out;
-    }
-
-    /**
-     * @brief Function overloads out operator to print all elements of array
-     *
-     * @tparam T type of list elements
-     * @param[in,out] out reference to output stream
-     * @param[in] std_list input container of type T
-     * @return std::ostream&
-     */
-    template<typename T, size_t N >
-    auto operator<<(std::ostream& out, const std::array<T, N>& std_array) -> std::ostream&
-    {
-        for (const auto& item : std_array)
-        {
-            out << item << ' ';
-        }
-        return out;
-    }
-
-    /**
-     * @brief Function overloads out operator to print all elements of vector
-     *
-     * @tparam T type of list elements
-     * @param[in,out] out reference to output stream
-     * @param[in] std_list input container of type T
-     * @return std::ostream&
-     */
-    template<typename T>
-    auto operator<<(std::ostream& out, const std::vector<T>& std_vector) -> std::ostream&
-    {
-        for (const auto& item : std_vector)
+        for (const auto& item : container)
         {
             out << item << ' ';
         }

--- a/tests/common.h
+++ b/tests/common.h
@@ -327,6 +327,39 @@ namespace tests
     }
 
     /**
+     * @brief Function checks size of two container
+     *
+     * @tparam T type of input container
+     * @tparam U type of input container with expected content
+     * @param[in] container input container
+     * @param[in] test_values input container with expected content
+     * @return flag if compared containers have different size
+     */
+    template<typename T, typename U>
+    auto compare_size(const T& container, const U& test_values) -> bool
+    {
+        size_t size{};
+        if constexpr (has_size<U>)
+        {
+            size = test_values.size();
+        }
+        else if constexpr (has_ranges<U>)
+        {
+            size = static_cast<size_t>(std::distance(test_values.begin(), test_values.end()));
+        }
+
+        tests::total_count() += static_cast<int>(size);
+
+        if (if_error(container.size(), size))
+        {
+            std::cout << "Objects of different size!\n";
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * @brief Function compares two values
      *
      * @tparam T type of compared objects
@@ -357,12 +390,8 @@ namespace tests
         requires has_ranges<T>
     auto cmp(const T& container, const std::initializer_list<U>& test_values) -> bool
     {
-        const auto size{ (test_values.size()) };
-        tests::total_count() += static_cast<int>(size);
-
-        if (if_error(container.size(), size))
+        if (compare_size(container, test_values))
         {
-            std::cout << "Objects of different length!\n";
             return true;
         }
 
@@ -420,21 +449,8 @@ namespace tests
     template<typename T, typename U>
     auto cmp(const T& container, const U& test_values) -> bool
     {
-        size_t size{};
-        if constexpr (has_size<U>)
+        if (compare_size(container, test_values))
         {
-            size = test_values.size();
-        }
-        else
-        {
-            size = static_cast<size_t>(std::distance(test_values.begin(), test_values.end()));
-        }
-
-        tests::total_count() += static_cast<int>(size);
-
-        if (if_error(container.size(), size))
-        {
-            std::cout << "Objects of different length!\n";
             return true;
         }
 
@@ -470,7 +486,7 @@ namespace tests
 
             T container_copy{ container };
             U test_values_copy{ test_values };
-            for (size_t i = 0; i < size; i++)
+            for (size_t i = 0; i < test_values.size(); i++)
             {
                 if (if_error(container_copy.top(), test_values_copy.top()))
                 {
@@ -486,7 +502,7 @@ namespace tests
 
             T container_copy{ container };
             U test_values_copy{ test_values };
-            for (size_t i = 0; i < size; i++)
+            for (size_t i = 0; i < test_values.size(); i++)
             {
                 if (if_error(container_copy.front(), test_values_copy.front()))
                 {
@@ -513,12 +529,8 @@ namespace tests
     template<typename T, size_t N>
     auto cmp(dsa::Array<T, N> array, const std::array<T, N>& test_values) -> bool
     {
-        const auto size{ (test_values.size()) };
-        tests::total_count() += static_cast<int>(size);
-
-        if (if_error(array.size(), size))
+        if (compare_size(array, test_values))
         {
-            std::cout << "Objects of different length!\n";
             return true;
         }
 
@@ -576,12 +588,8 @@ namespace tests
     template<typename T, size_t N>
     auto cmp(dsa::Array<T, N> array, const std::vector<T>& test_values) -> bool
     {
-        const auto size{ (test_values.size()) };
-        tests::total_count() += static_cast<int>(size);
-
-        if (if_error(array.size(), size))
+        if (compare_size(array, test_values))
         {
-            std::cout << "Objects of different length!\n";
             return true;
         }
 
@@ -638,12 +646,8 @@ namespace tests
     template<typename T>
     auto cmp(dsa::List<T> list, const std::list<T>& test_values) -> bool
     {
-        const auto size{ (test_values.size()) };
-        tests::total_count() += static_cast<int>(size);
-
-        if (if_error(list.size(), size))
+        if (compare_size(list, test_values))
         {
-            std::cout << "Objects of different length!\n";
             return true;
         }
 
@@ -700,12 +704,8 @@ namespace tests
     template<typename T>
     auto cmp(dsa::Vector<T> vector, const std::vector<T>& test_values) -> bool
     {
-        const auto size{ (test_values.size()) };
-        tests::total_count() += static_cast<int>(size);
-
-        if (if_error(vector.size(), size))
+        if (compare_size(vector, test_values))
         {
-            std::cout << "Objects of different length!\n";
             return true;
         }
 

--- a/tests/common.h
+++ b/tests/common.h
@@ -527,7 +527,7 @@ namespace tests
      * @return false if containers are equal
      */
     template<typename T, size_t N>
-    auto cmp(dsa::Array<T, N> array, const std::array<T, N>& test_values) -> bool
+    auto cmp(const dsa::Array<T, N>& array, const std::array<T, N>& test_values) -> bool
     {
         if (compare_size(array, test_values))
         {
@@ -586,7 +586,7 @@ namespace tests
      * @return false if containers are equal
      */
     template<typename T, size_t N>
-    auto cmp(dsa::Array<T, N> array, const std::vector<T>& test_values) -> bool
+    auto cmp(const dsa::Array<T, N>& array, const std::vector<T>& test_values) -> bool
     {
         if (compare_size(array, test_values))
         {
@@ -644,7 +644,7 @@ namespace tests
      * @return false if containers are equal
      */
     template<typename T>
-    auto cmp(dsa::List<T> list, const std::list<T>& test_values) -> bool
+    auto cmp(const dsa::List<T>& list, const std::list<T>& test_values) -> bool
     {
         if (compare_size(list, test_values))
         {
@@ -702,7 +702,7 @@ namespace tests
      * @return false if containers are equal
      */
     template<typename T>
-    auto cmp(dsa::Vector<T> vector, const std::vector<T>& test_values) -> bool
+    auto cmp(const dsa::Vector<T>& vector, const std::vector<T>& test_values) -> bool
     {
         if (compare_size(vector, test_values))
         {

--- a/tests/common.h
+++ b/tests/common.h
@@ -428,39 +428,6 @@ namespace tests
     }
 
     /**
-     * @brief Function compares values of Stack and initializer list
-     *
-     * @tparam T type of elements to compare
-     * @param[in] stack input Stack
-     * @param[in] test_values input initializer list
-     * @return true if compared containers are different
-     * @return false if containers are equal
-     */
-    template<typename T>
-    auto cmp(dsa::Stack<T> stack, const std::initializer_list<T>& test_values) -> bool
-    {
-        const auto size{ (test_values.size()) };
-        tests::total_count() += static_cast<int>(size);
-
-        if (if_error(stack.size(), size))
-        {
-            std::cout << "Objects of different length!\n";
-            return true;
-        }
-
-        for (const auto& item : test_values)
-        {
-            if (if_error(stack.top(), item))
-            {
-                return true;
-            }
-            stack.pop();
-        }
-
-        return false;
-    }
-
-    /**
      * @brief Function compares values of array class of constant size supporting ranges iterators and initializer list.
      *        Both classes must use the same underlying data type.
      *
@@ -526,22 +493,28 @@ namespace tests
     }
 
     /**
-     * @brief Function compares values of two classes with pop_front() public member function.
-     *        Both classes must use the same underlying data type.
+     * @brief Function compares values of two classes
      *
-     * @tparam T type of first list class
-     * @tparam U type of second list class
-     * @tparam V type of elements to compare
-     * @param[in] container input list
-     * @param[in] test_values input list
+     * @tparam T type of input container
+     * @tparam U type of input container with expected content
+     * @param[in] container input container
+     * @param[in] test_values input container with expected content
      * @return true if compared containers are different
      * @return false if containers are equal
      */
     template<typename T, typename U>
-        requires has_pop_front<T>&& has_pop_front<U>
-    auto cmp(T container, U test_values) -> bool
+    auto cmp(const T& container, const U& test_values) -> bool
     {
-        const auto size{ static_cast<size_t>(std::distance(test_values.begin(), test_values.end())) };
+        size_t size{};
+        if constexpr (has_size<U>)
+        {
+            size = test_values.size();
+        }
+        else
+        {
+            size = static_cast<size_t>(std::distance(test_values.begin(), test_values.end()));
+        }
+
         tests::total_count() += static_cast<int>(size);
 
         if (if_error(container.size(), size))
@@ -576,14 +549,21 @@ namespace tests
             }
         }
 
-        for (size_t i = 0; i < size; i++)
+        if constexpr (has_top<T> && has_top<U> && has_pop<T> && has_pop<U>)
         {
-            if (if_error(container.front(), test_values.front()))
+            // handle dsa::Stack and std::stack comparison
+
+            T container_copy{ container };
+            U test_values_copy{ test_values };
+            for (size_t i = 0; i < size; i++)
             {
-                return true;
+                if (if_error(container_copy.top(), test_values_copy.top()))
+                {
+                    return true;
+                }
+                container_copy.pop();
+                test_values_copy.pop();
             }
-            container.pop_front();
-            test_values.pop_front();
         }
 
         return false;
@@ -617,40 +597,6 @@ namespace tests
                 return true;
             }
             queue.pop();
-            test_values.pop();
-        }
-
-        return false;
-    }
-
-    /**
-     * @brief Function compares values of Stack and stack
-     *
-     * @tparam T type of elements to compare
-     * @param[in] stack input Stack
-     * @param[in] test_values input stack
-     * @return true if compared containers are different
-     * @return false if containers are equal
-     */
-    template<typename T>
-    auto cmp(dsa::Stack<T> stack, std::stack<T> test_values) -> bool
-    {
-        const auto size{ (test_values.size()) };
-        tests::total_count() += static_cast<int>(size);
-
-        if (if_error(stack.size(), size))
-        {
-            std::cout << "Objects of different length!\n";
-            return true;
-        }
-
-        for (size_t i = 0; i < size; i++)
-        {
-            if (if_error(stack.top(), test_values.top()))
-            {
-                return true;
-            }
-            stack.pop();
             test_values.pop();
         }
 
@@ -1073,7 +1019,6 @@ namespace tests
      * @param[in] expected expected content of input container, stored as elements of initializer list
      */
     template<typename T, typename U>
-        requires has_ranges<T>&& has_ranges<U>
     void compare(const std::string& container_name, const T& container, const U& expected)
     {
         print_containers(container_name, container, "Expected", expected);
@@ -1109,23 +1054,6 @@ namespace tests
      */
     template<typename T, typename U>
     void compare(const std::string& container_name, const T& container, std::queue<U> expected)
-    {
-        print_containers(container_name, container, "Expected", expected);
-        const bool res = cmp(container, expected);
-        std::cout << (res == 0 ? "PASS" : "FAIL") << "\n\n";
-    }
-
-    /**
-     * @brief Function compares content of two containers
-     *
-     * @tparam T input container
-     * @tparam U type of data stored in stack
-     * @param[in] container_name container name to print
-     * @param[in] container input container
-     * @param[in] expected expected content of input container, stored as stack
-     */
-    template<typename T, typename U>
-    void compare(const std::string& container_name, const T& container, const std::stack<U>& expected)
     {
         print_containers(container_name, container, "Expected", expected);
         const bool res = cmp(container, expected);

--- a/tests/common.h
+++ b/tests/common.h
@@ -395,39 +395,6 @@ namespace tests
     }
 
     /**
-     * @brief Function compares values of Queue and initializer list
-     *
-     * @tparam T type of elements to compare
-     * @param[in] queue input Queue
-     * @param[in] test_values input initializer list
-     * @return true if compared containers are different
-     * @return false if containers are equal
-     */
-    template<typename T>
-    auto cmp(dsa::Queue<T> queue, const std::initializer_list<T>& test_values) -> bool
-    {
-        const auto size{ (test_values.size()) };
-        tests::total_count() += static_cast<int>(size);
-
-        if (if_error(queue.size(), size))
-        {
-            std::cout << "Objects of different length!\n";
-            return true;
-        }
-
-        for (const auto& item : test_values)
-        {
-            if (if_error(queue.front(), item))
-            {
-                return true;
-            }
-            queue.pop();
-        }
-
-        return false;
-    }
-
-    /**
      * @brief Function compares values of array class of constant size supporting ranges iterators and initializer list.
      *        Both classes must use the same underlying data type.
      *
@@ -565,39 +532,21 @@ namespace tests
                 test_values_copy.pop();
             }
         }
-
-        return false;
-    }
-
-    /**
-     * @brief Function compares values of Queue and queue
-     *
-     * @tparam T type of elements to compare
-     * @param[in] queue input Queue
-     * @param[in] test_values input queue
-     * @return true if compared containers are different
-     * @return false if containers are equal
-     */
-    template<typename T>
-    auto cmp(dsa::Queue<T> queue, std::queue<T>& test_values) -> bool
-    {
-        const auto size{ (test_values.size()) };
-        tests::total_count() += static_cast<int>(size);
-
-        if (if_error(queue.size(), size))
+        else if constexpr (has_front<T> && has_front<U> && has_pop<T> && has_pop<U>)
         {
-            std::cout << "Objects of different length!\n";
-            return true;
-        }
+            // handle dsa::Queue and std::queue comparison
 
-        for (size_t i = 0; i < size; i++)
-        {
-            if (if_error(queue.front(), test_values.front()))
+            T container_copy{ container };
+            U test_values_copy{ test_values };
+            for (size_t i = 0; i < size; i++)
             {
-                return true;
+                if (if_error(container_copy.front(), test_values_copy.front()))
+                {
+                    return true;
+                }
+                container_copy.pop();
+                test_values_copy.pop();
             }
-            queue.pop();
-            test_values.pop();
         }
 
         return false;
@@ -1037,23 +986,6 @@ namespace tests
      */
     template<typename T, typename U>
     void compare(const std::string& container_name, const T& container, const std::initializer_list<U>& expected)
-    {
-        print_containers(container_name, container, "Expected", expected);
-        const bool res = cmp(container, expected);
-        std::cout << (res == 0 ? "PASS" : "FAIL") << "\n\n";
-    }
-
-    /**
-     * @brief Function compares content of two containers
-     *
-     * @tparam T input container
-     * @tparam U type of data stored in queue
-     * @param[in] container_name container name to print
-     * @param[in] container input container
-     * @param[in] expected expected content of input container, stored as queue
-     */
-    template<typename T, typename U>
-    void compare(const std::string& container_name, const T& container, std::queue<U> expected)
     {
         print_containers(container_name, container, "Expected", expected);
         const bool res = cmp(container, expected);

--- a/tests/common.h
+++ b/tests/common.h
@@ -370,6 +370,133 @@ namespace tests
     }
 
     /**
+     * @brief Function compares elements of two iterable container
+     *
+     * @tparam T type of input container
+     * @tparam U type of input container with expected content
+     * @param[in] container input container
+     * @param[in] test_values input container with expected content
+     * @return flag if compared containers have different size
+     */
+    template<typename T, typename U>
+    auto compare_elements_ranges(const T& container, const U& test_values) -> Status
+    {
+        auto iter = container.begin();
+
+        for (const auto& item : test_values)
+        {
+            if (if_error(*iter, item) != Status::OK)
+            {
+                return Status::Error;
+            }
+
+            ++iter;
+        }
+
+        return Status::OK;
+    }
+
+    /**
+     * @brief Function compares elements of stack container
+     *
+     * @tparam T type of input container
+     * @tparam U type of input container with expected content
+     * @param[in] container input container
+     * @param[in] test_values input container with expected content
+     * @return flag if compared containers have different size
+     */
+    template<typename T, typename U>
+    auto compare_elements_stack(const T& container, const U& test_values) -> Status
+    {
+        T container_copy{ container };
+        if constexpr (has_ranges<U>)
+        {
+            // handle dsa::Stack and std::stack comparison
+
+            for (const auto& item : test_values)
+            {
+                if (if_error(container_copy.top(), item) != Status::OK)
+                {
+                    return Status::Error;
+                }
+                container_copy.pop();
+            }
+        }
+        else if constexpr (has_top<U> && has_pop<U>)
+        {
+            // handle dsa::Stack or std::stack and std::initializer_list comparison
+
+            U test_values_copy{ test_values };
+            for (size_t i = 0; i < test_values.size(); i++)
+            {
+                if (if_error(container_copy.top(), test_values_copy.top()) != Status::OK)
+                {
+                    return Status::Error;
+                }
+                container_copy.pop();
+                test_values_copy.pop();
+            }
+        }
+        else
+        {
+            std::cout << "No constexpr condition was used for elements comparison of stack\n";
+            return Status::Error;
+        }
+
+        return Status::OK;
+    }
+
+    /**
+     * @brief Function compares elements of queue container
+     *
+     * @tparam T type of input container
+     * @tparam U type of input container with expected content
+     * @param[in] container input container
+     * @param[in] test_values input container with expected content
+     * @return flag if compared containers have different size
+     */
+    template<typename T, typename U>
+    auto compare_elements_queue(const T& container, const U& test_values) -> Status
+    {
+        T container_copy{ container };
+        if constexpr (has_ranges<U>)
+        {
+            // handle dsa::Queue or std::queue and std::initializer_list comparison
+
+            for (const auto& item : test_values)
+            {
+                if (if_error(container_copy.front(), item) != Status::OK)
+                {
+                    return Status::Error;
+                }
+                container_copy.pop();
+            }
+        }
+        else if constexpr (has_front<U> && has_pop<U>)
+        {
+            // handle dsa::Queue and std::queue comparison
+
+            U test_values_copy{ test_values };
+            for (size_t i = 0; i < test_values.size(); i++)
+            {
+                if (if_error(container_copy.front(), test_values_copy.front()) != Status::OK)
+                {
+                    return Status::Error;
+                }
+                container_copy.pop();
+                test_values_copy.pop();
+            }
+        }
+        else
+        {
+            std::cout << "No constexpr condition was used for elements comparison of queue\n";
+            return Status::Error;
+        }
+
+        return Status::OK;
+    }
+
+    /**
      * @brief Function iterates over input container elements to check if they are equal
      *
      * @tparam T type of input container
@@ -383,89 +510,23 @@ namespace tests
     {
         if constexpr (has_ranges<T> && has_ranges<U>)
         {
-            auto iter = container.begin();
-
-            for (const auto& item : test_values)
+            if (compare_elements_ranges(container, test_values) == Status::Error)
             {
-                if (if_error(*iter, item) != Status::OK)
-                {
-                    return Status::Error;
-                }
-
-                ++iter;
+                return Status::Error;
             }
         }
         else if constexpr (has_top<T> && has_pop<T>)
         {
-            T container_copy{ container };
-            if constexpr (has_ranges<U>)
-            {
-                // handle dsa::Stack and std::stack comparison
 
-                for (const auto& item : test_values)
-                {
-                    if (if_error(container_copy.top(), item) != Status::OK)
-                    {
-                        return Status::Error;
-                    }
-                    container_copy.pop();
-                }
-            }
-            else if constexpr (has_top<U> && has_pop<U>)
+            if (compare_elements_stack(container, test_values) == Status::Error)
             {
-                // handle dsa::Stack or std::stack and std::initializer_list comparison
-
-                U test_values_copy{ test_values };
-                for (size_t i = 0; i < test_values.size(); i++)
-                {
-                    if (if_error(container_copy.top(), test_values_copy.top()) != Status::OK)
-                    {
-                        return Status::Error;
-                    }
-                    container_copy.pop();
-                    test_values_copy.pop();
-                }
-            }
-            else
-            {
-                std::cout << "No constexpr condition was used for elements comparison\n";
                 return Status::Error;
             }
         }
         else if constexpr (has_front<T> && has_pop<T>)
         {
-            T container_copy{ container };
-            if constexpr (has_ranges<U>)
+            if (compare_elements_queue(container, test_values) == Status::Error)
             {
-                // handle dsa::Queue or std::queue and std::initializer_list comparison
-
-                for (const auto& item : test_values)
-                {
-                    if (if_error(container_copy.front(), item) != Status::OK)
-                    {
-                        return Status::Error;
-                    }
-                    container_copy.pop();
-                }
-            }
-            else if constexpr (has_front<U> && has_pop<U>)
-            {
-                // handle dsa::Queue and std::queue comparison
-
-                U test_values_copy{ test_values };
-                for (size_t i = 0; i < test_values.size(); i++)
-                {
-                    if (if_error(container_copy.front(), test_values_copy.front()) != Status::OK)
-                    {
-                        return Status::Error;
-                    }
-                    container_copy.pop();
-                    test_values_copy.pop();
-                }
-            }
-            else
-            {
-                std::cout << "No constexpr condition was used for elements comparison\n";
                 return Status::Error;
             }
         }

--- a/tests/common.h
+++ b/tests/common.h
@@ -604,6 +604,68 @@ namespace tests
     }
 
     /**
+     * @brief Function compares values of List and list
+     *
+     * @tparam T type of elements to compare
+     * @param[in] list input container
+     * @param[in] test_values input expected values
+     * @return true if compared containers are different
+     * @return false if containers are equal
+     */
+    template<typename T>
+    auto cmp(dsa::List<T> list, const std::list<T>& test_values) -> bool
+    {
+        const auto size{ (test_values.size()) };
+        tests::total_count() += static_cast<int>(size);
+
+        if (if_error(list.size(), size))
+        {
+            std::cout << "Objects of different length!\n";
+            return true;
+        }
+
+        if constexpr (std::ranges::bidirectional_range<dsa::List<T>>)
+        {
+            std::vector<T> forward{};
+            for (const auto& item : list)
+            {
+                forward.push_back(item);
+            }
+
+            std::vector<T> backward{};
+            for (const auto& item : std::views::reverse(list))
+            {
+                backward.push_back(item);
+            }
+
+            std::reverse(backward.begin(), backward.end());
+            if (forward == backward)
+            {
+                std::cout << "Forward and backward content OK\n";
+            }
+            if (forward != backward)
+            {
+                std::cout << "Forward and backward content of container is different!\n";
+                return true;
+            }
+        }
+
+        auto vector_iter = list.begin();
+
+        for (const auto& item : test_values)
+        {
+            if (if_error(*vector_iter, item))
+            {
+                return true;
+            }
+
+            ++vector_iter;
+        }
+
+        return false;
+    }
+
+    /**
      * @brief Function compares values of Vector and vector
      *
      * @tparam T type of elements to compare

--- a/tests/common.h
+++ b/tests/common.h
@@ -378,6 +378,44 @@ namespace tests
     }
 
     /**
+     * @brief Function checks if bidirectional container can be reversed preserving valid relation between elements
+     *
+     * @tparam T type of input container
+     * @param[in] container input container
+     * @return flag if compared containers have different size
+     */
+    template<typename T>
+    auto compare_bidirectional(const T& container) -> Status
+    {
+        using Type = element_type_t<T>;
+
+        std::vector<Type> forward{};
+        for (const auto& item : container)
+        {
+            forward.push_back(item);
+        }
+
+        std::vector<Type> backward{};
+        for (const auto& item : std::views::reverse(container))
+        {
+            backward.push_back(item);
+        }
+
+        std::reverse(backward.begin(), backward.end());
+        if (forward == backward)
+        {
+            std::cout << "Forward and backward content OK\n";
+        }
+        if (forward != backward)
+        {
+            std::cout << "Forward and backward content of container is different!\n";
+            return Status::Error;
+        }
+
+        return Status::OK;
+    }
+
+    /**
      * @brief Function compares elements of two iterable container
      *
      * @tparam T type of input container
@@ -516,6 +554,14 @@ namespace tests
     template<typename T, typename U>
     auto compare_elements(const T& container, const U& test_values) -> Status
     {
+        if constexpr (std::ranges::bidirectional_range<T>)
+        {
+            if (compare_bidirectional(container) != Status::OK)
+            {
+                return Status::Error;
+            }
+        }
+
         if constexpr (has_ranges<T> && has_ranges<U>)
         {
             if (compare_elements_ranges(container, test_values) == Status::Error)
@@ -582,32 +628,6 @@ namespace tests
             return Status::Error;
         }
 
-        if constexpr (std::ranges::bidirectional_range<T>)
-        {
-            std::vector<U> forward{};
-            for (const auto& item : container)
-            {
-                forward.push_back(item);
-            }
-
-            std::vector<U> backward{};
-            for (const auto& item : std::views::reverse(container))
-            {
-                backward.push_back(item);
-            }
-
-            std::reverse(backward.begin(), backward.end());
-            if (forward == backward)
-            {
-                std::cout << "Forward and backward content OK\n";
-            }
-            if (forward != backward)
-            {
-                std::cout << "Forward and backward content of container is different!\n";
-                return Status::Error;
-            }
-        }
-
         if (compare_elements(container, test_values) != Status::OK)
         {
             return Status::Error;
@@ -632,32 +652,6 @@ namespace tests
         if (compare_size(container, test_values) != Status::OK)
         {
             return Status::Error;
-        }
-
-        if constexpr (std::ranges::bidirectional_range<T>)
-        {
-            std::vector<T> forward{};
-            for (const auto& item : container)
-            {
-                forward.push_back(item);
-            }
-
-            std::vector<T> backward{};
-            for (const auto& item : std::views::reverse(container))
-            {
-                backward.push_back(item);
-            }
-
-            std::reverse(backward.begin(), backward.end());
-            if (forward == backward)
-            {
-                std::cout << "Forward and backward content OK\n";
-            }
-            if (forward != backward)
-            {
-                std::cout << "Forward and backward content of container is different!\n";
-                return Status::Error;
-            }
         }
 
         if (compare_elements(container, test_values) != Status::OK)
@@ -686,32 +680,6 @@ namespace tests
             return Status::Error;
         }
 
-        if constexpr (std::ranges::bidirectional_range<dsa::Array<T, N>>)
-        {
-            std::vector<T> forward{};
-            for (const auto& item : array)
-            {
-                forward.push_back(item);
-            }
-
-            std::vector<T> backward{};
-            for (const auto& item : std::views::reverse(array))
-            {
-                backward.push_back(item);
-            }
-
-            std::reverse(backward.begin(), backward.end());
-            if (forward == backward)
-            {
-                std::cout << "Forward and backward content OK\n";
-            }
-            if (forward != backward)
-            {
-                std::cout << "Forward and backward content of container is different!\n";
-                return Status::Error;
-            }
-        }
-
         if (compare_elements(array, test_values) != Status::OK)
         {
             return Status::Error;
@@ -736,32 +704,6 @@ namespace tests
         if (compare_size(array, test_values) != Status::OK)
         {
             return Status::Error;
-        }
-
-        if constexpr (std::ranges::bidirectional_range<dsa::Array<T, N>>)
-        {
-            std::vector<T> forward{};
-            for (const auto& item : array)
-            {
-                forward.push_back(item);
-            }
-
-            std::vector<T> backward{};
-            for (const auto& item : std::views::reverse(array))
-            {
-                backward.push_back(item);
-            }
-
-            std::reverse(backward.begin(), backward.end());
-            if (forward == backward)
-            {
-                std::cout << "Forward and backward content OK\n";
-            }
-            if (forward != backward)
-            {
-                std::cout << "Forward and backward content of container is different!\n";
-                return Status::Error;
-            }
         }
 
         if (compare_elements(array, test_values) != Status::OK)
@@ -789,32 +731,6 @@ namespace tests
             return Status::Error;
         }
 
-        if constexpr (std::ranges::bidirectional_range<dsa::List<T>>)
-        {
-            std::vector<T> forward{};
-            for (const auto& item : list)
-            {
-                forward.push_back(item);
-            }
-
-            std::vector<T> backward{};
-            for (const auto& item : std::views::reverse(list))
-            {
-                backward.push_back(item);
-            }
-
-            std::reverse(backward.begin(), backward.end());
-            if (forward == backward)
-            {
-                std::cout << "Forward and backward content OK\n";
-            }
-            if (forward != backward)
-            {
-                std::cout << "Forward and backward content of container is different!\n";
-                return Status::Error;
-            }
-        }
-
         if (compare_elements(list, test_values) != Status::OK)
         {
             return Status::Error;
@@ -838,32 +754,6 @@ namespace tests
         if (compare_size(vector, test_values) != Status::OK)
         {
             return Status::Error;
-        }
-
-        if constexpr (std::ranges::bidirectional_range<dsa::Vector<T>>)
-        {
-            std::vector<T> forward{};
-            for (const auto& item : vector)
-            {
-                forward.push_back(item);
-            }
-
-            std::vector<T> backward{};
-            for (const auto& item : std::views::reverse(vector))
-            {
-                backward.push_back(item);
-            }
-
-            std::reverse(backward.begin(), backward.end());
-            if (forward == backward)
-            {
-                std::cout << "Forward and backward content OK\n";
-            }
-            if (forward != backward)
-            {
-                std::cout << "Forward and backward content of container is different!\n";
-                return Status::Error;
-            }
         }
 
         if (compare_elements(vector, test_values) != Status::OK)

--- a/tests/common.h
+++ b/tests/common.h
@@ -178,6 +178,16 @@ namespace tests
     };
 
     /**
+     * @enum Status
+     * @brief Determines return codes for functions in tests
+     */
+    enum class Status : std::int8_t
+    {
+        OK = 0,                 ///< Function executed sucessfully
+        Error = -1              ///< Function returned error
+    };
+
+    /**
      * @brief Function return number of failed comparisons
      *
      * @return int& reference to failed comparison count
@@ -315,10 +325,10 @@ namespace tests
      * @retval false otherwise
      */
     template<typename T>
-    auto if_error(const T& val1, const T& val2) -> bool
+    auto if_error(const T& val1, const T& val2) -> Status
     {
-        const bool res = val1 != val2;
-        if (res)
+        const Status res = val1 != val2 ? Status::Error : Status::OK;
+        if (res != Status::OK)
         {
             std::cout << "Comparison error! Value " << val1 << " not equal to " << val2 << '\n';
             tests::failed_count()++;
@@ -336,7 +346,7 @@ namespace tests
      * @return flag if compared containers have different size
      */
     template<typename T, typename U>
-    auto compare_size(const T& container, const U& test_values) -> bool
+    auto compare_size(const T& container, const U& test_values) -> Status
     {
         size_t size{};
         if constexpr (has_size<U>)
@@ -350,13 +360,13 @@ namespace tests
 
         tests::total_count() += static_cast<int>(size);
 
-        if (if_error(container.size(), size))
+        if (if_error(container.size(), size) != Status::OK)
         {
             std::cout << "Objects of different size!\n";
-            return true;
+            return Status::Error;
         }
 
-        return false;
+        return Status::OK;
     }
 
     /**
@@ -369,7 +379,7 @@ namespace tests
      * @return flag if elements of compared containers are equal
      */
     template<typename T, typename U>
-    auto compare_elements(const T& container, const U& test_values) -> bool
+    auto compare_elements(const T& container, const U& test_values) -> Status
     {
         if constexpr (has_ranges<T> && has_ranges<U>)
         {
@@ -377,9 +387,9 @@ namespace tests
 
             for (const auto& item : test_values)
             {
-                if (if_error(*iter, item))
+                if (if_error(*iter, item) != Status::OK)
                 {
-                    return true;
+                    return Status::Error;
                 }
 
                 ++iter;
@@ -394,9 +404,9 @@ namespace tests
 
                 for (const auto& item : test_values)
                 {
-                    if (if_error(container_copy.top(), item))
+                    if (if_error(container_copy.top(), item) != Status::OK)
                     {
-                        return true;
+                        return Status::Error;
                     }
                     container_copy.pop();
                 }
@@ -408,9 +418,9 @@ namespace tests
                 U test_values_copy{ test_values };
                 for (size_t i = 0; i < test_values.size(); i++)
                 {
-                    if (if_error(container_copy.top(), test_values_copy.top()))
+                    if (if_error(container_copy.top(), test_values_copy.top()) != Status::OK)
                     {
-                        return true;
+                        return Status::Error;
                     }
                     container_copy.pop();
                     test_values_copy.pop();
@@ -419,7 +429,7 @@ namespace tests
             else
             {
                 std::cout << "No constexpr condition was used for elements comparison\n";
-                return true;
+                return Status::Error;
             }
         }
         else if constexpr (has_front<T> && has_pop<T>)
@@ -431,9 +441,9 @@ namespace tests
 
                 for (const auto& item : test_values)
                 {
-                    if (if_error(container_copy.front(), item))
+                    if (if_error(container_copy.front(), item) != Status::OK)
                     {
-                        return true;
+                        return Status::Error;
                     }
                     container_copy.pop();
                 }
@@ -445,9 +455,9 @@ namespace tests
                 U test_values_copy{ test_values };
                 for (size_t i = 0; i < test_values.size(); i++)
                 {
-                    if (if_error(container_copy.front(), test_values_copy.front()))
+                    if (if_error(container_copy.front(), test_values_copy.front()) != Status::OK)
                     {
-                        return true;
+                        return Status::Error;
                     }
                     container_copy.pop();
                     test_values_copy.pop();
@@ -456,16 +466,16 @@ namespace tests
             else
             {
                 std::cout << "No constexpr condition was used for elements comparison\n";
-                return true;
+                return Status::Error;
             }
         }
         else
         {
             std::cout << "No constexpr condition was used for elements comparison\n";
-            return true;
+            return Status::Error;
         }
 
-        return false;
+        return Status::OK;
     }
 
     /**
@@ -478,7 +488,7 @@ namespace tests
      * @retval false otherwise
      */
     template<typename T>
-    auto cmp(const T& val1, const T& val2) -> bool
+    auto cmp(const T& val1, const T& val2) -> Status
     {
         tests::total_count()++;
         return if_error(val1, val2);
@@ -496,12 +506,11 @@ namespace tests
      * @return false if containers are equal
      */
     template<typename T, typename U>
-        requires has_ranges<T>
-    auto cmp(const T& container, const std::initializer_list<U>& test_values) -> bool
+    auto cmp(const T& container, const std::initializer_list<U>& test_values) -> Status
     {
-        if (compare_size(container, test_values))
+        if (compare_size(container, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
         if constexpr (std::ranges::bidirectional_range<T>)
@@ -526,16 +535,16 @@ namespace tests
             if (forward != backward)
             {
                 std::cout << "Forward and backward content of container is different!\n";
-                return true;
+                return Status::Error;
             }
         }
 
-        if (compare_elements(container, test_values))
+        if (compare_elements(container, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
-        return false;
+        return Status::OK;
     }
 
     /**
@@ -549,11 +558,11 @@ namespace tests
      * @return false if containers are equal
      */
     template<typename T, typename U>
-    auto cmp(const T& container, const U& test_values) -> bool
+    auto cmp(const T& container, const U& test_values) -> Status
     {
-        if (compare_size(container, test_values))
+        if (compare_size(container, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
         if constexpr (std::ranges::bidirectional_range<T>)
@@ -578,16 +587,16 @@ namespace tests
             if (forward != backward)
             {
                 std::cout << "Forward and backward content of container is different!\n";
-                return true;
+                return Status::Error;
             }
         }
 
-        if (compare_elements(container, test_values))
+        if (compare_elements(container, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
-        return false;
+        return Status::OK;
     }
 
     /**
@@ -601,11 +610,11 @@ namespace tests
      * @return false if containers are equal
      */
     template<typename T, size_t N>
-    auto cmp(const dsa::Array<T, N>& array, const std::array<T, N>& test_values) -> bool
+    auto cmp(const dsa::Array<T, N>& array, const std::array<T, N>& test_values) -> Status
     {
-        if (compare_size(array, test_values))
+        if (compare_size(array, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
         if constexpr (std::ranges::bidirectional_range<dsa::Array<T, N>>)
@@ -630,16 +639,16 @@ namespace tests
             if (forward != backward)
             {
                 std::cout << "Forward and backward content of container is different!\n";
-                return true;
+                return Status::Error;
             }
         }
 
-        if (compare_elements(array, test_values))
+        if (compare_elements(array, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
-        return false;
+        return Status::OK;
     }
 
     /**
@@ -653,11 +662,11 @@ namespace tests
      * @return false if containers are equal
      */
     template<typename T, size_t N>
-    auto cmp(const dsa::Array<T, N>& array, const std::vector<T>& test_values) -> bool
+    auto cmp(const dsa::Array<T, N>& array, const std::vector<T>& test_values) -> Status
     {
-        if (compare_size(array, test_values))
+        if (compare_size(array, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
         if constexpr (std::ranges::bidirectional_range<dsa::Array<T, N>>)
@@ -682,16 +691,16 @@ namespace tests
             if (forward != backward)
             {
                 std::cout << "Forward and backward content of container is different!\n";
-                return true;
+                return Status::Error;
             }
         }
 
-        if (compare_elements(array, test_values))
+        if (compare_elements(array, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
-        return false;
+        return Status::OK;
     }
 
     /**
@@ -704,11 +713,11 @@ namespace tests
      * @return false if containers are equal
      */
     template<typename T>
-    auto cmp(const dsa::List<T>& list, const std::list<T>& test_values) -> bool
+    auto cmp(const dsa::List<T>& list, const std::list<T>& test_values) -> Status
     {
-        if (compare_size(list, test_values))
+        if (compare_size(list, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
         if constexpr (std::ranges::bidirectional_range<dsa::List<T>>)
@@ -733,16 +742,16 @@ namespace tests
             if (forward != backward)
             {
                 std::cout << "Forward and backward content of container is different!\n";
-                return true;
+                return Status::Error;
             }
         }
 
-        if (compare_elements(list, test_values))
+        if (compare_elements(list, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
-        return false;
+        return Status::OK;
     }
 
     /**
@@ -755,11 +764,11 @@ namespace tests
      * @return false if containers are equal
      */
     template<typename T>
-    auto cmp(const dsa::Vector<T>& vector, const std::vector<T>& test_values) -> bool
+    auto cmp(const dsa::Vector<T>& vector, const std::vector<T>& test_values) -> Status
     {
-        if (compare_size(vector, test_values))
+        if (compare_size(vector, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
         if constexpr (std::ranges::bidirectional_range<dsa::Vector<T>>)
@@ -784,16 +793,16 @@ namespace tests
             if (forward != backward)
             {
                 std::cout << "Forward and backward content of container is different!\n";
-                return true;
+                return Status::Error;
             }
         }
 
-        if (compare_elements(vector, test_values))
+        if (compare_elements(vector, test_values) != Status::OK)
         {
-            return true;
+            return Status::Error;
         }
 
-        return false;
+        return Status::OK;
     }
 
     /**
@@ -894,8 +903,8 @@ namespace tests
     void compare(const std::string& container_name, const T& container, const U& expected)
     {
         print_containers(container_name, container, "Expected", expected);
-        const bool res = cmp(container, expected);
-        std::cout << (res == 0 ? "PASS" : "FAIL") << "\n\n";
+        const Status res = cmp(container, expected);
+        std::cout << (res == Status::OK ? "PASS" : "FAIL") << "\n\n";
     }
 
     /**
@@ -911,8 +920,8 @@ namespace tests
     void compare(const std::string& container_name, const T& container, const std::initializer_list<U>& expected)
     {
         print_containers(container_name, container, "Expected", expected);
-        const bool res = cmp(container, expected);
-        std::cout << (res == 0 ? "PASS" : "FAIL") << "\n\n";
+        const Status res = cmp(container, expected);
+        std::cout << (res == Status::OK ? "PASS" : "FAIL") << "\n\n";
     }
 
     /**
@@ -927,8 +936,8 @@ namespace tests
     void compare(const std::string& container_name, const T& val1, const T& val2)
     {
         print_containers(container_name, val1, "Expected", val2);
-        const bool res = cmp(val1, val2);
-        std::cout << (res == 0 ? "PASS" : "FAIL") << "\n\n";
+        const Status res = cmp(val1, val2);
+        std::cout << (res == Status::OK ? "PASS" : "FAIL") << "\n\n";
     }
 
     /**
@@ -941,7 +950,7 @@ namespace tests
      * @retval false otherwise
      */
     template<typename T>
-    auto compare(T val1, T val2) -> bool
+    auto compare(T val1, T val2) -> Status
     {
         return cmp(val1, val2);
     }

--- a/tests/common.h
+++ b/tests/common.h
@@ -303,6 +303,32 @@ namespace tests
             return true;
         }
 
+        if constexpr (std::ranges::bidirectional_range<T<U>>)
+        {
+            std::vector<U> forward{};
+            for (const auto& item : container)
+            {
+                forward.push_back(item);
+            }
+
+            std::vector<U> backward{};
+            for (const auto& item : std::views::reverse(container))
+            {
+                backward.push_back(item);
+            }
+
+            std::reverse(backward.begin(), backward.end());
+            if (forward == backward)
+            {
+                std::cout << "Forward and backward content OK\n";
+            }
+            if (forward != backward)
+            {
+                std::cout << "Forward and backward content of container is different!\n";
+                return true;
+            }
+        }
+
         auto iter = container.begin();
 
         for (const auto& item : test_values)
@@ -408,6 +434,32 @@ namespace tests
             return true;
         }
 
+        if constexpr (std::ranges::bidirectional_range<T<U, N>>)
+        {
+            std::vector<U> forward{};
+            for (const auto& item : container)
+            {
+                forward.push_back(item);
+            }
+
+            std::vector<U> backward{};
+            for (const auto& item : std::views::reverse(container))
+            {
+                backward.push_back(item);
+            }
+
+            std::reverse(backward.begin(), backward.end());
+            if (forward == backward)
+            {
+                std::cout << "Forward and backward content OK\n";
+            }
+            if (forward != backward)
+            {
+                std::cout << "Forward and backward content of container is different!\n";
+                return true;
+            }
+        }
+
         auto iter = container.begin();
 
         for (const auto& item : test_values)
@@ -446,6 +498,32 @@ namespace tests
         {
             std::cout << "Objects of different length!\n";
             return true;
+        }
+
+        if constexpr (std::ranges::bidirectional_range<T>)
+        {
+            std::vector<T> forward{};
+            for (const auto& item : container)
+            {
+                forward.push_back(item);
+            }
+
+            std::vector<T> backward{};
+            for (const auto& item : std::views::reverse(container))
+            {
+                backward.push_back(item);
+            }
+
+            std::reverse(backward.begin(), backward.end());
+            if (forward == backward)
+            {
+                std::cout << "Forward and backward content OK\n";
+            }
+            if (forward != backward)
+            {
+                std::cout << "Forward and backward content of container is different!\n";
+                return true;
+            }
         }
 
         for (size_t i = 0; i < size; i++)
@@ -551,6 +629,32 @@ namespace tests
             return true;
         }
 
+        if constexpr (std::ranges::bidirectional_range<dsa::Array<T, N>>)
+        {
+            std::vector<T> forward{};
+            for (const auto& item : array)
+            {
+                forward.push_back(item);
+            }
+
+            std::vector<T> backward{};
+            for (const auto& item : std::views::reverse(array))
+            {
+                backward.push_back(item);
+            }
+
+            std::reverse(backward.begin(), backward.end());
+            if (forward == backward)
+            {
+                std::cout << "Forward and backward content OK\n";
+            }
+            if (forward != backward)
+            {
+                std::cout << "Forward and backward content of container is different!\n";
+                return true;
+            }
+        }
+
         auto array_iter = array.begin();
 
         for (const auto& item : test_values)
@@ -586,6 +690,32 @@ namespace tests
         {
             std::cout << "Objects of different length!\n";
             return true;
+        }
+
+        if constexpr (std::ranges::bidirectional_range<dsa::Array<T, N>>)
+        {
+            std::vector<T> forward{};
+            for (const auto& item : array)
+            {
+                forward.push_back(item);
+            }
+
+            std::vector<T> backward{};
+            for (const auto& item : std::views::reverse(array))
+            {
+                backward.push_back(item);
+            }
+
+            std::reverse(backward.begin(), backward.end());
+            if (forward == backward)
+            {
+                std::cout << "Forward and backward content OK\n";
+            }
+            if (forward != backward)
+            {
+                std::cout << "Forward and backward content of container is different!\n";
+                return true;
+            }
         }
 
         auto array_iter = array.begin();
@@ -684,6 +814,32 @@ namespace tests
         {
             std::cout << "Objects of different length!\n";
             return true;
+        }
+
+        if constexpr (std::ranges::bidirectional_range<dsa::Vector<T>>)
+        {
+            std::vector<T> forward{};
+            for (const auto& item : vector)
+            {
+                forward.push_back(item);
+            }
+
+            std::vector<T> backward{};
+            for (const auto& item : std::views::reverse(vector))
+            {
+                backward.push_back(item);
+            }
+
+            std::reverse(backward.begin(), backward.end());
+            if (forward == backward)
+            {
+                std::cout << "Forward and backward content OK\n";
+            }
+            if (forward != backward)
+            {
+                std::cout << "Forward and backward content of container is different!\n";
+                return true;
+            }
         }
 
         auto vector_iter = vector.begin();

--- a/tests/common.h
+++ b/tests/common.h
@@ -353,9 +353,9 @@ namespace tests
      * @return true if compared containers are different
      * @return false if containers are equal
      */
-    template<template <typename> typename T, typename U>
-        requires has_ranges<T<U>>
-    auto cmp(const T<U>& container, const std::initializer_list<U>& test_values) -> bool
+    template<typename T, typename U>
+        requires has_ranges<T>
+    auto cmp(const T& container, const std::initializer_list<U>& test_values) -> bool
     {
         const auto size{ (test_values.size()) };
         tests::total_count() += static_cast<int>(size);
@@ -366,72 +366,7 @@ namespace tests
             return true;
         }
 
-        if constexpr (std::ranges::bidirectional_range<T<U>>)
-        {
-            std::vector<U> forward{};
-            for (const auto& item : container)
-            {
-                forward.push_back(item);
-            }
-
-            std::vector<U> backward{};
-            for (const auto& item : std::views::reverse(container))
-            {
-                backward.push_back(item);
-            }
-
-            std::reverse(backward.begin(), backward.end());
-            if (forward == backward)
-            {
-                std::cout << "Forward and backward content OK\n";
-            }
-            if (forward != backward)
-            {
-                std::cout << "Forward and backward content of container is different!\n";
-                return true;
-            }
-        }
-
-        auto iter = container.begin();
-
-        for (const auto& item : test_values)
-        {
-            if (if_error(*iter, item))
-            {
-                return true;
-            }
-
-            ++iter;
-        }
-
-        return false;
-    }
-
-    /**
-     * @brief Function compares values of array class of constant size supporting ranges iterators and initializer list.
-     *        Both classes must use the same underlying data type.
-     *
-     * @tparam T type of class
-     * @tparam U type of underlying data type
-     * @param[in] container input list
-     * @param[in] test_values input initializer list
-     * @return true if compared containers are different
-     * @return false if containers are equal
-     */
-    template<template <typename, size_t> typename T, size_t N, typename U>
-        requires has_ranges<T<U, N>>
-    auto cmp(T<U, N> container, const std::initializer_list<U>& test_values) -> bool
-    {
-        const auto size{ (test_values.size()) };
-        tests::total_count() += static_cast<int>(size);
-
-        if (if_error(container.size(), size))
-        {
-            std::cout << "Objects of different length!\n";
-            return true;
-        }
-
-        if constexpr (std::ranges::bidirectional_range<T<U, N>>)
+        if constexpr (std::ranges::bidirectional_range<T>)
         {
             std::vector<U> forward{};
             for (const auto& item : container)

--- a/tests/common.h
+++ b/tests/common.h
@@ -952,6 +952,37 @@ namespace tests
     }
 
     /**
+     * @brief Function print PASS or FAIL message
+     *
+     * @param[in] status result of comparison containers or values
+     */
+    inline void print_status(Status status)
+    {
+        if (status == Status::OK)
+        {
+            std::cout << "PASS\n\n";
+        }
+        else
+        {
+            std::cout << "FAIL\n\n";
+        }
+    }
+
+    /**
+     * @brief Function handle tests results
+     *
+     * @param[in] status result of comparison containers or values
+     */
+    inline void result(Status status)
+    {
+        if (status != Status::OK)
+        {
+            tests::failed_count()++;
+        }
+        print_status(status);
+    }
+
+    /**
      * @brief Function compares content of two containers
      *
      * @tparam T input container
@@ -965,7 +996,7 @@ namespace tests
     {
         print_containers(container_name, container, "Expected", expected);
         const Status res = cmp(container, expected);
-        std::cout << (res == Status::OK ? "PASS" : "FAIL") << "\n\n";
+        result(res);
     }
 
     /**
@@ -982,7 +1013,7 @@ namespace tests
     {
         print_containers(container_name, container, "Expected", expected);
         const Status res = cmp(container, expected);
-        std::cout << (res == Status::OK ? "PASS" : "FAIL") << "\n\n";
+        print_status(res);
     }
 
     /**
@@ -998,7 +1029,7 @@ namespace tests
     {
         print_containers(container_name, val1, "Expected", val2);
         const Status res = cmp(val1, val2);
-        std::cout << (res == Status::OK ? "PASS" : "FAIL") << "\n\n";
+        print_status(res);
     }
 
     /**

--- a/tests/list/list_grow_test.cpp
+++ b/tests/list/list_grow_test.cpp
@@ -439,7 +439,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list6.insert(std_list6.end(), { 40, 50, 60 });
         tests::compare("List6 vs std", list6, std_list6);
 
-        dsa::List<int> std_list7{ 40 };
+        std::list<int> std_list7{ 40 };
         std_list7.insert(std_list7.begin(), { 10, 20, 30 });
         tests::compare("List7 vs std", list7, std_list7);
 

--- a/tests/queue/queue_ctors_test.cpp
+++ b/tests/queue/queue_ctors_test.cpp
@@ -105,7 +105,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Queue3 vs std", queue3, std_queue3);
 
         const std::queue<int> std_queue4{ std_queue1 };
-        tests::compare("Queue4 vs std", queue4, expected);
+        tests::compare("Queue4 vs std", queue4, std_queue4);
 
         std::queue<int> std_queue5{ std_queue1 };
         std_queue5.push(1);

--- a/tests/stack/stack_set_test.cpp
+++ b/tests/stack/stack_set_test.cpp
@@ -35,8 +35,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::Stack<int> stack2 = dsa::Stack<int>({ 0,10,20 });
         dsa::Stack<int> stack3 = dsa::Stack<int>({ 0,10,50 });
         stack2.swap(stack3);
-        tests::compare("Stack2", stack2, { 50,10,0 });
-        tests::compare("Stack3", stack3, { 20,10,0 });
+        tests::compare("Stack2", stack2, std::initializer_list<int>{ 50, 10, 0 });
+        tests::compare("Stack3", stack3, std::initializer_list<int>{ 20, 10, 0 });
 
         dsa::Stack<int> stack4 = dsa::Stack<int>({ 0,10,50 });
         stack4.swap(stack4);

--- a/tests/vector/vector_ctors_test.cpp
+++ b/tests/vector/vector_ctors_test.cpp
@@ -141,7 +141,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector11 vs std", vector11, std_vector11);
 
         const std::vector<int> std_temp12 = { 0, 10, 20, 30, 40, 50 };
-        const dsa::Vector<int> std_vector12(std_temp12.begin() + 1, std_temp12.begin() + 4);
+        const std::vector<int> std_vector12(std_temp12.begin() + 1, std_temp12.begin() + 4);
         tests::compare("Vector12 vs std", vector12, std_vector12);
 
         tests::print_stats();


### PR DESCRIPTION
Update implementation of functions in `tests` namespace to allow comparison of elements if forward and reverse direction for containers that allow bidirectional iterations.
Additionally, functions in `tests` namespace were refactored to reduce partial template specialisations and improve maintainability.

Closes #43 

## Checklist

- [x] update test framework to allow comparison of containers content in forward and reverse direction
- [x] refactor `tests` namespace to reduce number of partial template specialisations