### PR TITLE
Update method of setting up MSVC in CI workflow

### DIFF
--- a/.github/actions/setup-msvc/action.yml
+++ b/.github/actions/setup-msvc/action.yml
@@ -1,14 +1,34 @@
 name: Setup MSVC toolchain
-description: Install LLVM/Clang 19 on Ubuntu and set as default
+description: Setup MSVC toolchain on Windows
 runs:
   using: composite
   steps:
     - name: Setup MSVC toolchain
-      if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        toolset: "14.44"
-        arch: x64
+      shell: pwsh
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        
+        $vsPath = & $vsWhere `
+          -latest `
+          -products * `
+          -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+          -property installationPath
+
+        if(-not $vsPath)
+        {
+           throw "Visual Studio installation not found"
+        }
+
+        $devCmd = Join-Path $vsPath "Common7\Tools\VsDevCmd.bat"
+
+        $output = cmd /c "`"$devCmd`" -arch=x64 && set"
+
+        $output | ForEach-Object {
+          if ($_ -match "=") {
+            $name, $value = $_ -split "=", 2
+            Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
+          }
+        }
 
     - name: Check MSVC toolchain
       shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,15 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-24.04, windows-2025]
+        os: [ubuntu-24.04, windows-2025-vs2026]
         build_type: [Release]
         c_compiler: [gcc, clang, cl, clang-cl]
         include:
-          - os: windows-2025
+          - os: windows-2025-vs2026
             c_compiler: cl
             cpp_compiler: cl
             generator: Ninja
-          - os: windows-2025
+          - os: windows-2025-vs2026
             c_compiler: clang-cl
             cpp_compiler: clang-cl
             generator: Ninja
@@ -46,9 +46,9 @@ jobs:
             cpp_compiler: clang++
             generator: Ninja
         exclude:
-          - os: windows-2025
+          - os: windows-2025-vs2026
             c_compiler: gcc
-          - os: windows-2025
+          - os: windows-2025-vs2026
             c_compiler: clang
           - os: ubuntu-24.04
             c_compiler: cl
@@ -212,7 +212,7 @@ jobs:
 
   windows-clang-tidy:
     name: windows-2025-clang-tidy
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     needs: build
 
     # run clang-tidy only in PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,15 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-24.04, windows-2025-vs2026]
+        os: [ubuntu-24.04, windows-2025]
         build_type: [Release]
         c_compiler: [gcc, clang, cl, clang-cl]
         include:
-          - os: windows-2025-vs2026
+          - os: windows-2025
             c_compiler: cl
             cpp_compiler: cl
             generator: Ninja
-          - os: windows-2025-vs2026
+          - os: windows-2025
             c_compiler: clang-cl
             cpp_compiler: clang-cl
             generator: Ninja
@@ -46,9 +46,9 @@ jobs:
             cpp_compiler: clang++
             generator: Ninja
         exclude:
-          - os: windows-2025-vs2026
+          - os: windows-2025
             c_compiler: gcc
-          - os: windows-2025-vs2026
+          - os: windows-2025
             c_compiler: clang
           - os: ubuntu-24.04
             c_compiler: cl
@@ -212,7 +212,7 @@ jobs:
 
   windows-clang-tidy:
     name: windows-2025-clang-tidy
-    runs-on: windows-2025-vs2026
+    runs-on: windows-2025
     needs: build
 
     # run clang-tidy only in PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - os: windows-2025
             c_compiler: cl
             cpp_compiler: cl
-            generator: 'Visual Studio 17 2022'
+            generator: Ninja
           - os: windows-2025
             c_compiler: clang-cl
             cpp_compiler: clang-cl
@@ -122,7 +122,6 @@ jobs:
       shell: bash
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-        echo "generator-name='${{ matrix.generator }}'" >> "$GITHUB_OUTPUT"
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -133,7 +132,7 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -S ${{ github.workspace }}
-        -G ${{ steps.strings.outputs.generator-name }}
+        -G ${{ matrix.generator }}
         -DDOCS_ENABLED=OFF
 
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       if: runner.os == 'Linux' && (matrix.cpp_compiler == 'clang++' || matrix.cpp_compiler == 'g++')
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         files: ${{ github.workspace }}/docs/coverage/coverage.info
         fail_ci_if_error: true


### PR DESCRIPTION
Workflow `ci` was updated to resolve generated warnings and ensure compatibility with runner image using `VS2026`.

Closes #48 

## Checklist
- [x] `ci` workflow was updated to use `vswhere` to setup MSVC without external dependencies. Both `cl` and `clang-cl` compilers were set successfully for tests
- [x] `codecov-action` was updated to resolve GitHub Actions warning about `Node.js` depreciation
- [x] `ci` workflow was tested using `windows-2025-vs2026` image to confirm smooth transition to `VS2026`

