### PR TITLE
Prevent implicit conversion to List

### DIFF
--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -460,7 +460,7 @@ namespace dsa
          *
          * @param[in] count element count
          */
-        List(size_type count);
+        explicit List(size_type count);
 
         /**
          * @brief Construct a new List object of size \p count,


### PR DESCRIPTION
Update `dsa::List` class to prevent implicit calls of constructor from `std::size_t` argument.

Closes #54

## Checklist

- [x] prevent implicit conversion to `dsa::List`
- [x] verify tests results