### PR TITLE
Update Stack class to better match std::stack API and behaviour

### DIFF
--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -206,7 +206,7 @@ namespace dsa
          *
          * @param[in,out] other object to swap content with
          */
-        void swap(Stack<T>& other) noexcept;
+        void swap(Stack<T>& other) noexcept(std::is_nothrow_swappable_v<Container>);
 
     private:
 
@@ -349,7 +349,7 @@ namespace dsa
     }
 
     template<typename T>
-    void Stack<T>::swap(Stack<T>& other) noexcept
+    void Stack<T>::swap(Stack<T>& other) noexcept(std::is_nothrow_swappable_v<Container>)
     {
         if (&other != this)
         {

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -177,7 +177,7 @@ namespace dsa
          *
          * @param[in] value element of type T
          */
-        void push(T value);
+        void push(const_reference value);
 
         /**
          * @brief Function removes the top element of Stack
@@ -307,7 +307,7 @@ namespace dsa
     }
 
     template<typename T>
-    void Stack<T>::push(T value)
+    void Stack<T>::push(const_reference value)
     {
         container.push_back(value);
     }

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -34,8 +34,6 @@ namespace dsa
      * @brief Implements Stack class
      *
      * @tparam T type of data stored in Stack
-     *
-     * @todo add non-member specialized swap function
      */
     template<typename T>
     class Stack
@@ -391,6 +389,19 @@ namespace dsa
     auto operator<=>(const Stack<T>& lhs, const Stack<T>& rhs) -> std::compare_three_way_result_t<T>
     {
         return lhs.container <=> rhs.container;
+    }
+
+    /**
+     * @brief Exchanges content of two Stack containers
+     *
+     * @tparam T data type stored in containers
+     * @param[in] lhs container to swap content
+     * @param[in] rhs container to swap content
+     */
+    template<typename T>
+    void swap(Stack<T>& lhs, Stack<T>& rhs) noexcept(noexcept(lhs.swap(rhs)))
+    {
+        lhs.swap(rhs);
     }
 }
 #endif // !STACK_H

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -180,6 +180,13 @@ namespace dsa
         void push(const_reference value);
 
         /**
+         * @brief Function add new element at the top of Stack
+         *
+         * @param[in] value element of type T
+         */
+        void push(value_type&& value);
+
+        /**
          * @brief Function removes the top element of Stack
          */
         void pop();
@@ -310,6 +317,12 @@ namespace dsa
     void Stack<T>::push(const_reference value)
     {
         container.push_back(value);
+    }
+
+    template<typename T>
+    void Stack<T>::push(value_type&& value)
+    {
+        container.push_back(std::move(value));
     }
 
     template<typename T>

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -36,7 +36,6 @@ namespace dsa
      * @tparam T type of data stored in Stack
      *
      * @todo add operator<=>
-     * @todo add emplace
      * @todo add non-member specialized swap function
      */
     template<typename T>
@@ -187,6 +186,17 @@ namespace dsa
         void push(value_type&& value);
 
         /**
+         * @brief Insert new element to the end of the container
+         * @details The element is constructed in-place, i.e. no copy or move operations are performed
+         *
+         * @tparam ...Args
+         * @param[in] ...args args arguments to forward to the constructor of the element
+         * @return reference to the emplaced element
+         */
+        template<typename... Args>
+        auto emplace(Args&&... args) -> decltype(auto);
+
+        /**
          * @brief Function removes the top element of Stack
          */
         void pop();
@@ -323,6 +333,13 @@ namespace dsa
     void Stack<T>::push(value_type&& value)
     {
         container.push_back(std::move(value));
+    }
+
+    template<typename T>
+    template<typename... Args>
+    auto Stack<T>::emplace(Args&&... args) -> decltype(auto)
+    {
+        return container.emplace_back(std::forward<Args>(args)...);
     }
 
     template<typename T>

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -45,25 +45,39 @@ namespace dsa
     public:
 
         /**
+         * @brief Alias for underlying container type used in class
+         *
+         * @tparam T data type
+         */
+        using Container = List<T>;
+
+        /**
          * @brief Alias for data type used in class
          *
          * @tparam T data type
          */
-        using value_type = T;
+        using value_type = Container::value_type;
+
+        /**
+         * @brief Alias for size type used in class
+         *
+         * @tparam T size type
+         */
+        using size_type = Container::size_type;
 
         /**
          * @brief Alias for reference to data type used in class
          *
          * @tparam T& reference to data type
          */
-        using reference = T&;
+        using reference = Container::reference;
 
         /**
          * @brief Alias for const reference to data type used in class
          *
          * @tparam T& const reference to data type
          */
-        using const_reference = const T&;
+        using const_reference = Container::const_reference;
 
         /**
          * @brief Construct a new Stack object
@@ -175,7 +189,7 @@ namespace dsa
          */
         friend auto operator< <T>(const Stack<T>& stack1, const Stack<T>& stack2) -> bool;
 
-        List<T> container{};
+        Container container{};
     };
 
     template<typename T>

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -137,7 +137,7 @@ namespace dsa
          *
          * @return T& reference to Stack top element
          */
-        auto top() -> reference;
+        [[nodiscard]] auto top() -> reference;
 
         /**
          * @brief Function returns pointer to Stack top element

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -113,13 +113,6 @@ namespace dsa
         Stack(Stack<T>&& other) noexcept;
 
         /**
-         * @brief Construct a new Stack object using initializer list
-         *
-         * @param[in] init_list initializer list of values of type T
-         */
-        Stack(const std::initializer_list<T>& init_list);
-
-        /**
          * @brief Constructs Stack using copy assignment
          *
          * @param[in] other Stack object of type T
@@ -257,15 +250,6 @@ namespace dsa
     Stack<T>::Stack(Stack<T>&& other) noexcept
     {
         std::swap(container, other.container);
-    }
-
-    template<typename T>
-    Stack<T>::Stack(const std::initializer_list<T>& init_list)
-    {
-        for (const auto& item : init_list)
-        {
-            container.push_back(item);
-        }
     }
 
     template<typename T>

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -81,16 +81,23 @@ namespace dsa
 
         /**
          * @brief Construct a new Stack object
-         *
          */
-        Stack() = default;
+        Stack();
 
         /**
-         * @brief Construct a new Stack object using initializer list
+         * @brief Construct a new Stack object from base Container using copy constructor
          *
-         * @param[in] init_list initializer list of values of type T
+         * @param[in] cont object of type Container
          */
-        Stack(const std::initializer_list<T>& init_list);
+        explicit Stack(const Container& cont);
+
+        /**
+         * @brief Construct a new Stack object from base Container using move constructor
+         * @details Content of other object will be taken by constructed object
+         *
+         * @param[in,out] cont Stack object of type Container
+         */
+        explicit Stack(Container&& cont) noexcept;
 
         /**
          * @brief Construct a new Stack object using copy constructor
@@ -100,20 +107,27 @@ namespace dsa
         Stack(const Stack<T>& other);
 
         /**
-         * @brief Constructs Stack using copy assignment
-         *
-         * @param[in] other Stack object of type T
-         * @return Stack& reference to Stack object
-         */
-        auto operator=(const Stack<T>& other) -> Stack&;
-
-        /**
          * @brief Construct a new Stack object using move constructor
          * @details Content of other object will be taken by constructed object
          *
          * @param[in,out] other Stack object of type T
          */
         Stack(Stack<T>&& other) noexcept;
+
+        /**
+         * @brief Construct a new Stack object using initializer list
+         *
+         * @param[in] init_list initializer list of values of type T
+         */
+        Stack(const std::initializer_list<T>& init_list);
+
+        /**
+         * @brief Constructs Stack using copy assignment
+         *
+         * @param[in] other Stack object of type T
+         * @return Stack& reference to Stack object
+         */
+        auto operator=(const Stack<T>& other) -> Stack&;
 
         /**
          * @brief Assign Stack object using move assignment
@@ -193,13 +207,23 @@ namespace dsa
     };
 
     template<typename T>
-    Stack<T>::Stack(const std::initializer_list<T>& init_list)
+    Stack<T>::Stack()
+        : Stack(Container())
+    {}
+
+    template<typename T>
+    Stack<T>::Stack(const Container& cont)
     {
-        for (const auto& item : init_list)
+        for (const auto& item : cont)
         {
             container.push_back(item);
         }
     }
+
+    template<typename T>
+    Stack<T>::Stack(Container&& cont) noexcept
+        : container{ std::move(cont) }
+    {}
 
     template<typename T>
     Stack<T>::Stack(const Stack<T>& other)
@@ -210,6 +234,21 @@ namespace dsa
             {
                 container.push_back(item);
             }
+        }
+    }
+
+    template<typename T>
+    Stack<T>::Stack(Stack<T>&& other) noexcept
+    {
+        std::swap(container, other.container);
+    }
+
+    template<typename T>
+    Stack<T>::Stack(const std::initializer_list<T>& init_list)
+    {
+        for (const auto& item : init_list)
+        {
+            container.push_back(item);
         }
     }
 
@@ -230,12 +269,6 @@ namespace dsa
         }
 
         return *this;
-    }
-
-    template<typename T>
-    Stack<T>::Stack(Stack<T>&& other) noexcept
-    {
-        std::swap(container, other.container);
     }
 
     template<typename T>

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -351,10 +351,7 @@ namespace dsa
     template<typename T>
     void Stack<T>::swap(Stack<T>& other) noexcept(std::is_nothrow_swappable_v<Container>)
     {
-        if (&other != this)
-        {
-            std::swap(container, other.container);
-        }
+        std::swap(container, other.container);
     }
 
     /**

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -25,17 +25,16 @@ namespace dsa
     class Stack;
 
     template<typename T>
-    auto operator==(const Stack<T>& stack1, const Stack<T>& stack2) -> bool;
+    auto operator==(const Stack<T>& lhs, const Stack<T>& rhs) -> bool;
 
     template<typename T>
-    auto operator<(const Stack<T>& stack1, const Stack<T>& stack2) -> bool;
+    auto operator<=>(const Stack<T>& lhs, const Stack<T>& rhs)->std::compare_three_way_result_t<T>;
 
     /**
      * @brief Implements Stack class
      *
      * @tparam T type of data stored in Stack
      *
-     * @todo add operator<=>
      * @todo add non-member specialized swap function
      */
     template<typename T>
@@ -213,12 +212,12 @@ namespace dsa
         /**
          * @brief Forward friend declaration to access internal container comparison operator
          */
-        friend auto operator==<T>(const Stack<T>& stack1, const Stack<T>& stack2) -> bool;
+        friend auto operator==<T>(const Stack<T>& lhs, const Stack<T>& rhs) -> bool;
 
         /**
          * @brief Forward friend declaration to access internal container comparison operator
          */
-        friend auto operator< <T>(const Stack<T>& stack1, const Stack<T>& stack2) -> bool;
+        friend auto operator<=><T>(const Stack<T>& lhs, const Stack<T>& rhs)->std::compare_three_way_result_t<T>;
 
         Container container{};
     };
@@ -380,95 +379,34 @@ namespace dsa
      * @brief The relational operator compares two Stack objects
      *
      * @tparam T type of data stored in Stack
-     * @param[in] stack1 input container
-     * @param[in] stack2 input container
+     * @param[in] lhs input container
+     * @param[in] rhs input container
      * @retval true if containers are equal
      * @retval false if containers are not equal
      */
     template<typename T>
-    auto operator==(const Stack<T>& stack1, const Stack<T>& stack2) -> bool
+    auto operator==(const Stack<T>& lhs, const Stack<T>& rhs) -> bool
     {
-        return stack1.container == stack2.container;
+        return lhs.container == rhs.container;
     }
 
     /**
      * @brief The relational operator compares two Stack objects
      *
-     * @tparam T type of data stored in Stack
-     * @param[in] stack1 input container
-     * @param[in] stack2 input container
-     * @retval true if containers are not equal
-     * @retval false if containers are equal
-     */
-    template<typename T>
-    auto operator!=(const Stack<T>& stack1, const Stack<T>& stack2) -> bool
-    {
-        return !(operator==(stack1, stack2));
-    }
-
-    /**
-     * @brief The relational operator compares two Stack objects
+     * Depending on type T, function returns one of following objects:
+     * std::strong_ordering::less / equal / greater
+     * std::weak_ordering::less / equivalent / greater
+     * std::partial_ordering::less / equivalent / greater / unordered
+     * It is best to compare results with 0 to determine if lhs is <, >, or == to rhs
      *
-     * @tparam T type of data stored in Stack
-     * @param[in] stack1 input container
-     * @param[in] stack2 input container
-     * @retval true if the content of \p stack1 are lexicographically
-     *         less than the content of \p stack2
-     * @retval false otherwise
+     * @param[in] lhs input container
+     * @param[in] rhs input container
+     * @return three way comparison result type
      */
     template<typename T>
-    auto operator<(const Stack<T>& stack1, const Stack<T>& stack2) -> bool
+    auto operator<=>(const Stack<T>& lhs, const Stack<T>& rhs) -> std::compare_three_way_result_t<T>
     {
-        return stack1.container < stack2.container;
+        return lhs.container <=> rhs.container;
     }
-
-    /**
-     * @brief The relational operator compares two Stack objects
-     *
-     * @tparam T type of data stored in Stack
-     * @param[in] stack1 input container
-     * @param[in] stack2 input container
-     * @retval true if the content of \p stack1 are lexicographically
-     *         greater than the content of \p stack2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator>(const Stack<T>& stack1, const Stack<T>& stack2) -> bool
-    {
-        return operator<(stack2, stack1);
-    }
-
-    /**
-     * @brief The relational operator compares two Stack objects
-     *
-     * @tparam T type of data stored in Stack
-     * @param[in] stack1 input container
-     * @param[in] stack2 input container
-     * @retval true if the content of \p stack1 are lexicographically
-     *         less or equal than the content of \p stack2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator<=(const Stack<T>& stack1, const Stack<T>& stack2) -> bool
-    {
-        return !(operator>(stack1, stack2));
-    }
-
-    /**
-     * @brief The relational operator compares two Stack objects
-     *
-     * @tparam T type of data stored in Stack
-     * @param[in] stack1 input container
-     * @param[in] stack2 input container
-     * @retval true if the content of \p s1 are lexicographically
-     *         greater or equal than the content of \p s2
-     * @retval false otherwise
-     */
-    template<typename T>
-    auto operator>=(const Stack<T>& stack1, const Stack<T>& stack2) -> bool
-    {
-        return !(operator<(stack1, stack2));
-    }
-
 }
 #endif // !STACK_H

--- a/tests/common.h
+++ b/tests/common.h
@@ -457,7 +457,7 @@ namespace tests
         T container_copy{ container };
         if constexpr (has_ranges<U>)
         {
-            // handle dsa::Stack and std::stack comparison
+            // handle dsa::Stack or std::stack and std::initializer_list comparison
 
             for (const auto& item : test_values)
             {
@@ -470,7 +470,7 @@ namespace tests
         }
         else if constexpr (has_top<U> && has_pop<U>)
         {
-            // handle dsa::Stack or std::stack and std::initializer_list comparison
+            // handle dsa::Stack and std::stack comparison
 
             U test_values_copy{ test_values };
             for (size_t i = 0; i < test_values.size(); i++)

--- a/tests/stack/CMakeLists.txt
+++ b/tests/stack/CMakeLists.txt
@@ -27,3 +27,7 @@ add_test(NAME stack_set_test COMMAND stack_set_test)
 add_executable(stack_operators_test stack_operators_test.cpp ${SRC_DIR}/common.cpp)
 target_link_libraries(stack_operators_test PRIVATE dsa_testing)
 add_test(NAME stack_operators_test COMMAND stack_operators_test)
+
+add_executable(stack_swap_test stack_swap_test.cpp ${SRC_DIR}/common.cpp)
+target_link_libraries(stack_swap_test PRIVATE dsa_testing)
+add_test(NAME stack_swap_test COMMAND stack_swap_test)

--- a/tests/stack/stack_ctors_test.cpp
+++ b/tests/stack/stack_ctors_test.cpp
@@ -10,8 +10,10 @@
  */
 
 #include "common.h"
+#include "dsa/list.h"
 #include "dsa/stack.h"
 
+#include <deque>
 #include <exception>
 #include <initializer_list>
 #include <iostream>
@@ -48,8 +50,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
 
         std::cout << "Copy ctor\n";
-        // intentionally make a copy to test copy constructor
-        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         const dsa::Stack<int> stack4{ stack1 };
         tests::compare("Stack4", stack4, expected);
 
@@ -64,7 +64,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Stack5", stack5, expected);
 
         std::cout << "Copy self assignment ctor\n";
-        dsa::Stack<int> stack6{ 0, 10, 20 };
+        dsa::Stack<int> stack6{ dsa::List<int>({0, 10, 20}) };
         auto* pointer6 = &stack6;
         stack6 = *pointer6;
         tests::compare("Stack6", stack6, expected);
@@ -81,10 +81,26 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Stack8", stack8, expected);
 
         std::cout << "Move self assignment ctor\n";
-        dsa::Stack<int> stack9{ 0, 10, 20 };
+        dsa::Stack<int> stack9{ dsa::List<int>({0, 10, 20}) };
         auto* pointer9 = &stack9;
         stack9 = std::move(*pointer9);
         tests::compare("Stack9", stack9, expected);
+
+        const dsa::Stack<int> stack10(dsa::List<int>(5));
+        const std::initializer_list<int> expected10{ 0, 0, 0, 0, 0 };
+        tests::compare("Stack10", stack10, expected10);
+
+        std::cout << "Construct from List using copy ctor\n";
+        const dsa::List<int> temp11 = { 10, 20, 30 };
+        const dsa::Stack<int> stack11(temp11);
+        const std::initializer_list<int> expected11{ 30, 20, 10 };
+        tests::compare("Stack11", stack11, expected11);
+
+        std::cout << "Construct from List using move assignment\n";
+        dsa::List<int> temp12 = { 10, 20, 30 };
+        const dsa::Stack<int> stack12(std::move(temp12));
+        const std::initializer_list<int> expected12{ 30, 20, 10 };
+        tests::compare("Stack12", stack12, expected12);
 
 
         std::cout << "Compare operations results with std container\n\n";
@@ -115,15 +131,28 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_stack5 = std_stack1;
         tests::compare("Stack5 vs std", stack5, std_stack5);
 
-        std::stack<int> std_temp_1(std_stack1);
-        const std::stack<int> std_stack6 = std::move(std_temp_1);
+        const std::stack<int> std_stack6(std::deque<int>({ 0, 10, 20 }));
         tests::compare("Stack6 vs std", stack6, std_stack6);
 
         std::stack<int> std_temp_2(std_stack1);
-        std::stack<int> std_stack7;
-        std_stack7.push(0);
-        std_stack7 = std::move(std_temp_2);
+        const std::stack<int> std_stack7 = std::move(std_temp_2);
         tests::compare("Stack7 vs std", stack7, std_stack7);
+
+        std::stack<int> std_temp_8(std_stack1);
+        std::stack<int> std_stack8;
+        std_stack8 = std::move(std_temp_8);
+        tests::compare("Stack8 vs std", stack8, std_stack8);
+
+        const std::stack<int> std_stack10(std::deque<int>(5));
+        tests::compare("Stack10 vs std", stack10, std_stack10);
+
+        const std::deque<int> std_temp11 = { 10, 20, 30 };
+        const std::stack<int> std_stack11(std_temp11);
+        tests::compare("Stack11 vs std", stack11, std_stack11);
+
+        std::deque<int> std_temp12 = { 10, 20, 30 };
+        const std::stack<int> std_stack12(std::move(std_temp12));
+        tests::compare("Stack12 vs std", stack12, std_stack12);
 
 
         tests::print_stats();

--- a/tests/stack/stack_grow_test.cpp
+++ b/tests/stack/stack_grow_test.cpp
@@ -34,6 +34,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         stack1.push(10);
         tests::compare("Stack1", stack1, expected);
 
+        dsa::Stack<int> stack2;
+        stack2.emplace(40);
+        stack2.emplace(30);
+        stack2.emplace(20);
+        stack2.emplace(10);
+        tests::compare("Stack2", stack2, expected);
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -42,6 +49,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_stack1.push(20);
         std_stack1.push(10);
         tests::compare("Stack1 vs std", stack1, std_stack1);
+
+        std::stack<int> std_stack2;
+        std_stack2.emplace(40);
+        std_stack2.emplace(30);
+        std_stack2.emplace(20);
+        std_stack2.emplace(10);
+        tests::compare("Stack2 vs std", stack2, std_stack2);
 
 
         tests::print_stats();

--- a/tests/stack/stack_operators_test.cpp
+++ b/tests/stack/stack_operators_test.cpp
@@ -10,11 +10,17 @@
  */
 
 #include "common.h"
+#include "dsa/list.h"
 #include "dsa/stack.h"
 
+#include <cassert>
+#include <compare>
+#include <deque>
 #include <exception>
 #include <iostream>
+#include <limits>
 #include <stack>
+#include <type_traits>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -52,6 +58,18 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Stack1 >= stack2", stack1 >= stack2, false);
         tests::compare("Stack2 >= stack1", stack2 >= stack1, true);
 
+        // test three way comparison
+
+        tests::compare("Stack1 <=> stack2 !=", (stack1 <=> stack2) != 0, (stack1 <=> stack2) != 0);
+        tests::compare("Stack1 <=> stack2 <", (stack1 <=> stack2) < 0, (stack1 <=> stack2) < 0);
+        tests::compare("Stack1 <=> stack2 >", (stack1 <=> stack2) > 0, (stack1 <=> stack2) > 0);
+        tests::compare("Stack1 <=> stack2 <=", (stack1 <=> stack2) <= 0, (stack1 <=> stack2) <= 0);
+        tests::compare("Stack1 <=> stack2 >=", (stack1 <=> stack2) >= 0, (stack1 <=> stack2) >= 0);
+
+        tests::compare("Stack1 <=> stack2 <", (stack1 <=> stack2) == std::weak_ordering::less, true);
+        tests::compare("Stack1 <=> stack2 <>", (stack1 <=> stack2) != std::weak_ordering::equivalent, true);
+        tests::compare("Stack1 <=> stack2 <=", (stack1 <=> stack2) != std::weak_ordering::greater, true);
+
         std::cout << "Compare operators for objects of different size\n\n";
 
         tests::compare("Stack1 == stack3", stack1 == stack3, false);
@@ -78,6 +96,41 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Stack2 >= stack3", stack2 >= stack3, true);
         tests::compare("Stack3 >= stack2", stack3 >= stack2, false);
 
+        // test three way comparison
+
+        tests::compare("Stack1 <=> stack3 ==", (stack1 <=> stack3) == 0, false);
+        tests::compare("Stack1 <=> stack3 <", (stack1 <=> stack3) < 0, true);
+        tests::compare("Stack1 <=> stack3 >", (stack1 <=> stack3) > 0, false);
+        tests::compare("Stack1 <=> stack3 <=", (stack1 <=> stack3) <= 0, true);
+        tests::compare("Stack1 <=> stack3 >=", (stack1 <=> stack3) >= 0, false);
+
+        tests::compare("Stack1 <=> stack3 >=", (stack1 <=> stack3) != std::weak_ordering::less, false);
+        tests::compare("Stack1 <=> stack3 ==", (stack1 <=> stack3) == std::weak_ordering::equivalent, false);
+        tests::compare("Stack1 <=> stack3 <=", (stack1 <=> stack3) != std::weak_ordering::greater, true);
+
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::Stack<int>>, std::strong_ordering>,
+            "Int stack should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::Stack<double>>, std::partial_ordering>,
+            "Double stack should support strong ordering");
+
+        // test partial ordering
+        const dsa::Stack<double> stack7{ dsa::List<double>{1.0, 2.0, 3.0} };
+        const dsa::Stack<double> stack8{ dsa::List<double>{1.0, 2.0, std::numeric_limits<double>::quiet_NaN()} };
+        assert((stack7 <=> stack8) == std::partial_ordering::unordered);
+        tests::compare("Stack7 <=> stack8 weak ordering", (stack7 <=> stack8) != std::weak_ordering::less, true);
+
+        // test noexcept
+
+        // operators
+        static_assert(!noexcept(
+            dsa::Stack<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)} ==
+            dsa::Stack<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)}));
+        static_assert(!noexcept(
+            dsa::Stack<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)} <=>
+            dsa::Stack<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)}));
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -102,6 +155,21 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         tests::compare("Stack1 >= stack2 vs std", stack1 >= stack2, std_stack1 >= std_stack2);
         tests::compare("Stack2 >= stack1 vs std", stack2 >= stack1, std_stack2 >= std_stack1);
+
+        // test three way comparison
+
+        tests::compare("Stack1 <=> stack2 vs std !=", (stack1 <=> stack2) != 0, (std_stack1 <=> std_stack2) != 0);
+        tests::compare("Stack1 <=> stack2 vs std <", (stack1 <=> stack2) < 0, (std_stack1 <=> std_stack2) < 0);
+        tests::compare("Stack1 <=> stack2 vs std >", (stack1 <=> stack2) > 0, (std_stack1 <=> std_stack2) > 0);
+        tests::compare("Stack1 <=> stack2 vs std <=", (stack1 <=> stack2) <= 0, (std_stack1 <=> std_stack2) <= 0);
+        tests::compare("Stack1 <=> stack2 vs std >=", (stack1 <=> stack2) >= 0, (std_stack1 <=> std_stack2) >= 0);
+
+        tests::compare("Stack1 <=> stack2 vs std <",
+            (stack1 <=> stack2) == std::weak_ordering::less, (std_stack1 <=> std_stack2) == std::weak_ordering::less);
+        tests::compare("Stack1 <=> stack2 vs std <>",
+            (stack1 <=> stack2) != std::weak_ordering::equivalent, (std_stack1 <=> std_stack2) != std::weak_ordering::equivalent);
+        tests::compare("Stack1 <=> stack2 vs std <=",
+            (stack1 <=> stack2) != std::weak_ordering::greater, (std_stack1 <=> std_stack2) != std::weak_ordering::greater);
 
         std::cout << "Compare operators for objects of different size\n\n";
 
@@ -128,6 +196,48 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Stack3 >= stack1 vs std", stack3 >= stack1, std_stack3 >= std_stack1);
         tests::compare("Stack2 >= stack3 vs std", stack2 >= stack3, std_stack2 >= std_stack3);
         tests::compare("Stack3 >= stack2 vs std", stack3 >= stack2, std_stack3 >= std_stack2);
+
+        // test three way comparison
+
+        tests::compare("Stack1 <=> stack3 vs std ==", (stack1 <=> stack3) == 0, (std_stack1 <=> std_stack3) == 0);
+        tests::compare("Stack1 <=> stack3 vs std <", (stack1 <=> stack3) < 0, (std_stack1 <=> std_stack3) < 0);
+        tests::compare("Stack1 <=> stack3 vs std >", (stack1 <=> stack3) > 0, (std_stack1 <=> std_stack3) > 0);
+        tests::compare("Stack1 <=> stack3 vs std <=", (stack1 <=> stack3) <= 0, (std_stack1 <=> std_stack3) <= 0);
+        tests::compare("Stack1 <=> stack3 vs std >=", (stack1 <=> stack3) >= 0, (std_stack1 <=> std_stack3) >= 0);
+
+        tests::compare("Stack1 <=> stack3 vs std >=",
+            (stack1 <=> stack3) != std::weak_ordering::less, (std_stack1 <=> std_stack3) != std::weak_ordering::less);
+        tests::compare("Stack1 <=> stack3 vs std ==",
+            (stack1 <=> stack3) == std::weak_ordering::equivalent, (std_stack1 <=> std_stack3) == std::weak_ordering::equivalent);
+        tests::compare("Stack1 <=> stack3 vs std <= ",
+            (stack1 <=> stack3) != std::weak_ordering::greater, (std_stack1 <=> std_stack3) != std::weak_ordering::greater);
+
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::stack<int>>, std::strong_ordering>,
+            "Int stack should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::stack<double>>, std::partial_ordering>,
+            "Double stack should support strong ordering");
+
+        // test partial ordering
+        const std::stack<double> std_stack7{ std::deque<double>{1.0, 2.0, 3.0} };
+        const std::stack<double> std_stack8{ std::deque<double>{1.0, 2.0, std::numeric_limits<double>::quiet_NaN()} };
+        assert((std_stack7 <=> std_stack8) == std::partial_ordering::unordered);
+        assert((stack7 <=> stack8) == (std_stack7 <=> std_stack8));
+        tests::compare("std_stack7 <=> std_stack8 weak ordering",
+            (std_stack7 <=> std_stack8) == std::partial_ordering::unordered, true);
+        tests::compare("(stack7 <=> stack8) == (std_stack7 <=> std_stack8)",
+            (stack7 <=> stack8) == (std_stack7 <=> std_stack8), true);
+
+        // test noexcept
+
+        // operators
+        static_assert(!noexcept(
+            std::stack<tests::ThrowingType>{std::deque<tests::ThrowingType>(1)} ==
+            std::stack<tests::ThrowingType>{std::deque<tests::ThrowingType>(1)}));
+        static_assert(!noexcept(
+            std::stack<tests::ThrowingType>{std::deque < tests::ThrowingType>(1)} <=>
+            std::stack<tests::ThrowingType>{std::deque < tests::ThrowingType>(1)}));
 
 
         tests::print_stats();

--- a/tests/stack/stack_set_test.cpp
+++ b/tests/stack/stack_set_test.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "common.h"
+#include "dsa/list.h"
 #include "dsa/stack.h"
 
 #include <exception>
@@ -35,8 +36,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::Stack<int> stack2 = dsa::Stack<int>({ 0,10,20 });
         dsa::Stack<int> stack3 = dsa::Stack<int>({ 0,10,50 });
         stack2.swap(stack3);
-        tests::compare("Stack2", stack2, std::initializer_list<int>{ 50, 10, 0 });
-        tests::compare("Stack3", stack3, std::initializer_list<int>{ 20, 10, 0 });
+        tests::compare("Stack2", stack2, dsa::Stack(dsa::List<int>{ 0, 10, 50 }));
+        tests::compare("Stack3", stack3, dsa::Stack(dsa::List<int>{ 0, 10, 20 }));
 
         dsa::Stack<int> stack4 = dsa::Stack<int>({ 0,10,50 });
         stack4.swap(stack4);

--- a/tests/stack/stack_swap_test.cpp
+++ b/tests/stack/stack_swap_test.cpp
@@ -1,0 +1,117 @@
+/**
+ * @file stack_swap_test.cpp
+ * @brief This file tests functions swapping Stack objects
+ * @author Michal Zygmunt
+ *
+ * @copyright Copyright (c) 2026 Michal Zygmunt
+ * This project is distributed under the MIT License.
+ * See accompanying LICENSE.txt file or obtain copy at
+ * https://opensource.org/license/mit
+ */
+
+#include "common.h"
+#include "dsa/stack.h"
+
+#include <exception>
+#include <initializer_list>
+#include <iostream>
+#include <stack>
+#include <utility>
+
+int main() // NOLINT(modernize-use-trailing-return-type)
+{
+    // tests are based on hardcoded magic numbers for comparison of container content
+    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+
+    try
+    {
+        std::cout << "Start stack_swap_test:\n";
+
+        const std::initializer_list<int> il_1{ 1, 2, 3, 4, 5 };
+        const std::initializer_list<int> il_2{ 10, 20, 30, 40, 50 };
+
+        dsa::Stack<int> stack1 = dsa::Stack<int>(il_1);
+        dsa::Stack<int> stack2 = dsa::Stack<int>(il_2);
+        stack1.swap(stack2);
+        const std::initializer_list<int> expected1 = { 50, 40, 30, 20, 10 };
+        tests::compare("Stack1", stack1, expected1);
+        const std::initializer_list<int> expected2 = { 5, 4, 3, 2, 1 };
+        tests::compare("Stack2", stack2, expected2);
+
+        dsa::Stack<int> stack3 = dsa::Stack<int>(il_1);
+        dsa::Stack<int> stack4;
+        stack3.swap(stack4);
+        const std::initializer_list<int> expected3 = { };
+        tests::compare("Stack3", stack3, expected3);
+        const std::initializer_list<int> expected4 = { 5, 4, 3, 2, 1 };
+        tests::compare("Stack4", stack4, expected4);
+
+        dsa::Stack<int> stack5 = dsa::Stack<int>(il_1);
+        dsa::Stack<int> stack6 = dsa::Stack<int>(il_2);
+        dsa::swap(stack5, stack6);
+        const std::initializer_list<int> expected5 = { 50, 40, 30, 20, 10 };
+        tests::compare("Stack5", stack5, expected5);
+        const std::initializer_list<int> expected6 = { 5, 4, 3, 2, 1 };
+        tests::compare("Stack6", stack6, expected6);
+
+        dsa::Stack<int> stack7 = dsa::Stack<int>(il_1);
+        dsa::Stack<int> stack8;
+        dsa::swap(stack7, stack8);
+        const std::initializer_list<int> expected7 = { };
+        tests::compare("Stack7", stack7, expected7);
+        const std::initializer_list<int> expected8 = { 5, 4, 3, 2, 1 };
+        tests::compare("Stack8", stack8, expected8);
+
+        // swap safe type
+        static_assert(noexcept(swap(std::declval<dsa::Stack<int>&>(),
+            std::declval<dsa::Stack<int>&>())));
+        // swap throwing type
+        static_assert(noexcept(swap(std::declval<dsa::Stack<tests::ThrowingType>&>(),
+            std::declval<dsa::Stack<tests::ThrowingType>&>())));
+
+
+        std::cout << "Compare operations results with std container\n\n";
+
+        std::stack<int> std_stack1{ il_1 };
+        std::stack<int> std_stack2{ il_2 };
+        std_stack1.swap(std_stack2);
+        tests::compare("Stack1 vs std", stack1, std_stack1);
+        tests::compare("Stack2 vs std", stack2, std_stack2);
+
+        std::stack<int> std_stack3{ il_1 };
+        std::stack<int> std_stack4{};
+        std_stack3.swap(std_stack4);
+        tests::compare("Stack3 vs std", stack3, std_stack3);
+        tests::compare("Stack4 vs std", stack4, std_stack4);
+
+        std::stack<int> std_stack5(il_1);
+        std::stack<int> std_stack6(il_2);
+        std::swap(std_stack5, std_stack6);
+        tests::compare("Stack5 vs std", stack5, std_stack5);
+        tests::compare("Stack6 vs std", stack6, std_stack6);
+
+        std::stack<int> std_stack7(il_1);
+        std::stack<int> std_stack8;
+        std::swap(std_stack7, std_stack8);
+        tests::compare("Stack7 vs std", stack7, std_stack7);
+        tests::compare("Stack8 vs std", stack8, std_stack8);
+
+        // swap safe type
+        static_assert(noexcept(swap(std::declval<std::stack<int>&>(),
+            std::declval<std::stack<int>&>())));
+        // swap throwing type
+        static_assert(noexcept(swap(std::declval<std::stack<tests::ThrowingType>&>(),
+            std::declval<std::stack<tests::ThrowingType>&>())));
+
+
+        tests::print_stats();
+    }
+    catch (...)
+    {
+        return tests::handle_exception(std::current_exception());
+    }
+
+    return tests::failed_count();
+
+    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+}


### PR DESCRIPTION
Update `dsa::Stack` class to better match `std::stack` API and behaviour.

Closes #33 

## Checkilst

- [x] provide the same member types and methods as `std::stack`, including:
  * emplace
  * operator<=>, when base container also supports <=> operator
  * non-member specialised functions: swap
- [x] remove public functions / operators not supported by `std::stack`
- [x] update tests to match features provided by updated implementation
- [x] separate function declarations and definitions (move method implementation outside class, where possible)
- [x] check if `[[nodiscard]]` is applied consistently and intentionally