### PR TITLE
Update Doxygen configuration to allow changing docs theme on demand

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1478,7 +1478,7 @@ HTML_EXTRA_FILES       =
 # The default value is: AUTO_LIGHT.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE        = AUTO_LIGHT
+HTML_COLORSTYLE        = TOGGLE
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to


### PR DESCRIPTION
Updated `doxygen` configuration adds button near `search` field that allows switching between light and dark theme of generated docs.

When documentation is generated for the first time, system and/or web browser settings are still respected.
Button just allows to change theme on demand without affecting user settings.

Closes #50 

## Checklist
- [x] update `Doxyfile` to allow switching between light and dark theme on demand
- [x] verify if theme can be changed in documentation artifact generated by `doxygen` workflow