### PR TITLE
Prevent implicit conversion to ForwardList

### DIFF
--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -413,7 +413,7 @@ namespace dsa
          *
          * @param[in] count element count
          */
-        ForwardList(size_type count);
+        explicit ForwardList(size_type count);
 
         /**
          * @brief Construct a new ForwardList object of size \p count,


### PR DESCRIPTION
Update `dsa::ForwardList` class to prevent implicit calls of constructor from `std::size_t` argument.

Closes #53 

## Checklist

- [x] prevent implicit conversion to `dsa::ForwardList`
- [x] verify tests results