### PR TITLE
Update Queue class to better match std::queue API and behaviour

### DIFF
--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -137,7 +137,7 @@ namespace dsa
          *
          * @return T& reference to Queue first object
          */
-        auto front() -> reference;
+        [[nodiscard]] auto front() -> reference;
 
         /**
          * @brief Function returns pointer to Queue first object
@@ -151,7 +151,7 @@ namespace dsa
          *
          * @return T& reference to Queue last object
          */
-        auto back() -> reference;
+        [[nodiscard]] auto back() -> reference;
 
         /**
          * @brief Function returns pointer to Queue last object

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -220,7 +220,7 @@ namespace dsa
          *
          * @param[in,out] other object to swap content with
          */
-        void swap(Queue<T>& other) noexcept;
+        void swap(Queue<T>& other) noexcept(std::is_nothrow_swappable_v<Container>);
 
         /**
          * @brief Function add range of elements at the end of Queue
@@ -391,7 +391,7 @@ namespace dsa
     }
 
     template<typename T>
-    void Queue<T>::swap(Queue<T>& other) noexcept
+    void Queue<T>::swap(Queue<T>& other) noexcept(std::is_nothrow_swappable_v<Container>)
     {
         if (&other != this)
         {

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -35,7 +35,6 @@ namespace dsa
      * @tparam T type of data stored in Queue
      *
      * @todo add operator<=>
-     * @todo add emplace
      * @todo add non-member specialized swap function
      */
     template<typename T>
@@ -201,6 +200,17 @@ namespace dsa
         void push(value_type&& value);
 
         /**
+         * @brief Insert new element to the end of the container
+         * @details The element is constructed in-place, i.e. no copy or move operations are performed
+         *
+         * @tparam ...Args
+         * @param[in] ...args args arguments to forward to the constructor of the element
+         * @return reference to the emplaced element
+         */
+        template<typename... Args>
+        auto emplace(Args&&... args) -> decltype(auto);
+
+        /**
          * @brief Function removes the first element of Queue
          */
         void pop();
@@ -364,6 +374,14 @@ namespace dsa
     void Queue<T>::push(value_type&& value)
     {
         container.push_back(std::move(value));
+    }
+
+    template<typename T>
+    template<typename... Args>
+    auto Queue<T>::emplace(Args&&... args) -> decltype(auto)
+    {
+        container.emplace_back(std::forward<Args>(args)...);
+        return back();
     }
 
     template<typename T>

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -33,8 +33,6 @@ namespace dsa
      * @brief Implements Queue class
      *
      * @tparam T type of data stored in Queue
-     *
-     * @todo add non-member specialized swap function
      */
     template<typename T>
     class Queue
@@ -444,6 +442,19 @@ namespace dsa
     auto operator<=>(const Queue<T>& lhs, const Queue<T>& rhs) -> std::compare_three_way_result_t<T>
     {
         return lhs.container <=> rhs.container;
+    }
+
+    /**
+     * @brief Exchanges content of two Queue containers
+     *
+     * @tparam T data type stored in containers
+     * @param[in] lhs container to swap content
+     * @param[in] rhs container to swap content
+     */
+    template<typename T>
+    void swap(Queue<T>& lhs, Queue<T>& rhs) noexcept(noexcept(lhs.swap(rhs)))
+    {
+        lhs.swap(rhs);
     }
 }
 #endif // !QUEUE_H

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -113,13 +113,6 @@ namespace dsa
         Queue(Queue<T>&& other) noexcept;
 
         /**
-         * @brief Construct a new Queue object using initializer list
-         *
-         * @param[in] init_list initializer list of values of type T
-         */
-        Queue(const std::initializer_list<T>& init_list);
-
-        /**
          * @brief Constructs Queue using copy assignment
          *
          * @param[in] other Queue object of type T
@@ -287,15 +280,6 @@ namespace dsa
     Queue<T>::Queue(Queue<T>&& other) noexcept
         : container{ std::move(other.container) }
     {}
-
-    template<typename T>
-    Queue<T>::Queue(const std::initializer_list<T>& init_list)
-    {
-        for (const auto& item : init_list)
-        {
-            container.push_back(item);
-        }
-    }
 
     template<typename T>
     auto Queue<T>::operator=(const Queue<T>& other) -> Queue<T>&

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -198,7 +198,7 @@ namespace dsa
          *
          * @param[in] value element of type T
          */
-        void push(T&& value);
+        void push(value_type&& value);
 
         /**
          * @brief Function removes the first element of Queue
@@ -361,7 +361,7 @@ namespace dsa
     }
 
     template<typename T>
-    void Queue<T>::push(T&& value)
+    void Queue<T>::push(value_type&& value)
     {
         container.push_back(std::move(value));
     }

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -212,22 +212,6 @@ namespace dsa
          */
         void swap(Queue<T>& other) noexcept(std::is_nothrow_swappable_v<Container>);
 
-        /**
-         * @brief Function add range of elements at the end of Queue
-         *
-         * @param[in] other Queue to read elements from
-         * @return Queue<T>& reference to Queue
-         */
-        auto operator+=(const Queue<T>& other) -> Queue<T>&;
-
-        /**
-        * @brief Function add range of elements at the end of Queue
-        *
-        * @param[in] init_list std::initializer_list to read elements from
-        * @return Queue<T>& reference to Queue
-        */
-        auto operator+=(const std::initializer_list<T>& init_list) -> Queue<T>&;
-
     private:
 
         /**
@@ -375,17 +359,6 @@ namespace dsa
     void Queue<T>::swap(Queue<T>& other) noexcept(std::is_nothrow_swappable_v<Container>)
     {
         std::swap(container, other.container);
-    }
-
-    template<typename T>
-    auto Queue<T>::operator+=(const Queue<T>& other) -> Queue<T>&
-    {
-        for (const auto& item : other.container)
-        {
-            push(item);
-        }
-
-        return *this;
     }
 
     /**

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -24,17 +24,16 @@ namespace dsa
     class Queue;
 
     template<typename T>
-    auto operator==(const Queue<T>& queue1, const Queue<T>& queue2) -> bool;
+    auto operator==(const Queue<T>& lhs, const Queue<T>& rhs) -> bool;
 
     template<typename T>
-    auto operator<(const Queue<T>& queue1, const Queue<T>& queue2) -> bool;
+    auto operator<=>(const Queue<T>& lhs, const Queue<T>& rhs)->std::compare_three_way_result_t<T>;
 
     /**
      * @brief Implements Queue class
      *
      * @tparam T type of data stored in Queue
      *
-     * @todo add operator<=>
      * @todo add non-member specialized swap function
      */
     template<typename T>
@@ -243,12 +242,12 @@ namespace dsa
         /**
          * @brief Forward friend declaration to access internal container comparison operator
          */
-        friend auto operator==<T>(const Queue<T>& queue1, const Queue<T>& queue2) -> bool;
+        friend auto operator==<T>(const Queue<T>& lhs, const Queue<T>& rhs) -> bool;
 
         /**
          * @brief Forward friend declaration to access internal container comparison operator
          */
-        friend auto operator< <T>(const Queue<T>& queue1, const Queue<T>& queue2) -> bool;
+        friend auto operator<=><T>(const Queue<T>& lhs, const Queue<T>& rhs)->std::compare_three_way_result_t<T>;
 
         Container container{};
     };
@@ -433,95 +432,34 @@ namespace dsa
      * @brief The relational operator compares two Queue objects
      *
      * @tparam T type of data stored in Queue
-     * @param[in] queue1 input container
-     * @param[in] queue2 input container
+     * @param[in] lhs input container
+     * @param[in] rhs input container
      * @retval true if containers are equal
      * @retval false if containers are not equal
      */
     template<typename T>
-    auto operator==(const Queue<T>& queue1, const Queue<T>& queue2) -> bool
+    auto operator==(const Queue<T>& lhs, const Queue<T>& rhs) -> bool
     {
-        return queue1.container == queue2.container;
+        return lhs.container == rhs.container;
     }
 
     /**
      * @brief The relational operator compares two Queue objects
      *
-     * @tparam T type of data stored in Queue
-     * @param[in] queue1 input container
-     * @param[in] queue2 input container
-     * @retval true if containers are not equal
-     * @retval false if containers are equal
-     */
-    template<typename T>
-    auto operator!=(const Queue<T>& queue1, const Queue<T>& queue2) -> bool
-    {
-        return !(operator==(queue1, queue2));
-    }
-
-    /**
-     * @brief The relational operator compares two Queue objects
+     * Depending on type T, function returns one of following objects:
+     * std::strong_ordering::less / equal / greater
+     * std::weak_ordering::less / equivalent / greater
+     * std::partial_ordering::less / equivalent / greater / unordered
+     * It is best to compare results with 0 to determine if lhs is <, >, or == to rhs
      *
-     * @tparam T type of data stored in Queue
-     * @param[in] queue1 input container
-     * @param[in] queue2 input container
-     * @retval true if the content of \p queue1 are lexicographically
-     *         less than the content of \p queue2
-     * @retval false otherwise
+     * @param[in] lhs input container
+     * @param[in] rhs input container
+     * @return three way comparison result type
      */
     template<typename T>
-    auto operator<(const Queue<T>& queue1, const Queue<T>& queue2) -> bool
+    auto operator<=>(const Queue<T>& lhs, const Queue<T>& rhs) -> std::compare_three_way_result_t<T>
     {
-        return queue1.container < queue2.container;
+        return lhs.container <=> rhs.container;
     }
-
-    /**
-     * @brief The relational operator compares two Queue objects
-     *
-     * @tparam T type of data stored in Queue
-     * @param[in] queue1 input container
-     * @param[in] queue2 input container
-     * @retval true if the content of \p queue1 are lexicographically
-     *         greater than the content of \p queue2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator>(const Queue<T>& queue1, const Queue<T>& queue2) -> bool
-    {
-        return operator<(queue2, queue1);
-    }
-
-    /**
-     * @brief The relational operator compares two Queue objects
-     *
-     * @tparam T type of data stored in Queue
-     * @param[in] queue1 input container
-     * @param[in] queue2 input container
-     * @retval true if the content of \p queue1 are lexicographically
-     *         less or equal than the content of \p queue2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator<=(const Queue<T>& queue1, const Queue<T>& queue2) -> bool
-    {
-        return !(operator>(queue1, queue2));
-    }
-
-    /**
-     * @brief The relational operator compares two Queue objects
-     *
-     * @tparam T type of data stored in Queue
-     * @param[in] queue1 input container
-     * @param[in] queue2 input container
-     * @retval true if the content of \p queue1 are lexicographically
-     *         greater or equal than the content of \p queue2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator>=(const Queue<T>& queue1, const Queue<T>& queue2) -> bool
-    {
-        return !(operator<(queue1, queue2));
-    }
-
 }
 #endif // !QUEUE_H

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -44,25 +44,39 @@ namespace dsa
     public:
 
         /**
+         * @brief Alias for underlying container type used in class
+         *
+         * @tparam T data type
+         */
+        using Container = List<T>;
+
+        /**
          * @brief Alias for data type used in class
          *
          * @tparam T data type
          */
-        using value_type = T;
+        using value_type = Container::value_type;
+
+        /**
+         * @brief Alias for size type used in class
+         *
+         * @tparam T size type
+         */
+        using size_type = Container::size_type;
 
         /**
          * @brief Alias for reference to data type used in class
          *
          * @tparam T& reference to data type
          */
-        using reference = T&;
+        using reference = Container::reference;
 
         /**
          * @brief Alias for const reference to data type used in class
          *
          * @tparam T& const reference to data type
          */
-        using const_reference = const T&;
+        using const_reference = Container::const_reference;
 
         /**
          * @brief Construct a new Queue object
@@ -211,7 +225,7 @@ namespace dsa
          */
         friend auto operator< <T>(const Queue<T>& queue1, const Queue<T>& queue2) -> bool;
 
-        List<T> container{};
+        Container container{};
     };
 
     template<typename T>

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -393,10 +393,7 @@ namespace dsa
     template<typename T>
     void Queue<T>::swap(Queue<T>& other) noexcept(std::is_nothrow_swappable_v<Container>)
     {
-        if (&other != this)
-        {
-            std::swap(container, other.container);
-        }
+        std::swap(container, other.container);
     }
 
     template<typename T>

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -82,14 +82,22 @@ namespace dsa
          * @brief Construct a new Queue object
          *
          */
-        Queue() = default;
+        Queue();
 
         /**
-         * @brief Construct a new Queue object using initializer list
+         * @brief Construct a new Queue object from base Container using copy constructor
          *
-         * @param[in] init_list initializer list of values of type T
+         * @param[in] cont object of type Container
          */
-        Queue(const std::initializer_list<T>& init_list);
+        explicit Queue(const Container& cont);
+
+        /**
+         * @brief Construct a new Queue object from base Container using move constructor
+         * @details Content of other object will be taken by constructed object
+         *
+         * @param[in,out] cont Queue object of type Container
+         */
+        explicit Queue(Container&& cont) noexcept;
 
         /**
          * @brief Construct a new Queue object using copy constructor
@@ -99,20 +107,27 @@ namespace dsa
         Queue(const Queue<T>& other);
 
         /**
-         * @brief Constructs Queue using copy assignment
-         *
-         * @param[in] other Queue object of type T
-         * @return Queue& reference to Queue object
-         */
-        auto operator=(const Queue<T>& other) -> Queue&;
-
-        /**
          * @brief Construct a new Queue object using move constructor
          * @details Content of other object will be taken by constructed object
          *
          * @param[in,out] other Queue object of type T
          */
         Queue(Queue<T>&& other) noexcept;
+
+        /**
+         * @brief Construct a new Queue object using initializer list
+         *
+         * @param[in] init_list initializer list of values of type T
+         */
+        Queue(const std::initializer_list<T>& init_list);
+
+        /**
+         * @brief Constructs Queue using copy assignment
+         *
+         * @param[in] other Queue object of type T
+         * @return Queue& reference to Queue object
+         */
+        auto operator=(const Queue<T>& other) -> Queue&;
 
         /**
          * @brief Assign Queue object using move assignment
@@ -229,13 +244,23 @@ namespace dsa
     };
 
     template<typename T>
-    Queue<T>::Queue(const std::initializer_list<T>& init_list)
+    Queue<T>::Queue()
+        : Queue(Container())
+    {}
+
+    template<typename T>
+    Queue<T>::Queue(const Container& cont)
     {
-        for (const auto& item : init_list)
+        for (const auto& item : cont)
         {
             container.push_back(item);
         }
     }
+
+    template<typename T>
+    Queue<T>::Queue(Container&& cont) noexcept
+        : container{ std::move(cont) }
+    {}
 
     template<typename T>
     Queue<T>::Queue(const Queue<T>& other)
@@ -246,6 +271,20 @@ namespace dsa
             {
                 container.push_back(item);
             }
+        }
+    }
+
+    template<typename T>
+    Queue<T>::Queue(Queue<T>&& other) noexcept
+        : container{ std::move(other.container) }
+    {}
+
+    template<typename T>
+    Queue<T>::Queue(const std::initializer_list<T>& init_list)
+    {
+        for (const auto& item : init_list)
+        {
+            container.push_back(item);
         }
     }
 
@@ -266,12 +305,6 @@ namespace dsa
         }
 
         return *this;
-    }
-
-    template<typename T>
-    Queue<T>::Queue(Queue<T>&& other) noexcept
-        : container{ std::move(other.container) }
-    {
     }
 
     template<typename T>

--- a/tests/queue/CMakeLists.txt
+++ b/tests/queue/CMakeLists.txt
@@ -27,3 +27,7 @@ add_test(NAME queue_set_test COMMAND queue_set_test)
 add_executable(queue_operators_test queue_operators_test.cpp ${SRC_DIR}/common.cpp)
 target_link_libraries(queue_operators_test PRIVATE dsa_testing)
 add_test(NAME queue_operators_test COMMAND queue_operators_test)
+
+add_executable(queue_swap_test queue_swap_test.cpp ${SRC_DIR}/common.cpp)
+target_link_libraries(queue_swap_test PRIVATE dsa_testing)
+add_test(NAME queue_swap_test COMMAND queue_swap_test)

--- a/tests/queue/queue_ctors_test.cpp
+++ b/tests/queue/queue_ctors_test.cpp
@@ -10,8 +10,10 @@
  */
 
 #include "common.h"
+#include "dsa/list.h"
 #include "dsa/queue.h"
 
+#include <deque>
 #include <exception>
 #include <initializer_list>
 #include <iostream>
@@ -46,10 +48,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const dsa::Queue<int> queue3(expected);
         tests::compare("Queue3", queue3, expected);
 
-
         std::cout << "Copy ctor\n";
-        // intentionally make a copy to test copy constructor
-        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         const dsa::Queue<int> queue4{ queue1 };
         tests::compare("Queue4", queue4, expected);
 
@@ -64,7 +63,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Queue5", queue5, expected);
 
         std::cout << "Copy self assignment ctor\n";
-        dsa::Queue<int> queue6{ 0, 10, 20 };
+        dsa::Queue<int> queue6{ dsa::List<int>({0, 10, 20}) };
         auto* pointer6 = &queue6;
         queue6 = *pointer6;
         tests::compare("Queue6", queue6, expected);
@@ -82,10 +81,26 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Queue8", queue8, expected);
 
         std::cout << "Move self assignment ctor\n";
-        dsa::Queue<int> queue9{ 0, 10, 20 };
+        dsa::Queue<int> queue9{ dsa::List<int>({0, 10, 20}) };
         auto* pointer9 = &queue9;
         queue9 = std::move(*pointer9);
         tests::compare("Queue9", queue9, expected);
+
+        const dsa::Queue<int> queue10(dsa::List<int>(5));
+        const std::initializer_list<int> expected10{ 0, 0, 0, 0, 0 };
+        tests::compare("Queue10", queue10, expected10);
+
+        std::cout << "Construct from List using copy ctor\n";
+        const dsa::List<int> temp11 = { 10, 20, 30 };
+        const dsa::Queue<int> queue11(temp11);
+        const std::initializer_list<int> expected11{ 10, 20, 30 };
+        tests::compare("Queue11", queue11, expected11);
+
+        std::cout << "Construct from List using move assignment\n";
+        dsa::List<int> temp12 = { 10, 20, 30 };
+        const dsa::Queue<int> queue12(std::move(temp12));
+        const std::initializer_list<int> expected12{ 10, 20, 30 };
+        tests::compare("Queue12", queue12, expected12);
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -116,15 +131,28 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_queue5 = std_queue1;
         tests::compare("Queue5 vs std", queue5, std_queue5);
 
-        std::queue<int> std_temp_1(std_queue1);
-        const std::queue<int> std_queue6 = std::move(std_temp_1);
+        const std::queue<int> std_queue6(std::deque<int>({ 0, 10, 20 }));
         tests::compare("Queue6 vs std", queue6, std_queue6);
 
         std::queue<int> std_temp_2(std_queue1);
-        std::queue<int> std_queue7;
-        std_queue7.push(0);
-        std_queue7 = std::move(std_temp_2);
+        const std::queue<int> std_queue7 = std::move(std_temp_2);
         tests::compare("Queue7 vs std", queue7, std_queue7);
+
+        std::queue<int> std_temp_8(std_queue1);
+        std::queue<int> std_queue8;
+        std_queue8 = std::move(std_temp_8);
+        tests::compare("Queue8 vs std", queue8, std_queue8);
+
+        const std::queue<int> std_queue10(std::deque<int>(5));
+        tests::compare("Queue10 vs std", queue10, std_queue10);
+
+        const std::deque<int> std_temp11 = { 10, 20, 30 };
+        const std::queue<int> std_queue11(std_temp11);
+        tests::compare("Queue11 vs std", queue11, std_queue11);
+
+        std::deque<int> std_temp12 = { 10, 20, 30 };
+        const std::queue<int> std_queue12(std::move(std_temp12));
+        tests::compare("Queue12 vs std", queue12, std_queue12);
 
 
         tests::print_stats();

--- a/tests/queue/queue_grow_test.cpp
+++ b/tests/queue/queue_grow_test.cpp
@@ -34,6 +34,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         queue1.push(40);
         tests::compare("Queue1", queue1, expected);
 
+        dsa::Queue<int> queue2;
+        queue2.emplace(10);
+        queue2.emplace(20);
+        queue2.emplace(30);
+        queue2.emplace(40);
+        tests::compare("Queue2", queue2, expected);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -42,6 +49,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_queue1.push(30);
         std_queue1.push(40);
         tests::compare("Queue1 vs std", queue1, std_queue1);
+
+        std::queue<int> std_queue2;
+        std_queue2.emplace(10);
+        std_queue2.emplace(20);
+        std_queue2.emplace(30);
+        std_queue2.emplace(40);
+        tests::compare("Queue2 vs std", queue2, std_queue2);
 
 
         tests::print_stats();

--- a/tests/queue/queue_operators_test.cpp
+++ b/tests/queue/queue_operators_test.cpp
@@ -10,11 +10,17 @@
  */
 
 #include "common.h"
+#include "dsa/list.h"
 #include "dsa/queue.h"
 
+#include <cassert>
+#include <compare>
+#include <deque>
 #include <exception>
 #include <iostream>
+#include <limits>
 #include <queue>
+#include <type_traits>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -52,6 +58,18 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Queue1 >= queue2", queue1 >= queue2, false);
         tests::compare("Queue2 >= queue1", queue2 >= queue1, true);
 
+        // test three way comparison
+
+        tests::compare("Queue1 <=> queue2 !=", (queue1 <=> queue2) != 0, (queue1 <=> queue2) != 0);
+        tests::compare("Queue1 <=> queue2 <", (queue1 <=> queue2) < 0, (queue1 <=> queue2) < 0);
+        tests::compare("Queue1 <=> queue2 >", (queue1 <=> queue2) > 0, (queue1 <=> queue2) > 0);
+        tests::compare("Queue1 <=> queue2 <=", (queue1 <=> queue2) <= 0, (queue1 <=> queue2) <= 0);
+        tests::compare("Queue1 <=> queue2 >=", (queue1 <=> queue2) >= 0, (queue1 <=> queue2) >= 0);
+
+        tests::compare("Queue1 <=> queue2 <", (queue1 <=> queue2) == std::weak_ordering::less, true);
+        tests::compare("Queue1 <=> queue2 <>", (queue1 <=> queue2) != std::weak_ordering::equivalent, true);
+        tests::compare("Queue1 <=> queue2 <=", (queue1 <=> queue2) != std::weak_ordering::greater, true);
+
         std::cout << "Compare operators for objects of different size\n\n";
 
         tests::compare("Queue1 == queue3", queue1 == queue3, false);
@@ -78,6 +96,41 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Queue2 >= queue3", queue2 >= queue3, true);
         tests::compare("Queue3 >= queue2", queue3 >= queue2, false);
 
+        // test three way comparison
+
+        tests::compare("Queue1 <=> queue3 ==", (queue1 <=> queue3) == 0, false);
+        tests::compare("Queue1 <=> queue3 <", (queue1 <=> queue3) < 0, true);
+        tests::compare("Queue1 <=> queue3 >", (queue1 <=> queue3) > 0, false);
+        tests::compare("Queue1 <=> queue3 <=", (queue1 <=> queue3) <= 0, true);
+        tests::compare("Queue1 <=> queue3 >=", (queue1 <=> queue3) >= 0, false);
+
+        tests::compare("Queue1 <=> queue3 >=", (queue1 <=> queue3) != std::weak_ordering::less, false);
+        tests::compare("Queue1 <=> queue3 ==", (queue1 <=> queue3) == std::weak_ordering::equivalent, false);
+        tests::compare("Queue1 <=> queue3 <=", (queue1 <=> queue3) != std::weak_ordering::greater, true);
+
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::Queue<int>>, std::strong_ordering>,
+            "Int queue should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::Queue<double>>, std::partial_ordering>,
+            "Double queue should support strong ordering");
+
+        // test partial ordering
+        const dsa::Queue<double> queue7{ dsa::List<double>{1.0, 2.0, 3.0} };
+        const dsa::Queue<double> queue8{ dsa::List<double>{1.0, 2.0, std::numeric_limits<double>::quiet_NaN()} };
+        assert((queue7 <=> queue8) == std::partial_ordering::unordered);
+        tests::compare("Queue7 <=> queue8 weak ordering", (queue7 <=> queue8) != std::weak_ordering::less, true);
+
+        // test noexcept
+
+        // operators
+        static_assert(!noexcept(
+            dsa::Queue<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)} ==
+            dsa::Queue<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)}));
+        static_assert(!noexcept(
+            dsa::Queue<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)} <=>
+            dsa::Queue<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)}));
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -102,6 +155,21 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         tests::compare("Queue1 >= queue2 vs std", queue1 >= queue2, std_queue1 >= std_queue2);
         tests::compare("Queue2 >= queue1 vs std", queue2 >= queue1, std_queue2 >= std_queue1);
+
+        // test three way comparison
+
+        tests::compare("Queue1 <=> queue2 vs std !=", (queue1 <=> queue2) != 0, (std_queue1 <=> std_queue2) != 0);
+        tests::compare("Queue1 <=> queue2 vs std <", (queue1 <=> queue2) < 0, (std_queue1 <=> std_queue2) < 0);
+        tests::compare("Queue1 <=> queue2 vs std >", (queue1 <=> queue2) > 0, (std_queue1 <=> std_queue2) > 0);
+        tests::compare("Queue1 <=> queue2 vs std <=", (queue1 <=> queue2) <= 0, (std_queue1 <=> std_queue2) <= 0);
+        tests::compare("Queue1 <=> queue2 vs std >=", (queue1 <=> queue2) >= 0, (std_queue1 <=> std_queue2) >= 0);
+
+        tests::compare("Queue1 <=> queue2 vs std <",
+            (queue1 <=> queue2) == std::weak_ordering::less, (std_queue1 <=> std_queue2) == std::weak_ordering::less);
+        tests::compare("Queue1 <=> queue2 vs std <>",
+            (queue1 <=> queue2) != std::weak_ordering::equivalent, (std_queue1 <=> std_queue2) != std::weak_ordering::equivalent);
+        tests::compare("Queue1 <=> queue2 vs std <=",
+            (queue1 <=> queue2) != std::weak_ordering::greater, (std_queue1 <=> std_queue2) != std::weak_ordering::greater);
 
         std::cout << "Compare operators for objects of different size\n\n";
 
@@ -128,6 +196,48 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Queue3 >= queue1 vs std", queue3 >= queue1, std_queue3 >= std_queue1);
         tests::compare("Queue2 >= queue3 vs std", queue2 >= queue3, std_queue2 >= std_queue3);
         tests::compare("Queue3 >= queue2 vs std", queue3 >= queue2, std_queue3 >= std_queue2);
+
+        // test three way comparison
+
+        tests::compare("Queue1 <=> queue3 vs std ==", (queue1 <=> queue3) == 0, (std_queue1 <=> std_queue3) == 0);
+        tests::compare("Queue1 <=> queue3 vs std <", (queue1 <=> queue3) < 0, (std_queue1 <=> std_queue3) < 0);
+        tests::compare("Queue1 <=> queue3 vs std >", (queue1 <=> queue3) > 0, (std_queue1 <=> std_queue3) > 0);
+        tests::compare("Queue1 <=> queue3 vs std <=", (queue1 <=> queue3) <= 0, (std_queue1 <=> std_queue3) <= 0);
+        tests::compare("Queue1 <=> queue3 vs std >=", (queue1 <=> queue3) >= 0, (std_queue1 <=> std_queue3) >= 0);
+
+        tests::compare("Queue1 <=> queue3 vs std >=",
+            (queue1 <=> queue3) != std::weak_ordering::less, (std_queue1 <=> std_queue3) != std::weak_ordering::less);
+        tests::compare("Queue1 <=> queue3 vs std ==",
+            (queue1 <=> queue3) == std::weak_ordering::equivalent, (std_queue1 <=> std_queue3) == std::weak_ordering::equivalent);
+        tests::compare("Queue1 <=> queue3 vs std <= ",
+            (queue1 <=> queue3) != std::weak_ordering::greater, (std_queue1 <=> std_queue3) != std::weak_ordering::greater);
+
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::queue<int>>, std::strong_ordering>,
+            "Int queue should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::queue<double>>, std::partial_ordering>,
+            "Double queue should support strong ordering");
+
+        // test partial ordering
+        const std::queue<double> std_queue7{ std::deque<double>{1.0, 2.0, 3.0} };
+        const std::queue<double> std_queue8{ std::deque<double>{1.0, 2.0, std::numeric_limits<double>::quiet_NaN()} };
+        assert((std_queue7 <=> std_queue8) == std::partial_ordering::unordered);
+        assert((queue7 <=> queue8) == (std_queue7 <=> std_queue8));
+        tests::compare("std_queue7 <=> std_queue8 weak ordering",
+            (std_queue7 <=> std_queue8) == std::partial_ordering::unordered, true);
+        tests::compare("(queue7 <=> queue8) == (std_queue7 <=> std_queue8)",
+            (queue7 <=> queue8) == (std_queue7 <=> std_queue8), true);
+
+        // test noexcept
+
+        // operators
+        static_assert(!noexcept(
+            std::queue<tests::ThrowingType>{std::deque<tests::ThrowingType>(1)} ==
+            std::queue<tests::ThrowingType>{std::deque<tests::ThrowingType>(1)}));
+        static_assert(!noexcept(
+            std::queue<tests::ThrowingType>{std::deque < tests::ThrowingType>(1)} <=>
+            std::queue<tests::ThrowingType>{std::deque < tests::ThrowingType>(1)}));
 
 
         tests::print_stats();

--- a/tests/queue/queue_set_test.cpp
+++ b/tests/queue/queue_set_test.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "common.h"
+#include "dsa/list.h"
 #include "dsa/queue.h"
 
 #include <exception>
@@ -35,8 +36,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::Queue<int> queue2 = dsa::Queue<int>({ 0,10,20 });
         dsa::Queue<int> queue3 = dsa::Queue<int>({ 50,10,20 });
         queue2.swap(queue3);
-        tests::compare("Queue2", queue2, { 50, 10, 20 });
-        tests::compare("Queue3", queue3, { 0, 10, 20 });
+        tests::compare("Queue2", queue2, dsa::Queue(dsa::List<int>{ 50, 10, 20 }));
+        tests::compare("Queue3", queue3, dsa::Queue(dsa::List<int>{  0, 10, 20 }));
 
         dsa::Queue<int> queue4 = dsa::Queue<int>({ 50,10,20 });
         queue4.swap(queue4);

--- a/tests/queue/queue_swap_test.cpp
+++ b/tests/queue/queue_swap_test.cpp
@@ -1,0 +1,117 @@
+/**
+ * @file queue_swap_test.cpp
+ * @brief This file tests functions swapping Queue objects
+ * @author Michal Zygmunt
+ *
+ * @copyright Copyright (c) 2026 Michal Zygmunt
+ * This project is distributed under the MIT License.
+ * See accompanying LICENSE.txt file or obtain copy at
+ * https://opensource.org/license/mit
+ */
+
+#include "common.h"
+#include "dsa/queue.h"
+
+#include <exception>
+#include <initializer_list>
+#include <iostream>
+#include <queue>
+#include <utility>
+
+int main() // NOLINT(modernize-use-trailing-return-type)
+{
+    // tests are based on hardcoded magic numbers for comparison of container content
+    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+
+    try
+    {
+        std::cout << "Start queue_swap_test:\n";
+
+        const std::initializer_list<int> il_1{ 1, 2, 3, 4, 5 };
+        const std::initializer_list<int> il_2{ 10, 20, 30, 40, 50 };
+
+        dsa::Queue<int> queue1 = dsa::Queue<int>(il_1);
+        dsa::Queue<int> queue2 = dsa::Queue<int>(il_2);
+        queue1.swap(queue2);
+        const std::initializer_list<int> expected1 = { 10, 20, 30, 40, 50 };
+        tests::compare("Queue1", queue1, expected1);
+        const std::initializer_list<int> expected2 = { 1, 2, 3, 4, 5 };
+        tests::compare("Queue2", queue2, expected2);
+
+        dsa::Queue<int> queue3 = dsa::Queue<int>(il_1);
+        dsa::Queue<int> queue4;
+        queue3.swap(queue4);
+        const std::initializer_list<int> expected3 = { };
+        tests::compare("Queue3", queue3, expected3);
+        const std::initializer_list<int> expected4 = { 1, 2, 3, 4, 5 };
+        tests::compare("Queue4", queue4, expected4);
+
+        dsa::Queue<int> queue5 = dsa::Queue<int>(il_1);
+        dsa::Queue<int> queue6 = dsa::Queue<int>(il_2);
+        dsa::swap(queue5, queue6);
+        const std::initializer_list<int> expected5 = il_2;
+        tests::compare("Queue5", queue5, expected5);
+        const std::initializer_list<int> expected6 = il_1;
+        tests::compare("Queue6", queue6, expected6);
+
+        dsa::Queue<int> queue7 = dsa::Queue<int>(il_1);
+        dsa::Queue<int> queue8;
+        dsa::swap(queue7, queue8);
+        const std::initializer_list<int> expected7 = { };
+        tests::compare("Queue7", queue7, expected7);
+        const std::initializer_list<int> expected8 = il_1;
+        tests::compare("Queue8", queue8, expected8);
+
+        // swap safe type
+        static_assert(noexcept(swap(std::declval<dsa::Queue<int>&>(),
+            std::declval<dsa::Queue<int>&>())));
+        // swap throwing type
+        static_assert(noexcept(swap(std::declval<dsa::Queue<tests::ThrowingType>&>(),
+            std::declval<dsa::Queue<tests::ThrowingType>&>())));
+
+
+        std::cout << "Compare operations results with std container\n\n";
+
+        std::queue<int> std_queue1{ il_1 };
+        std::queue<int> std_queue2{ il_2 };
+        std_queue1.swap(std_queue2);
+        tests::compare("Queue1 vs std", queue1, std_queue1);
+        tests::compare("Queue2 vs std", queue2, std_queue2);
+
+        std::queue<int> std_queue3{ il_1 };
+        std::queue<int> std_queue4{};
+        std_queue3.swap(std_queue4);
+        tests::compare("Queue3 vs std", queue3, std_queue3);
+        tests::compare("Queue4 vs std", queue4, std_queue4);
+
+        std::queue<int> std_queue5(il_1);
+        std::queue<int> std_queue6(il_2);
+        std::swap(std_queue5, std_queue6);
+        tests::compare("Queue5 vs std", queue5, std_queue5);
+        tests::compare("Queue6 vs std", queue6, std_queue6);
+
+        std::queue<int> std_queue7(il_1);
+        std::queue<int> std_queue8;
+        std::swap(std_queue7, std_queue8);
+        tests::compare("Queue7 vs std", queue7, std_queue7);
+        tests::compare("Queue8 vs std", queue8, std_queue8);
+
+        // swap safe type
+        static_assert(noexcept(swap(std::declval<std::queue<int>&>(),
+            std::declval<std::queue<int>&>())));
+        // swap throwing type
+        static_assert(noexcept(swap(std::declval<std::queue<tests::ThrowingType>&>(),
+            std::declval<std::queue<tests::ThrowingType>&>())));
+
+
+        tests::print_stats();
+    }
+    catch (...)
+    {
+        return tests::handle_exception(std::current_exception());
+    }
+
+    return tests::failed_count();
+
+    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+}


### PR DESCRIPTION
Update dsa::Queue class to better match std::queue API and behaviour.

Closes #32 

## Checklist

- [x] provide the same member types and methods as `std::queue`, including:
  * emplace
  * operator<=> from base container
  * non-member specialised functions: swap
- [x] remove public functions / operators not supported by `std::queue`
  * remove `operator+=`
  * remove ctor using `std::initializer_list`
- [x] update tests to match features provided by updated implementation
- [x] separate function declarations and definitions (move method implementation outside class, where possible)
- [x] check if `[[nodiscard]]` is applied consistently and intentionally