### PR TITLE
Update Vector class to better match std::vector API and behaviour

### DIFF
--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -1266,119 +1266,6 @@ namespace dsa
         std::swap(*this, other);
     }
 
-    template<typename T>
-    inline auto Vector<T>::calc_new_capacity() -> size_type
-    {
-        return m_capacity == 0 ? 1 : m_capacity * 2;
-    }
-
-    template<typename T>
-    auto Vector<T>::insert_make_space_for_new_elems(const_iterator pos, size_type count) -> iterator
-    {
-        iterator new_pos{};
-
-        if (size() + count > capacity())
-        {
-            // allocate memory to store new content
-            const size_type new_capacity = m_capacity + count;
-            pointer new_data = allocator_type().allocate(new_capacity);
-
-            // use iterator to move all objects from original vector to new allocated memory
-            iterator iter{ begin() };
-            iterator new_iter = new_data;
-
-            // move all objects before pos from original memory
-            while (iter != pos)
-            {
-                std::allocator_traits<allocator_type>::construct(m_allocator, new_iter, std::move(*iter));
-                ++iter;
-                ++new_iter;
-            }
-
-            // make space for new elements
-            new_pos = new_iter;
-            for (size_t i = 0; i < count; i++)
-            {
-                ++new_iter;
-            }
-
-            // move all remaining objects from original memory
-            while (iter != end())
-            {
-                std::allocator_traits<allocator_type>::construct(m_allocator, new_iter, std::move(*iter));
-                ++iter;
-                ++new_iter;
-            }
-
-            clear_allocation();
-            m_data = new_data;
-            m_capacity = new_capacity;
-            m_size += count;
-        }
-        else
-        {
-            // store address to insert new elements
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-            iterator iter{ const_cast<iterator>(pos) };
-            new_pos = iter;
-
-            // move object to the right
-            std::move(iter, end(), iter + count);
-
-            m_size += count;
-        }
-
-        return new_pos;
-    }
-
-    template<typename T>
-    void Vector<T>::reallocate(size_type new_cap)
-    {
-        /*
-        * strong exception guarantee by:
-        * - throwing exception in case container is too large
-        * - using std::move_if_noexcept during reallocation
-        */
-
-        if (new_cap > max_size())
-        {
-            throw std::length_error("Pos argument outside of container range");
-        }
-
-        pointer new_data = allocator_type().allocate(new_cap);
-        for (size_t i = 0; i < m_size; i++)
-        {
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            std::allocator_traits<allocator_type>::construct(m_allocator, new_data + i, std::move_if_noexcept(m_data[i]));
-        }
-        clear_allocation();
-        m_data = new_data;
-        m_capacity = new_cap;
-        // m_size stay the same as before reallocation
-    }
-
-    template<typename T>
-    void Vector<T>::destroy_elements()
-    {
-        iterator iter{ begin() };
-        while (iter != end())
-        {
-            std::allocator_traits<allocator_type>::destroy(m_allocator, iter);
-            ++iter;
-        }
-    }
-
-    template<typename T>
-    void Vector<T>::clear_allocation()
-    {
-        if (m_data)
-        {
-            destroy_elements();
-            std::allocator_traits<allocator_type>::deallocate(m_allocator, m_data, m_capacity);
-            m_capacity = 0;
-        }
-    }
-
     /**
      * @brief Overloads operator to print all elements of Vector
      *
@@ -1517,6 +1404,121 @@ namespace dsa
         auto removed_count = static_cast<Vector<T>::size_type>(container.end() - new_end_iter);
         container.erase(new_end_iter, container.end());
         return removed_count;
+    }
+
+    // definitions of private methods
+
+    template<typename T>
+    inline auto Vector<T>::calc_new_capacity() -> size_type
+    {
+        return m_capacity == 0 ? 1 : m_capacity * 2;
+    }
+
+    template<typename T>
+    auto Vector<T>::insert_make_space_for_new_elems(const_iterator pos, size_type count) -> iterator
+    {
+        iterator new_pos{};
+
+        if (size() + count > capacity())
+        {
+            // allocate memory to store new content
+            const size_type new_capacity = m_capacity + count;
+            pointer new_data = allocator_type().allocate(new_capacity);
+
+            // use iterator to move all objects from original vector to new allocated memory
+            iterator iter{ begin() };
+            iterator new_iter = new_data;
+
+            // move all objects before pos from original memory
+            while (iter != pos)
+            {
+                std::allocator_traits<allocator_type>::construct(m_allocator, new_iter, std::move(*iter));
+                ++iter;
+                ++new_iter;
+            }
+
+            // make space for new elements
+            new_pos = new_iter;
+            for (size_t i = 0; i < count; i++)
+            {
+                ++new_iter;
+            }
+
+            // move all remaining objects from original memory
+            while (iter != end())
+            {
+                std::allocator_traits<allocator_type>::construct(m_allocator, new_iter, std::move(*iter));
+                ++iter;
+                ++new_iter;
+            }
+
+            clear_allocation();
+            m_data = new_data;
+            m_capacity = new_capacity;
+            m_size += count;
+        }
+        else
+        {
+            // store address to insert new elements
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+            iterator iter{ const_cast<iterator>(pos) };
+            new_pos = iter;
+
+            // move object to the right
+            std::move(iter, end(), iter + count);
+
+            m_size += count;
+        }
+
+        return new_pos;
+    }
+
+    template<typename T>
+    void Vector<T>::reallocate(size_type new_cap)
+    {
+        /*
+        * strong exception guarantee by:
+        * - throwing exception in case container is too large
+        * - using std::move_if_noexcept during reallocation
+        */
+
+        if (new_cap > max_size())
+        {
+            throw std::length_error("Pos argument outside of container range");
+        }
+
+        pointer new_data = allocator_type().allocate(new_cap);
+        for (size_t i = 0; i < m_size; i++)
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            std::allocator_traits<allocator_type>::construct(m_allocator, new_data + i, std::move_if_noexcept(m_data[i]));
+        }
+        clear_allocation();
+        m_data = new_data;
+        m_capacity = new_cap;
+        // m_size stay the same as before reallocation
+    }
+
+    template<typename T>
+    void Vector<T>::destroy_elements()
+    {
+        iterator iter{ begin() };
+        while (iter != end())
+        {
+            std::allocator_traits<allocator_type>::destroy(m_allocator, iter);
+            ++iter;
+        }
+    }
+
+    template<typename T>
+    void Vector<T>::clear_allocation()
+    {
+        if (m_data)
+        {
+            destroy_elements();
+            std::allocator_traits<allocator_type>::deallocate(m_allocator, m_data, m_capacity);
+            m_capacity = 0;
+        }
     }
 }
 

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -374,7 +374,7 @@ namespace dsa
          *
          * @return reverse_iterator to the first element
          */
-        [[nodiscard]] constexpr auto rbegin() -> reverse_iterator;
+        [[nodiscard]] constexpr auto rbegin() noexcept -> reverse_iterator;
 
         /**
          * @brief Returns const_reverse_iterator to the first element of reversed underlaying data structure
@@ -383,7 +383,7 @@ namespace dsa
          *
          * @return const_reverse_iterator to the first element
          */
-        [[nodiscard]] constexpr auto rbegin() const -> const_reverse_iterator;
+        [[nodiscard]] constexpr auto rbegin() const noexcept -> const_reverse_iterator;
 
         /**
          * @brief Returns const_reverse_iterator to the first element of reversed underlaying data structure
@@ -996,13 +996,13 @@ namespace dsa
     }
 
     template<typename T>
-    [[nodiscard]] constexpr auto Vector<T>::rbegin() -> reverse_iterator
+    [[nodiscard]] constexpr auto Vector<T>::rbegin() noexcept -> reverse_iterator
     {
         return reverse_iterator(end());
     }
 
     template<typename T>
-    [[nodiscard]] constexpr auto Vector<T>::rbegin() const -> const_reverse_iterator
+    [[nodiscard]] constexpr auto Vector<T>::rbegin() const noexcept -> const_reverse_iterator
     {
         return const_reverse_iterator(end());
     }

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -188,7 +188,9 @@ namespace dsa
          * @param[in,out] other Vector object of type T
          * @return Vector& reference to constructed Vector of type T
          */
-        constexpr auto operator=(Vector<T>&& other) noexcept -> Vector<T>&;
+        constexpr auto operator=(Vector<T>&& other) noexcept(
+            std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value ||
+            std::allocator_traits<allocator_type>::is_always_equal::value)->Vector<T>&;
 
         /**
          * @brief Assign Vector object from \p init_list elements
@@ -783,7 +785,9 @@ namespace dsa
     }
 
     template<typename T>
-    constexpr auto Vector<T>::operator=(Vector<T>&& other) noexcept -> Vector<T>&
+    constexpr auto Vector<T>::operator=(Vector<T>&& other) noexcept(
+        std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value ||
+        std::allocator_traits<allocator_type>::is_always_equal::value)-> Vector<T>&
     {
         if (&other != this)
         {

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -70,17 +70,13 @@ namespace dsa
 
         /**
          * @brief Alias for pointer to data type used in class
-         *
-         * @tparam T* pointer to data type
          */
-        using pointer = T*;
+        using pointer = std::allocator_traits<allocator_type>::pointer;
 
         /**
          * @brief Alias for const pointer to data type used in class
-         *
-         * @tparam T* pointer to data type
          */
-        using const_pointer = const T*;
+        using const_pointer = std::allocator_traits<allocator_type>::const_pointer;
 
         /**
          * @brief Alias for reference to data type used in class

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -1382,19 +1382,6 @@ namespace dsa
     }
 
     /**
-     * @brief Exchanges content of two Vector containers
-     *
-     * @tparam T data type stored in containers
-     * @param[in] vector1 container to swap content
-     * @param[in] vector2 container to swap content
-     */
-    template<typename T>
-    void swap(Vector<T>& vector1, Vector<T>& vector2) noexcept
-    {
-        vector1.swap(vector2);
-    }
-
-    /**
      * @brief Overloads operator to print all elements of Vector
      *
      * @tparam T data type stored in container
@@ -1483,6 +1470,19 @@ namespace dsa
         // first n elements are equal
         // check sizes
         return lhs.size() <=> rhs.size();
+    }
+
+    /**
+     * @brief Exchanges content of two Vector containers
+     *
+     * @tparam T data type stored in containers
+     * @param[in] lhs container to swap content
+     * @param[in] rhs container to swap content
+     */
+    template<typename T>
+    void swap(Vector<T>& lhs, Vector<T>& rhs) noexcept(noexcept(lhs.swap(rhs)))
+    {
+        lhs.swap(rhs);
     }
 }
 

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -1416,33 +1416,33 @@ namespace dsa
     /**
      * @brief The relational operator compares two Vector objects
      *
-     * @tparam T type of data stored in container
-     * @param[in] vector1 input container
-     * @param[in] vector2 input container
+     * @tparam T type of data stored in Vector
+     * @param[in] lhs input container
+     * @param[in] rhs input container
      * @retval true if containers are equal
      * @retval false if containers are not equal
      */
     template<typename T>
-    auto operator==(const Vector<T>& vector1, const Vector<T>& vector2) -> bool
+    auto operator==(const Vector<T>& lhs, const Vector<T>& rhs)
+        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> bool
     {
-        if (vector1.size() != vector2.size())
+        if (lhs.size() != rhs.size())
         {
             return false;
         }
 
-        auto vector1_iter = vector1.cbegin();
-        auto vector2_iter = vector2.cbegin();
+        auto lhs_iter = lhs.cbegin();
+        auto rhs_iter = rhs.cbegin();
 
-        // vectors have equal size, test condition for one vector
-        while (vector1_iter != vector1.cend())
+        while (lhs_iter != lhs.cend())
         {
-            if (*vector1_iter != *vector2_iter)
+            if (*lhs_iter != *rhs_iter)
             {
                 return false;
             }
 
-            vector1_iter++;
-            vector2_iter++;
+            lhs_iter++;
+            rhs_iter++;
         }
 
         return true;
@@ -1451,43 +1451,38 @@ namespace dsa
     /**
      * @brief The relational operator compares two Vector objects
      *
-     * @param[in] vector1 input container
-     * @param[in] vector2 input container
-     * @retval -1 if the content of \p vector1 is lexicographically lesser than the content of \p vector2
-     * @retval  0 if the content of \p vector1 and \p vector2 is equal
-     * @retval +1 if the content of \p vector1 is lexicographically greater than the content of \p vector2
+     * Depending on type T, function returns one of following objects:
+     * std::strong_ordering::less / equal / greater
+     * std::weak_ordering::less / equivalent / greater
+     * std::partial_ordering::less / equivalent / greater / unordered
+     * It is best to compare results with 0 to determine if lhs is <, >, or == to rhs
+     *
+     * @param[in] lhs input container
+     * @param[in] rhs input container
+     * @return three way comparison result type
      */
     template<typename T>
-    constexpr auto operator<=>(const Vector<T>& vector1, const Vector<T>& vector2)
+    auto operator<=>(const Vector<T>& lhs, const Vector<T>& rhs)
+        noexcept(noexcept(*lhs.begin() == *rhs.begin()))->std::compare_three_way_result_t<T>
     {
-        auto vector1_iter = vector1.cbegin();
-        auto vector2_iter = vector2.cbegin();
+        auto lhs_iter = lhs.cbegin();
+        auto rhs_iter = rhs.cbegin();
 
-        while (vector1_iter != vector1.cend() && vector2_iter != vector2.cend())
+        while (lhs_iter != lhs.cend() && rhs_iter != rhs.cend())
         {
-            if (*vector1_iter < *vector2_iter)
+            auto cmp = *lhs_iter <=> *rhs_iter;
+            if (cmp != 0)
             {
-                return std::strong_ordering::less;
-            }
-            if (*vector1_iter > *vector2_iter)
-            {
-                return std::strong_ordering::greater;
+                return cmp;
             }
 
-            vector1_iter++;
-            vector2_iter++;
+            lhs_iter++;
+            rhs_iter++;
         }
 
-        if (vector1.size() < vector2.size())
-        {
-            return std::strong_ordering::less;
-        }
-        if (vector1.size() > vector2.size())
-        {
-            return std::strong_ordering::greater;
-        }
-
-        return std::strong_ordering::equivalent;
+        // first n elements are equal
+        // check sizes
+        return lhs.size() <=> rhs.size();
     }
 }
 

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -401,7 +401,7 @@ namespace dsa
          *
          * @return reverse_iterator to the element after the last element
          */
-        [[nodiscard]] constexpr auto rend() -> reverse_iterator;
+        [[nodiscard]] constexpr auto rend() noexcept -> reverse_iterator;
 
         /**
          * @brief Returns const_reverse_iterator past the last element of reversed underlaying data structure
@@ -410,7 +410,7 @@ namespace dsa
          *
          * @return const_reverse_iterator to the element after the last element
          */
-        [[nodiscard]] constexpr auto rend() const -> const_reverse_iterator;
+        [[nodiscard]] constexpr auto rend() const noexcept -> const_reverse_iterator;
 
         /**
          * @brief Returns const_reverse_iterator past the last element of reversed underlaying data structure
@@ -1014,13 +1014,13 @@ namespace dsa
     }
 
     template<typename T>
-    [[nodiscard]] constexpr auto Vector<T>::rend() -> reverse_iterator
+    [[nodiscard]] constexpr auto Vector<T>::rend() noexcept -> reverse_iterator
     {
         return reverse_iterator(begin());
     }
 
     template<typename T>
-    [[nodiscard]] constexpr auto Vector<T>::rend() const -> const_reverse_iterator
+    [[nodiscard]] constexpr auto Vector<T>::rend() const noexcept -> const_reverse_iterator
     {
         return const_reverse_iterator(begin());
     }

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -170,7 +170,7 @@ namespace dsa
         /**
          * @brief Destroy the Vector object
          */
-        ~Vector();
+        constexpr ~Vector();
 
         /**
          * @brief Assign Vector object using copy assignment
@@ -758,7 +758,7 @@ namespace dsa
     }
 
     template<typename T>
-    Vector<T>::~Vector()
+    constexpr Vector<T>::~Vector()
     {
         clear_allocation();
     }

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -626,7 +626,9 @@ namespace dsa
          *
          * @param[in] other container to exchange content with
          */
-        constexpr void swap(Vector<T>& other) noexcept;
+        constexpr void swap(Vector<T>& other) noexcept(
+            std::allocator_traits<allocator_type>::propagate_on_container_swap::value ||
+            std::allocator_traits<allocator_type>::is_always_equal::value);
 
     private:
 
@@ -1259,7 +1261,9 @@ namespace dsa
     }
 
     template<typename T>
-    constexpr void Vector<T>::swap(Vector<T>& other) noexcept
+    constexpr void Vector<T>::swap(Vector<T>& other) noexcept(
+        std::allocator_traits<allocator_type>::propagate_on_container_swap::value ||
+        std::allocator_traits<allocator_type>::is_always_equal::value)
     {
         std::swap(*this, other);
     }

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -471,7 +471,7 @@ namespace dsa
          *
          * @note Operation invalidates all pointers and references
          */
-        constexpr void clear();
+        constexpr void clear() noexcept;
 
         /**
          * @brief Insert a copy of \p value before \p pos
@@ -1075,7 +1075,7 @@ namespace dsa
     }
 
     template<typename T>
-    constexpr void Vector<T>::clear()
+    constexpr void Vector<T>::clear() noexcept
     {
         destroy_elements();
         m_size = 0;

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -165,7 +165,7 @@ namespace dsa
          *
          * @param[in] init_list initializer list of values of type T
          */
-        constexpr Vector(std::initializer_list<T> init_list);
+        Vector(std::initializer_list<T> init_list);
 
         /**
          * @brief Destroy the Vector object
@@ -752,7 +752,7 @@ namespace dsa
     }
 
     template<typename T>
-    constexpr Vector<T>::Vector(std::initializer_list<T> init_list)
+    Vector<T>::Vector(std::initializer_list<T> init_list)
     {
         assign(init_list);
     }

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -12,6 +12,7 @@
 #ifndef VECTOR_H
 #define VECTOR_H
 
+#include <algorithm>
 #include <cstddef>
 #include <initializer_list>
 #include <iostream>
@@ -33,9 +34,6 @@ namespace dsa
      *       `dsa::Vector<bool>` behaves like a regular container,
      *       without bit-packing. This design choice prioritizes correctness
      *       and predictable semantics over memory optimization.
-     *
-     * @todo add non-member specialized erase function
-     * @todo add non-member specialized erase_if function
      */
     template<typename T>
     class Vector
@@ -1483,6 +1481,42 @@ namespace dsa
     void swap(Vector<T>& lhs, Vector<T>& rhs) noexcept(noexcept(lhs.swap(rhs)))
     {
         lhs.swap(rhs);
+    }
+
+    /**
+     * @brief Function erases from container all elements that are equal to \p value
+     *
+     * @tparam T data type stored in containers
+     * @tparam U data type of \p value
+     * @param[in,out] container object to remove erase elements from
+     * @param[in] value value to remove from \p container
+     * @return size_type number of elements removed
+     */
+    template<typename T, typename U>
+    constexpr auto erase(Vector<T>& container, const U& value) -> Vector<T>::size_type
+    {
+        auto* new_end_iter = std::remove(container.begin(), container.end(), value);
+        auto removed_count = static_cast<Vector<T>::size_type>(container.end() - new_end_iter);
+        container.erase(new_end_iter, container.end());
+        return removed_count;
+    }
+
+    /**
+     * @brief Function erases from container all elements that satisfy the predicate \p pred
+     *
+     * @tparam T data type stored in containers
+     * @tparam Pred predicate to check if element should be erased
+     * @param[in,out] container container object to remove erase elements from
+     * @param[in] pred predicate which returns \p true if the element should be erased
+     * @return size_type number of elements removed
+     */
+    template<typename T, typename Pred>
+    constexpr auto erase_if(Vector<T>& container, Pred pred) -> Vector<T>::size_type
+    {
+        auto* new_end_iter = std::remove_if(container.begin(), container.end(), pred);
+        auto removed_count = static_cast<Vector<T>::size_type>(container.end() - new_end_iter);
+        container.erase(new_end_iter, container.end());
+        return removed_count;
     }
 }
 

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -455,7 +455,7 @@ namespace dsa
          *
          * @return size_type number of allocated elements
          */
-        constexpr auto capacity() -> size_type;
+        constexpr auto capacity() const noexcept -> size_type;
 
         /**
          * @brief Request to remove of unused capacity
@@ -1060,7 +1060,7 @@ namespace dsa
     }
 
     template<typename T>
-    constexpr auto Vector<T>::capacity() -> size_type
+    constexpr auto Vector<T>::capacity() const noexcept -> size_type
     {
         return m_capacity;
     }

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -123,7 +123,7 @@ namespace dsa
          *
          * @param[in] count element count
          */
-        constexpr Vector(size_type count);
+        explicit Vector(size_type count);
 
         /**
          * @brief Construct a new Vector object of size \p count,
@@ -712,10 +712,9 @@ namespace dsa
     constexpr Vector<T>::Vector() = default;
 
     template<typename T>
-    constexpr Vector<T>::Vector(size_type count)
+    Vector<T>::Vector(size_type count)
         : Vector(count, T())
-    {
-    }
+    {}
 
     template<typename T>
     constexpr Vector<T>::Vector(size_type count, const T& value)

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -453,7 +453,7 @@ namespace dsa
          *
          * @return size_type number of allocated elements
          */
-        constexpr auto capacity() const noexcept -> size_type;
+        [[nodiscard]] constexpr auto capacity() const noexcept -> size_type;
 
         /**
          * @brief Request to remove of unused capacity
@@ -1037,7 +1037,7 @@ namespace dsa
     }
 
     template<typename T>
-    constexpr auto Vector<T>::capacity() const noexcept -> size_type
+    [[nodiscard]] constexpr auto Vector<T>::capacity() const noexcept -> size_type
     {
         return m_capacity;
     }

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -565,30 +565,7 @@ namespace dsa
          * @note iterator \p pos must be valid and dereferencable
          *       iterators and references at and after \p pos are invalidated
          */
-        constexpr auto erase(iterator pos) -> iterator;
-
-        /**
-         * @brief Erases specified element from the container
-         *
-         * @param[in] pos iterator to the element to remove
-         * @return iterator iterator to element after last erased element
-         *
-         * @note iterator \p pos must be valid and dereferencable
-         *       iterators and references at and after \p pos are invalidated
-         */
         constexpr auto erase(const_iterator pos) -> iterator;
-
-        /**
-         * @brief Erases elements in range [ \p first , \p last ) from the container
-         *
-         * @param[in] first element defining range of elements to insert
-         * @param[in] last element definig range of elements to insert
-         * @return iterator iterator to element after last erased element
-         *
-         * @note iterator \p first does not need to be dereferencable
-         *       iterators and references at and after \p first are invalidated
-         */
-        constexpr auto erase(iterator first, iterator last) -> iterator;
 
         /**
          * @brief Erases elements in range [ \p first , \p last ) from the container
@@ -1181,21 +1158,9 @@ namespace dsa
     }
 
     template<typename T>
-    constexpr auto Vector<T>::erase(iterator pos) -> iterator
-    {
-        return erase(pos, pos + 1);
-    }
-
-    template<typename T>
     constexpr auto Vector<T>::erase(const_iterator pos) -> iterator
     {
         return erase(pos, pos + 1);
-    }
-
-    template<typename T>
-    constexpr auto Vector<T>::erase(iterator first, iterator last) -> iterator
-    {
-        return erase(static_cast<const_iterator>(first), static_cast<const_iterator>(last));
     }
 
     template<typename T>

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -83,24 +83,24 @@ namespace dsa
          *
          * @tparam T& reference to data type
          */
-        using reference = T&;
+        using reference = value_type&;
 
         /**
          * @brief Alias for const reference to data type used in class
          *
          * @tparam T& const reference to data type
          */
-        using const_reference = const T&;
+        using const_reference = const value_type&;
 
         /**
          * @brief Alias for iterator to data type used in class
          */
-        using iterator = T*;
+        using iterator = value_type*;
 
         /**
          * @brief Alias for const iterator to data type used in class
          */
-        using const_iterator = const T*;
+        using const_iterator = const value_type*;
 
         /**
          * @brief Alias for reverse_iterator to data type used in class

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -427,7 +427,7 @@ namespace dsa
          * @return true if container is empty
          * @return false if container is not empty
          */
-        [[nodiscard]] constexpr auto empty() const -> bool;
+        [[nodiscard]] constexpr auto empty() const noexcept -> bool;
 
         /**
          * @brief Returns number of elements in container
@@ -1032,7 +1032,7 @@ namespace dsa
     }
 
     template<typename T>
-    [[nodiscard]] constexpr auto Vector<T>::empty() const -> bool
+    [[nodiscard]] constexpr auto Vector<T>::empty() const noexcept -> bool
     {
         return m_size == 0;
     }

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -233,7 +233,7 @@ namespace dsa
          *
          * @return allocator_type type of memory allocator
          */
-        [[nodiscard]] constexpr auto get_allocator() const -> allocator_type;
+        [[nodiscard]] constexpr auto get_allocator() const noexcept -> allocator_type;
 
         /**
          * @brief Returns a reference to Vector element at \p pos index.
@@ -871,7 +871,7 @@ namespace dsa
     }
 
     template<typename T>
-    [[nodiscard]] constexpr auto Vector<T>::get_allocator() const -> allocator_type
+    [[nodiscard]] constexpr auto Vector<T>::get_allocator() const noexcept -> allocator_type
     {
         return m_allocator;
     }

--- a/tests/vector/vector_ctors_test.cpp
+++ b/tests/vector/vector_ctors_test.cpp
@@ -123,16 +123,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_vector5.push_back(4);
         std_vector5.push_back(5);
         std_vector5 = std_vector1;
-        tests::compare("Vector5 vs std", vector5, expected);
+        tests::compare("Vector5 vs std", vector5, std_vector5);
 
         std::vector<int> std_temp_1(std_vector1);
         const std::vector<int> std_vector6 = std::move(std_temp_1);
-        tests::compare("Vector6 vs std", vector6, expected);
+        tests::compare("Vector6 vs std", vector6, std_vector6);
 
         std::vector<int> std_temp_2(std_vector1);
         std::vector<int> std_vector7(1, 0);
         std_vector7 = std::move(std_temp_2);
-        tests::compare("Vector7 vs std", vector7, expected);
+        tests::compare("Vector7 vs std", vector7, std_vector7);
 
         const std::vector<int> std_vector10{ 0, 10, 20 };
         tests::compare("Vector10 vs std", vector10, std_vector10);

--- a/tests/vector/vector_itors_test.cpp
+++ b/tests/vector/vector_itors_test.cpp
@@ -305,7 +305,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("vector20()", vector20, expected20);
 
         // test data access
-        int* ptr_vector20 = vector20.data();
+        const int* ptr_vector20 = vector20.data();
         static_assert(std::is_same_v<decltype(vector20.data()), int*>, "data() must return T*");
         tests::compare("vector20[0]", *ptr_vector20, 10);
 

--- a/tests/vector/vector_operators_test.cpp
+++ b/tests/vector/vector_operators_test.cpp
@@ -12,8 +12,12 @@
 #include "common.h"
 #include "dsa/vector.h"
 
+#include <cassert>
+#include <compare>
 #include <exception>
 #include <iostream>
+#include <limits>
+#include <type_traits>
 #include <vector>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
@@ -103,6 +107,20 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector1 <=> vector3 <=", (vector1 <=> vector3) != std::weak_ordering::greater, true);
 
 
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::Vector<int>>, std::strong_ordering>,
+            "Int vector should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::Vector<double>>, std::partial_ordering>,
+            "Double vector should support strong ordering");
+
+        // test partial ordering
+        const dsa::Vector<double> vector7{ 1.0, 2.0, 3.0 };
+        const dsa::Vector<double> vector8{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() };
+        assert((vector7 <=> vector8) == std::partial_ordering::unordered);
+        tests::compare("Vector7 <=> vector8 weak ordering", (vector7 <=> vector8) != std::weak_ordering::less, true);
+
+
         std::cout << "Compare operations results with std container\n\n";
 
         const std::vector<int> std_vector1({ 1, 2, 3 });
@@ -169,6 +187,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector2 >= vector3 vs std", vector2 >= vector3, std_vector2 >= std_vector3);
         tests::compare("Vector3 >= vector2 vs std", vector3 >= vector2, std_vector3 >= std_vector2);
 
+        // test three way comparison
+
         tests::compare("Vector1 <=> vector3 vs std ==", (vector1 <=> vector3) == 0, (std_vector1 <=> std_vector3) == 0);
         tests::compare("Vector1 <=> vector3 vs std <", (vector1 <=> vector3) < 0, (std_vector1 <=> std_vector3) < 0);
         tests::compare("Vector1 <=> vector3 vs std >", (vector1 <=> vector3) > 0, (std_vector1 <=> std_vector3) > 0);
@@ -181,6 +201,23 @@ int main() // NOLINT(modernize-use-trailing-return-type)
             (vector1 <=> vector3) == std::weak_ordering::equivalent, (std_vector1 <=> std_vector3) == std::weak_ordering::equivalent);
         tests::compare("Vector1 <=> vector3 vs std <= ",
             (vector1 <=> vector3) != std::weak_ordering::greater, (std_vector1 <=> std_vector3) != std::weak_ordering::greater);
+
+        // test comparison categories
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::vector<int>>, std::strong_ordering>,
+            "Int vector should support strong ordering");
+
+        static_assert(std::is_same_v<std::compare_three_way_result_t<std::vector<double>>, std::partial_ordering>,
+            "Double vector should support strong ordering");
+
+        // test partial ordering
+        const std::vector<double> std_vector7{ 1.0, 2.0, 3.0 };
+        const std::vector<double> std_vector8{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() };
+        assert((std_vector7 <=> std_vector8) == std::partial_ordering::unordered);
+        assert((vector7 <=> vector8) == (std_vector7 <=> std_vector8));
+        tests::compare("std_list7 <=> std_list8 weak ordering",
+            (std_vector7 <=> std_vector8) == std::partial_ordering::unordered, true);
+        tests::compare("(vector7 <=> vector8) == (std_vector7 <=> std_vector8)",
+            (vector7 <=> vector8) == (std_vector7 <=> std_vector8), true);
 
 
         tests::print_stats();

--- a/tests/vector/vector_operators_test.cpp
+++ b/tests/vector/vector_operators_test.cpp
@@ -120,6 +120,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         assert((vector7 <=> vector8) == std::partial_ordering::unordered);
         tests::compare("Vector7 <=> vector8 weak ordering", (vector7 <=> vector8) != std::weak_ordering::less, true);
 
+        // test noexcept
+
+        // operators
+        static_assert(!noexcept(dsa::Vector<tests::ThrowingType>{1} == dsa::Vector<tests::ThrowingType>{1}));
+        static_assert(!noexcept(dsa::Vector<tests::ThrowingType>{1} <=> dsa::Vector<tests::ThrowingType>{1}));
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -218,6 +224,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
             (std_vector7 <=> std_vector8) == std::partial_ordering::unordered, true);
         tests::compare("(vector7 <=> vector8) == (std_vector7 <=> std_vector8)",
             (vector7 <=> vector8) == (std_vector7 <=> std_vector8), true);
+
+        // test noexcept
+
+        // operators
+        static_assert(!noexcept(std::vector<tests::ThrowingType>{1} == std::vector<tests::ThrowingType>{1}));
+        static_assert(!noexcept(std::vector<tests::ThrowingType>{1} <=> std::vector<tests::ThrowingType>{1}));
 
 
         tests::print_stats();

--- a/tests/vector/vector_shrink_test.cpp
+++ b/tests/vector/vector_shrink_test.cpp
@@ -116,6 +116,42 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector11 size()", vector11.size(), static_cast<std::size_t>(5));
         tests::compare("Vector11 capacity()", vector11.capacity(), static_cast<std::size_t>(5));
 
+        dsa::Vector<int> vector12 = dsa::Vector<int>({ 0, 10, 0, 0, 40, 0 });
+        auto cnt12 = dsa::erase(vector12, 0);
+        const std::initializer_list<int> expected12 = { 10, 40 };
+        tests::compare("Vector12", vector12, expected12);
+        tests::compare("Vector12 removed count", cnt12, std::size_t{ 4 });
+
+        dsa::Vector<int> vector13 = dsa::Vector<int>({ 0, 0, 0, 0, 0, 0 });
+        auto cnt13 = dsa::erase(vector13, 0);
+        const std::initializer_list<int> expected13 = { };
+        tests::compare("Vector13", vector13, expected13);
+        tests::compare("Vector13 erase count", cnt13, std::size_t{ 6 });
+
+        dsa::Vector<int> vector14 = dsa::Vector<int>({ 0, 10, 0, 0, 40, 0 });
+        auto cnt14 = dsa::erase_if(vector14, [](int val) { return val == 0; });
+        const std::initializer_list<int> expected14 = { 10, 40 };
+        tests::compare("Vector14", vector14, expected14);
+        tests::compare("Vector14 erase count", cnt14, std::size_t{ 4 });
+
+        dsa::Vector<int> vector15 = dsa::Vector<int>({ 0, 0, 0, 0, 0, 0 });
+        auto cnt15 = dsa::erase_if(vector15, [](int val) { return val == 0; });
+        const std::initializer_list<int> expected15 = { };
+        tests::compare("Vector15", vector15, expected15);
+        tests::compare("Vector15 erase_if count", cnt15, std::size_t{ 6 });
+
+        dsa::Vector<int> vector16 = dsa::Vector<int>({ 0, 1, 2, 3, 4, 5 });
+        auto cnt16 = dsa::erase_if(vector16, [](int val) { return val % 2 == 0; });
+        const std::initializer_list<int> expected16 = { 1, 3, 5 };
+        tests::compare("Vector16", vector16, expected16);
+        tests::compare("Vector16 erase_if count", cnt16, std::size_t{ 3 });
+
+        dsa::Vector<int> vector17 = dsa::Vector<int>({ 0, 10, 2, 5, 7, 9 });
+        auto cnt17 = dsa::erase_if(vector17, [](int val) { return val <= 5; });
+        const std::initializer_list<int> expected17 = { 10, 7, 9 };
+        tests::compare("Vector17", vector17, expected17);
+        tests::compare("Vector17 erase_if count", cnt17, std::size_t{ 3 });
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -145,6 +181,36 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto std_it6 = std::remove(std_vector6.begin(), std_vector6.end(), 0);
         std_vector6.erase(std_it6, std_vector6.end());
         tests::compare("Vector6 vs std", vector6, std_vector6);
+
+        std::vector<int> std_vector12 = std::vector<int>({ 0, 10, 0, 0, 40, 0 });
+        auto std_cnt12 = std::erase(std_vector12, 0);
+        tests::compare("Vector12 vs std", vector12, std_vector12);
+        tests::compare("Vector12 vs std removed count", cnt12, std_cnt12);
+
+        std::vector<int> std_vector13 = std::vector<int>({ 0, 0, 0, 0, 0, 0 });
+        auto std_cnt13 = std::erase(std_vector13, 0);
+        tests::compare("Vector13 vs std", vector13, std_vector13);
+        tests::compare("Vector13 vs std erase count", cnt13, std_cnt13);
+
+        std::vector<int> std_vector14 = std::vector<int>({ 0, 10, 0, 0, 40, 0 });
+        auto std_cnt14 = std::erase_if(std_vector14, [](int val) { return val == 0; });
+        tests::compare("Vector14 vs std", vector14, std_vector14);
+        tests::compare("Vector14 vs std erase count", cnt14, std_cnt14);
+
+        std::vector<int> std_vector15 = std::vector<int>({ 0, 0, 0, 0, 0, 0 });
+        auto std_cnt15 = std::erase_if(std_vector15, [](int val) { return val == 0; });
+        tests::compare("Vector15 vs std", vector15, std_vector15);
+        tests::compare("Vector15 vs std erase_if count", cnt15, std_cnt15);
+
+        std::vector<int> std_vector16 = std::vector<int>({ 0, 1, 2, 3, 4, 5 });
+        auto std_cnt16 = std::erase_if(std_vector16, [](int val) { return val % 2 == 0; });
+        tests::compare("Vector16 vs std", vector16, std_vector16);
+        tests::compare("Vector16 vs std erase_if count", cnt16, std_cnt16);
+
+        std::vector<int> std_vector17 = std::vector<int>({ 0, 10, 2, 5, 7, 9 });
+        auto std_cnt17 = std::erase_if(std_vector17, [](int val) { return val <= 5; });
+        tests::compare("Vector17 vs std", vector17, std_vector17);
+        tests::compare("Vector17 vs std erase_if count", cnt17, std_cnt17);
 
 
         tests::print_stats();

--- a/tests/vector/vector_swap_test.cpp
+++ b/tests/vector/vector_swap_test.cpp
@@ -15,6 +15,7 @@
 #include <exception>
 #include <initializer_list>
 #include <iostream>
+#include <utility>
 #include <vector>
 
 int main() // NOLINT(modernize-use-trailing-return-type)
@@ -58,6 +59,21 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector6", vector6, temp7);
         tests::compare("Vector7", vector7, temp6);
 
+        dsa::Vector<int> vector8 = dsa::Vector<int>(il_1);
+        dsa::Vector<int> vector9;
+        dsa::swap(vector8, vector9);
+        const std::initializer_list<int> expected8 = { };
+        tests::compare("Vector8", vector8, expected8);
+        const std::initializer_list<int> expected9 = il_1;
+        tests::compare("Vector9", vector9, expected9);
+
+        // swap safe type
+        static_assert(noexcept(swap(std::declval<dsa::Vector<int>&>(),
+            std::declval<dsa::Vector<int>&>())));
+        // swap throwing type
+        static_assert(noexcept(swap(std::declval<dsa::Vector<tests::ThrowingType>&>(),
+            std::declval<dsa::Vector<tests::ThrowingType>&>())));
+
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -75,7 +91,28 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         std::vector<int> std_vector5{ 1, 2, 3, 4 };
         std_vector5.swap(std_vector5);
-        tests::compare("vector13 vs std", vector5, std_vector5);
+        tests::compare("vector5 vs std", vector5, std_vector5);
+
+        const std::initializer_list<int> std_temp6{ 1, 2, 3, 4, 5 };
+        const std::initializer_list<int> std_temp7{ 10, 20, 30 };
+        std::vector<int> std_vector6{ std_temp6 };
+        std::vector<int> std_vector7{ std_temp7 };
+        std::swap(std_vector6, std_vector7);
+        tests::compare("Vector6 vs std", vector6, std_vector6);
+        tests::compare("Vector7 vs std", vector7, std_vector7);
+
+        std::vector<int> std_vector8 = std::vector<int>(il_1);
+        std::vector<int> std_vector9;
+        std::swap(std_vector8, std_vector9);
+        tests::compare("Vector8 vs std", vector8, std_vector8);
+        tests::compare("Vector9 vs std", vector9, std_vector9);
+
+        // swap safe type
+        static_assert(noexcept(swap(std::declval<std::vector<int>&>(),
+            std::declval<std::vector<int>&>())));
+        // swap throwing type
+        static_assert(noexcept(swap(std::declval<std::vector<tests::ThrowingType>&>(),
+            std::declval<std::vector<tests::ThrowingType>&>())));
 
 
         tests::print_stats();


### PR DESCRIPTION
Update `dsa::Vector` class to better match `std::vector` API and behaviour.

Closes #34

## Checklist

- [x] provide the same member types and methods as `std::vector`
  * add non-member specialised functions: `erase`, `erase_if` functions
  * remove public method `erase` with not `const` iterator arguments (used before C++20)
  * fix `noexcept` specification for public methods: `capacity`, `clear`, `empty`, `get_allocator`, `operator=`, `rbegin`, `rend`, `swap`
  * fix results ordering of `operator<=>`
- [x] update tests to match features provided by updated implementation
- [x] separate function declarations and definitions (move method implementation outside class, where possible)
- [x] check if `[[nodiscard]]` is applied consistently and intentionally


