### PR TITLE
Update doxygen workflow actions to use supported version of Node.js

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -3,8 +3,11 @@
 name: Doxygen Workflow
 
 on:
+  # Run workflow also on pull requests to allow testing documentation generation before deploying to GitHub Pages
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "**" ]
 
 permissions:
   contents: write
@@ -76,6 +79,10 @@ jobs:
 
   deploy:
     needs: build
+
+    # Sanity check to prevent deploying documentation from other branch than 'main'
+    if: github.ref == 'refs/heads/main'
+
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -82,4 +82,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deploy
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -70,7 +70,7 @@ jobs:
       with:
         name: doxygen-docs-artifact
         path: docs/html/
-        retention-days: 5
+        retention-days: 2
 
     - name: Upload Pages
       uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -63,14 +63,14 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Save Doxygen HTML as Artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: doxygen-docs-artifact
         path: docs/html/
         retention-days: 5
 
     - name: Upload Pages
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v5
       with:
         path: docs/html/
 


### PR DESCRIPTION
GitHub Actions used in `doxygen` workflow were updated to versions using Node.js 24.
In order to verify generated documentation before it is deployed to GitHub Actions, artifacts are now generated also on pull requests, not just after merging changes to `main`. To prevent taking too much space, artifact retention time was decreased.

Closes #45 

## Checklist

- [x] update github actions doxygen workflow to version supporting Node.js 24