### PR TITLE
Add clang-format checks to CI workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,321 @@
+---
+Language:        Cpp
+AlignAfterOpenBracket: true
+AccessModifierOffset: -2
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: true
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments:
+  AlignPPAndNotPP: true
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowBreakBeforeQtProperty: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AllowShortNamespacesOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackLongBracedList: true
+BinPackParameters: BinPack
+BitFieldColonSpacing: Both
+BracedInitializerIndentWidth: -1
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterExternBlock: true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      false
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakAfterOpenBracketBracedList: false
+BreakAfterOpenBracketFunction: false
+BreakAfterOpenBracketIf: false
+BreakAfterOpenBracketLoop: false
+BreakAfterOpenBracketSwitch: false
+BreakAfterReturnType: None
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeCloseBracketBracedList: false
+BreakBeforeCloseBracketFunction: false
+BreakBeforeCloseBracketIf: false
+BreakBeforeCloseBracketLoop: false
+BreakBeforeCloseBracketSwitch: false
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTemplateCloser: false
+BreakBeforeTernaryOperators: true
+BreakBinaryOperations: Never
+BreakConstructorInitializers: BeforeColon
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+BreakTemplateDeclarations: MultiLine
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: AlignFirstComment
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+EnumTrailingComma: Leave
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExportBlock: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigitsInsert: 0
+  BinaryMaxDigitsRemove: 0
+  Decimal:         0
+  DecimalMinDigitsInsert: 0
+  DecimalMaxDigitsRemove: 0
+  Hex:             0
+  HexMinDigitsInsert: 0
+  HexMaxDigitsRemove: 0
+  BinaryMinDigits: 0
+  DecimalMinDigits: 0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLines:
+  AtEndOfFile:     false
+  AtStartOfBlock:  true
+  AtStartOfFile:   true
+KeepFormFeed:    false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+NumericLiteralCase:
+  ExponentLetter:  Leave
+  HexDigit:        Leave
+  Prefix:          Leave
+  Suffix:          Leave
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+OneLineFormatOffRegex: ''
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakBeforeMemberAccess: 150
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 1000
+PointerAlignment: Right
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  Always
+RemoveBracesLLVM: false
+RemoveEmptyLinesInUnwrappedLines: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes:
+  Enabled:         true
+  IgnoreCase:      false
+  IgnoreExtension: false
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterOperatorKeyword: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterNot:        false
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBraces: Never
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TableGenBreakInsideDAGArg: DontBreak
+TabWidth:        4
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+WrapNamespaceBodyWithEmptyLines: Leave
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,8 @@
 ---
 Language:        Cpp
-AlignAfterOpenBracket: true
-AccessModifierOffset: -2
-AlignArrayOfStructures: None
+AlignAfterOpenBracket: DontAlign
+AccessModifierOffset: -4
+AlignArrayOfStructures: Right
 AlignConsecutiveAssignments:
   Enabled:         false
   AcrossEmptyLines: false
@@ -71,8 +71,8 @@ AlignTrailingComments:
   AlignPPAndNotPP: true
   Kind:            Always
   OverEmptyLines:  0
-AllowAllArgumentsOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowBreakBeforeNoexceptSpecifier: Never
 AllowBreakBeforeQtProperty: false
 AllowShortBlocksOnASingleLine: Never
@@ -130,7 +130,7 @@ BreakBeforeCloseBracketIf: false
 BreakBeforeCloseBracketLoop: false
 BreakBeforeCloseBracketSwitch: false
 BreakBeforeConceptDeclarations: Always
-BreakBeforeBraces: Custom
+BreakBeforeBraces: Allman
 BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTemplateCloser: false
 BreakBeforeTernaryOperators: true
@@ -139,16 +139,16 @@ BreakConstructorInitializers: BeforeColon
 BreakFunctionDefinitionParameters: false
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
-BreakTemplateDeclarations: MultiLine
+BreakTemplateDeclarations: Yes
 ColumnLimit:     120
-CommentPragmas:  '^ IWYU pragma:'
+CommentPragmas:  '^ *(IWYU pragma:|NOLINT)'
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: AlignFirstComment
 DerivePointerAlignment: false
 DisableFormat:   false
-EmptyLineAfterAccessModifier: Never
+EmptyLineAfterAccessModifier: Always
 EmptyLineBeforeAccessModifier: LogicalBlock
 EnumTrailingComma: Leave
 ExperimentalAutoDetectBinPacking: false
@@ -177,7 +177,7 @@ IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
 IndentCaseBlocks: false
-IndentCaseLabels: false
+IndentCaseLabels: true
 IndentExportBlock: true
 IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
@@ -214,7 +214,7 @@ MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MainIncludeChar: Quote
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
+NamespaceIndentation: All
 NumericLiteralCase:
   ExponentLetter:  Leave
   HexDigit:        Leave
@@ -226,7 +226,7 @@ ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 OneLineFormatOffRegex: ''
-PackConstructorInitializers: BinPack
+PackConstructorInitializers: Never
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakBeforeMemberAccess: 150
@@ -239,10 +239,10 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 1000
-PointerAlignment: Right
+PointerAlignment: Left
 PPIndentWidth:   -1
 QualifierAlignment: Leave
-ReferenceAlignment: Pointer
+ReferenceAlignment: Left
 ReflowComments:  Always
 RemoveBracesLLVM: false
 RemoveEmptyLinesInUnwrappedLines: false
@@ -262,7 +262,7 @@ SortUsingDeclarations: LexicographicNumeric
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterOperatorKeyword: false
-SpaceAfterTemplateKeyword: true
+SpaceAfterTemplateKeyword: false
 SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
@@ -286,6 +286,7 @@ SpaceBeforeParensOptions:
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceBeforeSquareBrackets: false
 SpaceInEmptyBraces: Never
+SpacesInParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  Never
 SpacesInContainerLiterals: true
@@ -300,7 +301,7 @@ SpacesInParensOptions:
   InEmptyParentheses: false
   Other:           false
 SpacesInSquareBrackets: false
-Standard:        Latest
+Standard:        c++20
 StatementAttributeLikeMacros:
   - Q_EMIT
 StatementMacros:

--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,7 @@ AlignConsecutiveAssignments:
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
-  AlignFunctionDeclarations: false
+# AlignFunctionDeclarations: false
   AlignFunctionPointers: false
   PadOperators:    true
 AlignConsecutiveBitFields:
@@ -16,7 +16,7 @@ AlignConsecutiveBitFields:
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
-  AlignFunctionDeclarations: false
+# AlignFunctionDeclarations: false
   AlignFunctionPointers: false
   PadOperators:    false
 AlignConsecutiveDeclarations:
@@ -24,7 +24,7 @@ AlignConsecutiveDeclarations:
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
-  AlignFunctionDeclarations: true
+# AlignFunctionDeclarations: true
   AlignFunctionPointers: false
   PadOperators:    false
 AlignConsecutiveMacros:
@@ -32,7 +32,7 @@ AlignConsecutiveMacros:
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
-  AlignFunctionDeclarations: false
+# AlignFunctionDeclarations: false
   AlignFunctionPointers: false
   PadOperators:    false
 AlignConsecutiveShortCaseStatements:
@@ -46,7 +46,7 @@ AlignConsecutiveTableGenBreakingDAGArgColons:
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
-  AlignFunctionDeclarations: false
+# AlignFunctionDeclarations: false
   AlignFunctionPointers: false
   PadOperators:    false
 AlignConsecutiveTableGenCondOperatorColons:
@@ -54,7 +54,7 @@ AlignConsecutiveTableGenCondOperatorColons:
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
-  AlignFunctionDeclarations: false
+# AlignFunctionDeclarations: false
   AlignFunctionPointers: false
   PadOperators:    false
 AlignConsecutiveTableGenDefinitionColons:
@@ -62,19 +62,19 @@ AlignConsecutiveTableGenDefinitionColons:
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
-  AlignFunctionDeclarations: false
+# AlignFunctionDeclarations: false
   AlignFunctionPointers: false
   PadOperators:    false
 AlignEscapedNewlines: Right
 AlignOperands:   Align
 AlignTrailingComments:
-  AlignPPAndNotPP: true
+  # AlignPPAndNotPP: true
   Kind:            Always
   OverEmptyLines:  0
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowBreakBeforeNoexceptSpecifier: Never
-AllowBreakBeforeQtProperty: false
+# AllowBreakBeforeQtProperty: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseExpressionOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
@@ -84,16 +84,18 @@ AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
-AllowShortNamespacesOnASingleLine: false
+# AllowShortNamespacesOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AttributeMacros:
   - __capability
 BinPackArguments: true
-BinPackLongBracedList: true
-BinPackParameters: BinPack
+# BinPackLongBracedList: true
+# BinPackParameters: BinPack
+BinPackParameters: true
 BitFieldColonSpacing: Both
-BracedInitializerIndentWidth: -1
+# BracedInitializerIndentWidth: -1
+BracedInitializerIndentWidth: 2
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      true
@@ -116,25 +118,25 @@ BraceWrapping:
 BreakAdjacentStringLiterals: true
 BreakAfterAttributes: Leave
 BreakAfterJavaFieldAnnotations: false
-BreakAfterOpenBracketBracedList: false
-BreakAfterOpenBracketFunction: false
-BreakAfterOpenBracketIf: false
-BreakAfterOpenBracketLoop: false
-BreakAfterOpenBracketSwitch: false
+# BreakAfterOpenBracketBracedList: false
+# BreakAfterOpenBracketFunction: false
+# BreakAfterOpenBracketIf: false
+# BreakAfterOpenBracketLoop: false
+# BreakAfterOpenBracketSwitch: false
 BreakAfterReturnType: None
 BreakArrays:     true
 BreakBeforeBinaryOperators: None
-BreakBeforeCloseBracketBracedList: false
-BreakBeforeCloseBracketFunction: false
-BreakBeforeCloseBracketIf: false
-BreakBeforeCloseBracketLoop: false
-BreakBeforeCloseBracketSwitch: false
+# BreakBeforeCloseBracketBracedList: false
+# BreakBeforeCloseBracketFunction: false
+# BreakBeforeCloseBracketIf: false
+# BreakBeforeCloseBracketLoop: false
+# BreakBeforeCloseBracketSwitch: false
 BreakBeforeConceptDeclarations: Always
 BreakBeforeBraces: Allman
 BreakBeforeInlineASMColon: OnlyMultiline
-BreakBeforeTemplateCloser: false
+# BreakBeforeTemplateCloser: false
 BreakBeforeTernaryOperators: true
-BreakBinaryOperations: Never
+# BreakBinaryOperations: Never
 BreakConstructorInitializers: BeforeColon
 BreakFunctionDefinitionParameters: false
 BreakInheritanceList: BeforeColon
@@ -145,12 +147,13 @@ CommentPragmas:  '^ *(IWYU pragma:|NOLINT)'
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
-Cpp11BracedListStyle: AlignFirstComment
+# Cpp11BracedListStyle: AlignFirstComment
+Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 DisableFormat:   false
 EmptyLineAfterAccessModifier: Always
 EmptyLineBeforeAccessModifier: LogicalBlock
-EnumTrailingComma: Leave
+# EnumTrailingComma: Leave
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 ForEachMacros:
@@ -178,7 +181,7 @@ IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
 IndentCaseBlocks: false
 IndentCaseLabels: true
-IndentExportBlock: true
+# IndentExportBlock: true
 IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
 IndentPPDirectives: None
@@ -190,14 +193,14 @@ InsertNewlineAtEOF: false
 InsertTrailingCommas: None
 IntegerLiteralSeparator:
   Binary:          0
-  BinaryMinDigitsInsert: 0
-  BinaryMaxDigitsRemove: 0
+  # BinaryMinDigitsInsert: 0
+  # BinaryMaxDigitsRemove: 0
   Decimal:         0
-  DecimalMinDigitsInsert: 0
-  DecimalMaxDigitsRemove: 0
+  # DecimalMinDigitsInsert: 0
+  # DecimalMaxDigitsRemove: 0
   Hex:             0
-  HexMinDigitsInsert: 0
-  HexMaxDigitsRemove: 0
+  # HexMinDigitsInsert: 0
+  # HexMaxDigitsRemove: 0
   BinaryMinDigits: 0
   DecimalMinDigits: 0
   HexMinDigits:    0
@@ -207,7 +210,7 @@ KeepEmptyLines:
   AtEndOfFile:     false
   AtStartOfBlock:  true
   AtStartOfFile:   true
-KeepFormFeed:    false
+# KeepFormFeed:    false
 LambdaBodyIndentation: Signature
 LineEnding:      DeriveLF
 MacroBlockBegin: ''
@@ -215,21 +218,21 @@ MacroBlockEnd:   ''
 MainIncludeChar: Quote
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
-NumericLiteralCase:
-  ExponentLetter:  Leave
-  HexDigit:        Leave
-  Prefix:          Leave
-  Suffix:          Leave
+# NumericLiteralCase:
+#   ExponentLetter:  Leave
+#   HexDigit:        Leave
+#   Prefix:          Leave
+#   Suffix:          Leave
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-OneLineFormatOffRegex: ''
+# OneLineFormatOffRegex: ''
 PackConstructorInitializers: Never
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakBeforeMemberAccess: 150
+# PenaltyBreakBeforeMemberAccess: 150
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakOpenParenthesis: 0
@@ -243,9 +246,10 @@ PointerAlignment: Left
 PPIndentWidth:   -1
 QualifierAlignment: Leave
 ReferenceAlignment: Left
-ReflowComments:  Always
+# ReflowComments:  Always
+ReflowComments:  true
 RemoveBracesLLVM: false
-RemoveEmptyLinesInUnwrappedLines: false
+# RemoveEmptyLinesInUnwrappedLines: false
 RemoveParentheses: Leave
 RemoveSemicolon: false
 RequiresClausePosition: OwnLine
@@ -253,15 +257,16 @@ RequiresExpressionIndentation: OuterScope
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
 SkipMacroDefinitionBody: false
-SortIncludes:
-  Enabled:         true
-  IgnoreCase:      false
-  IgnoreExtension: false
+# SortIncludes:
+#   Enabled:         true
+#   IgnoreCase:      false
+#   IgnoreExtension: false
+SortIncludes:    CaseSensitive
 SortJavaStaticImport: Before
 SortUsingDeclarations: LexicographicNumeric
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
-SpaceAfterOperatorKeyword: false
+# SpaceAfterOperatorKeyword: false
 SpaceAfterTemplateKeyword: false
 SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
@@ -277,7 +282,7 @@ SpaceBeforeParensOptions:
   AfterFunctionDefinitionName: false
   AfterFunctionDeclarationName: false
   AfterIfMacros:   true
-  AfterNot:        false
+  # AfterNot:        false
   AfterOverloadedOperator: false
   AfterPlacementOperator: true
   AfterRequiresInClause: false
@@ -285,7 +290,7 @@ SpaceBeforeParensOptions:
   BeforeNonEmptyParentheses: false
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceBeforeSquareBrackets: false
-SpaceInEmptyBraces: Never
+# SpaceInEmptyBraces: Never
 SpacesInParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  Never
@@ -317,6 +322,6 @@ WhitespaceSensitiveMacros:
   - NS_SWIFT_NAME
   - PP_STRINGIZE
   - STRINGIZE
-WrapNamespaceBodyWithEmptyLines: Leave
+# WrapNamespaceBodyWithEmptyLines: Leave
 ...
 

--- a/.github/actions/setup-llvm-19/action.yml
+++ b/.github/actions/setup-llvm-19/action.yml
@@ -13,7 +13,7 @@ runs:
         chmod +x llvm.sh
         sudo ./llvm.sh 19
 
-        sudo apt-get install -y clang-19 lldb-19 lld-19 clang-tidy-19 --no-install-recommends
+        sudo apt-get install -y clang-19 lldb-19 lld-19 clang-tidy-19 clang-format-19 --no-install-recommends
 
         # Set LLVM/Clang 19 as default on Ubuntu
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 200
@@ -31,8 +31,13 @@ runs:
         sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-19 200
         sudo update-alternatives --set clang-tidy /usr/bin/clang-tidy-19
 
+        # Set LLVM/Clang tools used for clang-format
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-19 200
+        sudo update-alternatives --set clang-format /usr/bin/clang-format-19
+
         # Check LLVM/Clang version
         clang --version
         llvm-cov --version
         llvm-profdata --version
         clang-tidy --version
+        clang-format --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,15 @@ jobs:
           git fetch origin "${{ github.base_ref }}"
           git diff --name-only "origin/${{ github.base_ref }}...HEAD" > changed.txt
         elif [ "${{ github.event_name }}" == "push" ]; then
-          git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" > changed.txt
+          if git cat-file -e "${{ github.event.before }}^{commit}" 2>/dev/null; then
+            git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" > changed.txt
+          elif git rev-parse "${{ github.sha }}^" >/dev/null 2>&1; then
+            echo "Using parent of current commit"
+            git diff --name-only "${{ github.sha }}^" "${{ github.sha }}" > changed.txt
+          else
+            echo "First commit, checking all files."
+            git ls-tree --name-only -r "${{ github.sha }}" > changed.txt
+          fi
         fi
 
         grep -E '\.(cpp|h)$' changed.txt > files.txt || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,15 @@ jobs:
     - name: Get list of changed C/C++ files
       id: changed-files
       run: |
-        git diff --name-only origin/${{ github.base_ref }}...HEAD > changed.txt
+        set -euo pipefail
+
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          git fetch origin "${{ github.base_ref }}"
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" > changed.txt
+        elif [ "${{ github.event_name }}" == "push" ]; then
+          git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" > changed.txt
+        fi
+
         grep -E '\.(cpp|h)$' changed.txt > files.txt || true
 
     - name: Run clang-format check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,43 @@ on:
     branches: [ "**" ]
 
 jobs:
+  clang-format:
+    name: ubuntu-24.04-clang-format
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+  
+    - name: Show Ubuntu version
+      run: lsb_release -a
+
+    - name: Install LLVM/Clang 19 on Ubuntu
+      # Ubuntu 24.04 has installed Clang versions: 16.0.6, 17.0.6, 18.1.3
+      # Install Clang 19 as it was used initially on local Ubuntu OS
+      uses: ./.github/actions/setup-llvm-19
+
+    - name: Get list of changed C/C++ files
+      id: changed-files
+      run: |
+        git diff --name-only origin/${{ github.base_ref }}...HEAD > changed.txt
+        grep -E '\.(cpp|h)$' changed.txt > files.txt || true
+
+    - name: Run clang-format check
+      if: hashFiles('files.txt') != ''
+      run: |
+        clang-format --dry-run --Werror $(cat files.txt)
+
+    - name: Result
+      if: hashFiles('files.txt') == ''
+      run: echo "No C/C++ files to format"
+
+
+
   build:
     runs-on: ${{ matrix.os }}
+    needs: clang-format
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,17 @@ jobs:
           fi
         fi
 
-        grep -E '\.(cpp|h)$' changed.txt > files.txt || true
-
         echo "Changed files:"
+        cat changed.txt
+
+        if grep -qx ".clang-format" changed.txt; then
+          echo ".clang-format changed - checking all C/C++ files"
+          find . -type f \( -name "*.cpp" -o -name "*.h" \) > files.txt
+        else
+          grep -E '\.(cpp|h)$' changed.txt > files.txt || true
+        fi
+
+        echo "Files to check:"
         cat files.txt || true
 
         if [ -s files.txt ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,29 @@ jobs:
 
         grep -E '\.(cpp|h)$' changed.txt > files.txt || true
 
-    - name: Run clang-format check
-      if: hashFiles('files.txt') != ''
-      run: |
-        clang-format --dry-run --Werror $(cat files.txt)
+        echo "Changed files:"
+        cat files.txt || true
 
-    - name: Result
-      if: hashFiles('files.txt') == ''
-      run: echo "No C/C++ files to format"
+        if [ -s files.txt ]; then
+          echo "has_files=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_files=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Run clang-format check on changed files
+      if: steps.changed-files.outputs.has_files == 'true'
+      run: |
+        if clang-format --dry-run --Werror $(cat files.txt); then
+          echo "::notice::Formatting check passed."
+        else
+          echo "::error::Formatting check failed."
+          echo "::error::Run clang-format on the affected files and commit the changes."
+          exit 1
+        fi
+
+    - name: No changed files detected
+      if: steps.changed-files.outputs.has_files == 'false'
+      run: echo "::notice::No .cpp or .h files changed. Skipping formatting check."
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(ENABLE_WARNINGS "Enable strict compiler flags" ON)
 option(ENABLE_SANITIZERS "Enable sanitizers ASan/UBSan" ON)
 option(ENABLE_CLANG_TIDY "Enable clang-tidy static code analysis" OFF)
 option(ENABLE_CLANG_TIDY_STRICT "Fail on first clang-tidy warning/error" OFF)
+option(ENABLE_CLANG_FORMAT "Enable custom target for formatting using clang-format rules" ON)
 option(DOCS_ENABLED "Enable documentation generation" ON)
 option(CODE_TESTING "Enable code testing" ON)
 option(CODE_COVERAGE "Enable coverage reporting" ON)
@@ -54,6 +55,28 @@ if(ENABLE_CLANG_TIDY)
 		)
 	else()
 		message(WARNING "clang-tidy not found")
+	endif()
+endif()
+
+
+if(ENABLE_CLANG_FORMAT)
+	message(STATUS "Project files formatting with clang-format option enabled")
+
+	find_program(CLANG_FORMAT_EXE NAMES clang-format)
+	
+	if(CLANG_FORMAT_EXE)
+		message(STATUS "clang-format found " ${CLANG_FORMAT_EXE})
+		
+		file(GLOB_RECURSE SOURCE_FILES
+			*.cpp *.h
+		)
+		add_custom_target(format
+			COMMAND ${CLANG_FORMAT_EXE} -i ${SOURCE_FILES}
+			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+			COMMENT "Formatting source files with clang-format"
+		)
+	else()
+		message(WARNING "clang-format not found")
 	endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,12 @@ if(ENABLE_CLANG_FORMAT)
 	
 	if(CLANG_FORMAT_EXE)
 		message(STATUS "clang-format found " ${CLANG_FORMAT_EXE})
-		
-		file(GLOB_RECURSE SOURCE_FILES
-			*.cpp *.h
+
+		file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS
+			"${CMAKE_SOURCE_DIR}/include/*.cpp"
+			"${CMAKE_SOURCE_DIR}/include/*.h"
+			"${CMAKE_SOURCE_DIR}/tests/*.cpp"
+			"${CMAKE_SOURCE_DIR}/tests/*.h"
 		)
 		add_custom_target(format
 			COMMAND ${CLANG_FORMAT_EXE} -i ${SOURCE_FILES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,11 +73,16 @@ if(ENABLE_CLANG_FORMAT)
 			"${CMAKE_SOURCE_DIR}/tests/*.cpp"
 			"${CMAKE_SOURCE_DIR}/tests/*.h"
 		)
-		add_custom_target(format
-			COMMAND ${CLANG_FORMAT_EXE} -i ${SOURCE_FILES}
-			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-			COMMENT "Formatting source files with clang-format"
+
+		add_custom_target(format)
+		foreach(FILE IN LISTS SOURCE_FILES)
+		add_custom_command(
+			COMMENT "Formatting ${FILE} with clang-format"
+			TARGET format
+			COMMAND ${CLANG_FORMAT_EXE} -i "${FILE}"
 		)
+		endforeach()
+
 	else()
 		message(WARNING "clang-format not found")
 	endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,15 @@ if(ENABLE_CLANG_FORMAT)
 		)
 		endforeach()
 
+		add_custom_target(check-format)
+		foreach(FILE IN LISTS SOURCE_FILES)
+		add_custom_command(
+			COMMENT "Check formatting of ${FILE} with clang-format"
+			TARGET check-format
+			COMMAND ${CLANG_FORMAT_EXE} --dry-run --Werror "${FILE}"
+		)
+		endforeach()
+
 	else()
 		message(WARNING "clang-format not found")
 	endif()

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ where applicable.
 ### Optional
 - Doxygen and Graphviz (dot) to generate documentation locally
 - Clang-tidy to check code quality and application of best practices
+- Clang-format to maintain a consistent coding style across the codebase
 - Python 3 and WSL/Linux tools to generate code coverage reports locally
 
 Adding CMake configuration options can be used to disable features that
@@ -133,6 +134,38 @@ cmake -S . -B build \
   -DCMAKE_C_COMPILER=clang-cl \
   -DENABLE_CLANG_TIDY=ON
 cmake --build build --config Release
+```
+
+## Code Formatting
+
+The project uses `clang-format` to maintain a consistent coding style
+across the codebase. The formatting rules are defined in the
+`.clang-format` file located in the repository root.
+
+It is recommended to configure your IDE to automatically
+format source files using the project's `.clang-format` configuration.
+This helps keep the codebase consistent and reduces formatting-only
+changes in commits.
+
+Code formatting is checked by CI workflow.
+
+### Formatting with CMake
+
+Enable the formatting target when configuring the project:
+
+```bash
+cmake -S . -B build -DENABLE_CLANG_FORMAT=ON
+```
+
+Then run the formatting target:
+```bash
+cmake --build build --target format
+```
+
+To only check formatting without making any changes to files
+run following target:
+```bash
+cmake --build build --target check-format
 ```
 
 ## Usage Example

--- a/include/dsa/array.h
+++ b/include/dsa/array.h
@@ -429,8 +429,8 @@ namespace dsa
          * @brief Underlaying fixed size array containing all elements
          *        Conditional size is used to handle zero sized array without template specialization
          */
-         // Public for aggregate initialization, same as std::array
-         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays, misc-non-private-member-variables-in-classes)
+        // Public for aggregate initialization, same as std::array
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays, misc-non-private-member-variables-in-classes)
         value_type m_data[N == 0 ? 1 : N]{};
     };
 
@@ -530,12 +530,12 @@ namespace dsa
     // Intentional use of C-style array: the array bound must be part of the type
     // to enable compile-time size deduction
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-    [[nodiscard]] constexpr auto to_array(T(&array)[N]) -> Array<std::remove_cv_t<T>, N>
+    [[nodiscard]] constexpr auto to_array(T (&array)[N]) -> Array<std::remove_cv_t<T>, N>
     {
-        return[&]<std::size_t... I>(std::index_sequence<I...>)
+        return [&]<std::size_t... I>(std::index_sequence<I...>)
         {
             // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-            return dsa::Array<std::remove_cv_t<T>, N>{array[I]...};
+            return dsa::Array<std::remove_cv_t<T>, N>{ array[I]... };
         }(std::make_index_sequence<N>{});
     }
 
@@ -551,12 +551,12 @@ namespace dsa
     // Intentional use of C-style array: the array bound must be part of the type
     // to enable compile-time size deduction
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-rvalue-reference-param-not-moved)
-    [[nodiscard]] constexpr auto to_array(T(&& array)[N]) -> Array<std::remove_cv_t<T>, N>
+    [[nodiscard]] constexpr auto to_array(T (&&array)[N]) -> Array<std::remove_cv_t<T>, N>
     {
-        return[&]<std::size_t... I>(std::index_sequence<I...>)
+        return [&]<std::size_t... I>(std::index_sequence<I...>)
         {
             // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-            return dsa::Array<std::remove_cv_t<T>, N>{std::move(array[I])...};
+            return dsa::Array<std::remove_cv_t<T>, N>{ std::move(array[I])... };
         }(std::make_index_sequence<N>{});
     }
 
@@ -588,8 +588,8 @@ namespace dsa
      * @retval false if input containers are not equal
      */
     template<typename T, std::size_t N>
-    [[nodiscard]] constexpr auto operator==(const Array<T, N>& lhs, const Array<T, N>& rhs)
-        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> bool
+    [[nodiscard]] constexpr auto operator==(const Array<T, N>& lhs, const Array<T, N>& rhs) noexcept(
+        noexcept(*lhs.begin() == *rhs.begin())) -> bool
     {
         auto lhs_iter = lhs.cbegin();
         auto rhs_iter = rhs.cbegin();
@@ -622,8 +622,8 @@ namespace dsa
      * @return three way comparison result type
      */
     template<typename T, std::size_t N>
-    [[nodiscard]] constexpr auto operator<=>(const Array<T, N>& lhs, const Array<T, N>& rhs)
-        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> std::compare_three_way_result_t<T>
+    [[nodiscard]] constexpr auto operator<=>(const Array<T, N>& lhs, const Array<T, N>& rhs) noexcept(
+        noexcept(*lhs.begin() == *rhs.begin())) -> std::compare_three_way_result_t<T>
     {
         auto lhs_iter = lhs.cbegin();
         auto rhs_iter = rhs.cbegin();
@@ -642,18 +642,18 @@ namespace dsa
 
         return std::compare_three_way_result_t<T>::equivalent;
     }
-}
+} // namespace dsa
 
 namespace std
 {
     /*
-    * These are explicit specializations of standard templates 'tuple_size' and 'tuple_element'
-    * for a user-defined type dsa::Array. This is allowed by C++ standard and required
-    * to enable structured bindings and tuple-like behaviour.
-    *
-    * No new symbols or modification of standard library behaviour was introduced,
-    * only providing valid specialization for user-defined type.
-    */
+     * These are explicit specializations of standard templates 'tuple_size' and 'tuple_element'
+     * for a user-defined type dsa::Array. This is allowed by C++ standard and required
+     * to enable structured bindings and tuple-like behaviour.
+     *
+     * No new symbols or modification of standard library behaviour was introduced,
+     * only providing valid specialization for user-defined type.
+     */
     // NOLINTBEGIN(cert-dcl58-cpp)
 
     /// @cond SPECIALIZATION
@@ -666,7 +666,7 @@ namespace std
      * @see https://en.cppreference.com/w/cpp/container/array/tuple_size.html
      */
     template<typename T, std::size_t N>
-    struct tuple_size <dsa::Array<T, N>> : std::integral_constant<std::size_t, N>
+    struct tuple_size<dsa::Array<T, N>> : std::integral_constant<std::size_t, N>
     {
     };
     /// @endcond
@@ -695,9 +695,9 @@ namespace std
     namespace ranges
     {
         /*
-        * These are explicit specializations of range semantics for a user-defined type dsa::Array
-        * specifically to be recognized as 'borrowed range' or 'view'
-        */
+         * These are explicit specializations of range semantics for a user-defined type dsa::Array
+         * specifically to be recognized as 'borrowed range' or 'view'
+         */
 
         /// @cond SPECIALIZATION
         /**
@@ -744,9 +744,9 @@ namespace std
         template<typename T, std::size_t N>
         inline constexpr bool enable_view<const dsa::Array<T, N>> = true;
         /// @endcond
-    }
+    } // namespace ranges
 
     // NOLINTEND(cert-dcl58-cpp)
-}
+} // namespace std
 
 #endif // !ARRAY_H

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -64,7 +64,7 @@ namespace dsa
              * @param[in] other NodeBase object
              * @return NodeBase& reference to NodeBase object
              */
-            auto operator=(const NodeBase& other) -> NodeBase & = default;
+            auto operator=(const NodeBase& other) -> NodeBase& = default;
 
             /**
              * @brief Construct NodeBase object using move constructor
@@ -81,7 +81,7 @@ namespace dsa
              * @param[in,out] other NodeBase object
              * @return NodeBase& reference to NodeBase object
              */
-            auto operator=(NodeBase&& other) -> NodeBase & = default;
+            auto operator=(NodeBase&& other) -> NodeBase& = default;
 
             /**
              * @brief Destroy the Node Base object
@@ -112,7 +112,8 @@ namespace dsa
              */
             Node(const T& value)
                 : m_value{ value }
-            {}
+            {
+            }
 
             /**
              * @brief Construct a new Node object with initial value using move semantics
@@ -122,7 +123,8 @@ namespace dsa
              */
             Node(T&& value)
                 : m_value{ std::move(value) }
-            {}
+            {
+            }
 
             /**
              * @brief Function returns value stored in Node object
@@ -229,7 +231,8 @@ namespace dsa
              */
             ForwardListIterator(NodeBase* node) noexcept
                 : m_current_node{ node }
-            {}
+            {
+            }
 
             /**
              * @brief Overload operator= to assign \p node to currently pointed ForwardListIterator
@@ -680,13 +683,13 @@ namespace dsa
         auto emplace_after(const_iterator pos, Args&&... args) -> iterator;
 
         /**
-        * @brief Function erases Node after specified ForwardList const_iterator
-        *
-        * @param[in] pos const_iterator after which element will be erased
-        * @return pointer to element after deleted iterator
-        * @retval iterator element after deleted element
-        * @retval nullptr if invalid iterator
-        */
+         * @brief Function erases Node after specified ForwardList const_iterator
+         *
+         * @param[in] pos const_iterator after which element will be erased
+         * @return pointer to element after deleted iterator
+         * @retval iterator element after deleted element
+         * @retval nullptr if invalid iterator
+         */
         auto erase_after(const const_iterator& pos) -> iterator;
 
         /**
@@ -884,8 +887,8 @@ namespace dsa
          *       iterators or references of objects moved from \p other will
          *       refer to the same elements of \p this
          */
-        void splice_after(const const_iterator& pos, ForwardList<T>& other,
-            const const_iterator& first, const const_iterator& last);
+        void splice_after(const const_iterator& pos, ForwardList<T>& other, const const_iterator& first,
+            const const_iterator& last);
 
         /**
          * @brief Function moves elements from other ForwardList object
@@ -1051,8 +1054,8 @@ namespace dsa
          * @param[in] iter const_iterator after which elements of \p other will be taken
          * @details Content of other object will be taken by constructed object
          */
-         // transfers ownership of nodes, moving entire container is not necessary
-         // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+        // transfers ownership of nodes, moving entire container is not necessary
+        // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
         void transfer(const const_iterator& pos, ForwardList<T>&& other, const const_iterator& iter);
 
         /**
@@ -1064,10 +1067,10 @@ namespace dsa
          * @param[in] last const_iterator until which elements of \p other will be taken
          * @details Content of other object will be taken by constructed object
          */
-         // transfers ownership of nodes, moving entire container is not necessary
-         // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
-        void transfer(const const_iterator& pos, ForwardList<T>&& other,
-            const const_iterator& first, const const_iterator& last);
+        // transfers ownership of nodes, moving entire container is not necessary
+        // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+        void transfer(const const_iterator& pos, ForwardList<T>&& other, const const_iterator& first,
+            const const_iterator& last);
 
         /**
          * @brief Function sorts nodes using merge sort algorithm
@@ -1126,7 +1129,8 @@ namespace dsa
     template<typename T>
     ForwardList<T>::ForwardList(size_type count)
         : ForwardList(count, T{})
-    {}
+    {
+    }
 
     template<typename T>
     ForwardList<T>::ForwardList(size_type count, const T& value)
@@ -1337,7 +1341,6 @@ namespace dsa
         return end();
     }
 
-
     template<typename T>
     auto ForwardList<T>::empty() const -> bool
     {
@@ -1366,15 +1369,14 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::insert_after(const const_iterator& pos, const_reference value)
-        -> typename ForwardList<T>::iterator
+    auto ForwardList<T>::insert_after(const const_iterator& pos, const_reference value) ->
+        typename ForwardList<T>::iterator
     {
         return insert_after(pos, 1, value);
     }
 
     template<typename T>
-    auto ForwardList<T>::insert_after(const const_iterator& pos, T&& value)
-        -> typename ForwardList<T>::iterator
+    auto ForwardList<T>::insert_after(const const_iterator& pos, T&& value) -> typename ForwardList<T>::iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1388,8 +1390,8 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::insert_after(const const_iterator& pos, size_type count, const_reference value)
-        -> typename ForwardList<T>::iterator
+    auto ForwardList<T>::insert_after(const const_iterator& pos, size_type count, const_reference value) ->
+        typename ForwardList<T>::iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1408,8 +1410,8 @@ namespace dsa
     template<typename T>
     template<typename InputIt>
         requires std::input_iterator<InputIt>
-    auto ForwardList<T>::insert_after(const const_iterator& pos, InputIt first, InputIt last)
-        -> typename ForwardList<T>::iterator
+    auto ForwardList<T>::insert_after(const const_iterator& pos, InputIt first, InputIt last) ->
+        typename ForwardList<T>::iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1427,8 +1429,8 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::insert_after(const const_iterator& pos, std::initializer_list<T> init_list)
-        -> typename ForwardList<T>::iterator
+    auto ForwardList<T>::insert_after(const const_iterator& pos, std::initializer_list<T> init_list) ->
+        typename ForwardList<T>::iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1472,8 +1474,8 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::erase_after(const const_iterator& first,
-        const const_iterator& last) -> typename ForwardList<T>::iterator
+    auto ForwardList<T>::erase_after(const const_iterator& first, const const_iterator& last) ->
+        typename ForwardList<T>::iterator
     {
         if (!if_valid_iterator(first) || !if_valid_iterator(last))
         {
@@ -1576,8 +1578,8 @@ namespace dsa
     }
 
     template<typename T>
-    void ForwardList<T>::swap(ForwardList<T>& other)
-        noexcept(std::allocator_traits<allocator_type>::is_always_equal::value)
+    void ForwardList<T>::swap(ForwardList<T>& other) noexcept(
+        std::allocator_traits<allocator_type>::is_always_equal::value)
     {
         std::swap(m_head, other.m_head);
         std::swap(m_size, other.m_size);
@@ -1632,8 +1634,7 @@ namespace dsa
                 if (node_this && node_other)
                 {
                     // 2nd condition keeps correct order of equal elements
-                    if (comp(node_this->value(), node_other->value()) ||
-                        !comp(node_other->value(), node_this->value()))
+                    if (comp(node_this->value(), node_other->value()) || !comp(node_other->value(), node_this->value()))
                     {
                         to_move = m_head->m_next;
                         to_return = to_move->m_next;
@@ -1700,14 +1701,15 @@ namespace dsa
     }
 
     template<typename T>
-    void ForwardList<T>::splice_after(const const_iterator& pos, ForwardList<T>& other,
-        const const_iterator& first, const const_iterator& last)
+    void ForwardList<T>::splice_after(const const_iterator& pos, ForwardList<T>& other, const const_iterator& first,
+        const const_iterator& last)
     {
         transfer(pos, std::move(other), first, last);
     }
 
     template<typename T>
-    void ForwardList<T>::splice_after(const_iterator pos, ForwardList<T>&& other, const_iterator first, const_iterator last)
+    void ForwardList<T>::splice_after(const_iterator pos, ForwardList<T>&& other, const_iterator first,
+        const_iterator last)
     {
         transfer(pos, std::move(other), first, last);
     }
@@ -1864,8 +1866,8 @@ namespace dsa
      * @retval false if containers are not equal
      */
     template<typename T>
-    [[nodiscard]] auto operator==(const ForwardList<T>& lhs, const ForwardList<T>& rhs)
-        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> bool
+    [[nodiscard]] auto operator==(const ForwardList<T>& lhs, const ForwardList<T>& rhs) noexcept(
+        noexcept(*lhs.begin() == *rhs.begin())) -> bool
     {
         if (lhs.size() != rhs.size())
         {
@@ -1903,8 +1905,8 @@ namespace dsa
      * @return three way comparison result type
      */
     template<typename T>
-    [[nodiscard]] auto operator<=>(const ForwardList<T>& lhs, const ForwardList<T>& rhs)
-        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> std::compare_three_way_result_t<T>
+    [[nodiscard]] auto operator<=>(const ForwardList<T>& lhs, const ForwardList<T>& rhs) noexcept(
+        noexcept(*lhs.begin() == *rhs.begin())) -> std::compare_three_way_result_t<T>
     {
         auto lhs_iter = lhs.cbegin();
         auto rhs_iter = rhs.cbegin();
@@ -2091,8 +2093,8 @@ namespace dsa
     template<typename T>
     // transfers ownership of nodes, moving entire container is not necessary
     // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
-    void ForwardList<T>::transfer(const const_iterator& pos, ForwardList<T>&& other,
-        const const_iterator& first, const const_iterator& last)
+    void ForwardList<T>::transfer(const const_iterator& pos, ForwardList<T>&& other, const const_iterator& first,
+        const const_iterator& last)
     {
         if (&other != this && other.m_size > 0)
         {
@@ -2103,8 +2105,8 @@ namespace dsa
                 return;
             }
 
-            NodeBase* temp_prev{ pos.m_current_node };     // to append to
-            NodeBase* temp_next{ first.m_current_node };   // does not move
+            NodeBase* temp_prev{ pos.m_current_node };   // to append to
+            NodeBase* temp_next{ first.m_current_node }; // does not move
 
             NodeBase* first_to_move{ temp_next->m_next };
             NodeBase* last_to_move{ temp_next };
@@ -2196,6 +2198,6 @@ namespace dsa
 
         return result;
     }
-}
+} // namespace dsa
 
 #endif // !FORWARD_LIST_H

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -64,7 +64,7 @@ namespace dsa
              * @param[in] other NodeBase object
              * @return NodeBase& reference to NodeBase object
              */
-            auto operator=(const NodeBase& other) -> NodeBase & = default;
+            auto operator=(const NodeBase& other) -> NodeBase& = default;
 
             /**
              * @brief Construct NodeBase object using move constructor
@@ -81,7 +81,7 @@ namespace dsa
              * @param[in,out] other NodeBase object
              * @return NodeBase& reference to NodeBase object
              */
-            auto operator=(NodeBase&& other) -> NodeBase & = default;
+            auto operator=(NodeBase&& other) -> NodeBase& = default;
 
             /**
              * @brief Destroy the Node Base object
@@ -117,7 +117,8 @@ namespace dsa
              */
             Node(const T& value)
                 : m_value{ value }
-            {}
+            {
+            }
 
             /**
              * @brief Construct a new Node object with initial value using move semantics
@@ -127,7 +128,8 @@ namespace dsa
              */
             Node(T&& value)
                 : m_value{ std::move(value) }
-            {}
+            {
+            }
 
             /**
              * @brief Function returns value stored in Node object
@@ -235,7 +237,8 @@ namespace dsa
              */
             ListIterator(NodeBase* node) noexcept
                 : m_current_node{ node }
-            {}
+            {
+            }
 
             /**
              * @brief Overload operator= to assign \p node to currently pointed ListIterator
@@ -519,7 +522,8 @@ namespace dsa
          * @param[in,out] other List object of type T
          * @return List&
          */
-        auto operator=(List<T>&& other) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value)->List&;
+        auto operator=(List<T>&& other) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value)
+            -> List&;
 
         /**
          * @brief Assign elements from initializer list to List object
@@ -795,14 +799,14 @@ namespace dsa
         auto emplace(const_iterator pos, Args&&... args) -> iterator;
 
         /**
-        * @brief Function erases Node object at specified \p pos
-        *
-        * @param[in] pos iterator to element to erase
-        * @return iterator following erased element
-        * @retval iterator to element following \p pos
-        * @retval begin iterator if \p pos was first element prior to removal
-        * @retval end iterator if \p pos was last element prior to removal
-        */
+         * @brief Function erases Node object at specified \p pos
+         *
+         * @param[in] pos iterator to element to erase
+         * @return iterator following erased element
+         * @retval iterator to element following \p pos
+         * @retval begin iterator if \p pos was first element prior to removal
+         * @retval end iterator if \p pos was last element prior to removal
+         */
         auto erase(const_iterator pos) -> iterator;
 
         /**
@@ -941,8 +945,8 @@ namespace dsa
          * @param[in,out] other container to take elements from
          * @details Content of other object will be taken by constructed object
          */
-         // transfers ownership of nodes, moving entire container is not necessary
-         // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+        // transfers ownership of nodes, moving entire container is not necessary
+        // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
         void merge(List<T>&& other);
 
         /**
@@ -1195,8 +1199,8 @@ namespace dsa
          * @param[in] last const_iterator until which elements of \p other will be taken
          * @details Content of other object will be taken by constructed object
          */
-         // transfers ownership of nodes, moving entire container is not necessary
-         // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+        // transfers ownership of nodes, moving entire container is not necessary
+        // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
         void transfer(const_iterator pos, List<T>&& other, const_iterator first, const const_iterator& last);
 
         /**
@@ -1259,7 +1263,8 @@ namespace dsa
     template<typename T>
     List<T>::List(size_type count)
         : List(count, T{})
-    {}
+    {
+    }
 
     template<typename T>
     List<T>::List(size_type count, const T& value)
@@ -1314,7 +1319,7 @@ namespace dsa
 
     template<typename T>
     auto List<T>::operator=(List<T>&& other) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value)
-        ->List&
+        -> List&
     {
         if (&other != this)
         {
@@ -1546,8 +1551,8 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::insert(const const_iterator& pos, size_type count, const_reference value)
-        -> typename List<T>::iterator
+    auto List<T>::insert(const const_iterator& pos, size_type count, const_reference value) ->
+        typename List<T>::iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1619,7 +1624,6 @@ namespace dsa
         ++m_size;
         return iterator(newNode);
     }
-
 
     template<typename T>
     auto List<T>::erase(const_iterator pos) -> typename List<T>::iterator
@@ -1837,8 +1841,7 @@ namespace dsa
                 if (node_this && node_other)
                 {
                     // 2nd condition keeps correct order of equal elements
-                    if (comp(node_this->value(), node_other->value()) ||
-                        !comp(node_other->value(), node_this->value()))
+                    if (comp(node_this->value(), node_other->value()) || !comp(node_other->value(), node_this->value()))
                     {
                         to_move = m_head;
                         to_move->m_prev = temp_tail;
@@ -1919,8 +1922,8 @@ namespace dsa
     }
 
     template<typename T>
-    void List<T>::splice(const const_iterator& pos, List<T>& other,
-        const const_iterator& first, const const_iterator& last)
+    void List<T>::splice(const const_iterator& pos, List<T>& other, const const_iterator& first,
+        const const_iterator& last)
     {
         transfer(pos, std::move(other), first, last);
     }
@@ -2104,8 +2107,7 @@ namespace dsa
      * @retval false if containers are not equal
      */
     template<typename T>
-    auto operator==(const List<T>& lhs, const List<T>& rhs)
-        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> bool
+    auto operator==(const List<T>& lhs, const List<T>& rhs) noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> bool
     {
         if (lhs.size() != rhs.size())
         {
@@ -2143,8 +2145,8 @@ namespace dsa
      * @return three way comparison result type
      */
     template<typename T>
-    auto operator<=>(const List<T>& lhs, const List<T>& rhs)
-        noexcept(noexcept(*lhs.begin() == *rhs.begin()))->std::compare_three_way_result_t<T>
+    auto operator<=>(const List<T>& lhs, const List<T>& rhs) noexcept(noexcept(*lhs.begin() == *rhs.begin()))
+        -> std::compare_three_way_result_t<T>
     {
         auto lhs_iter = lhs.cbegin();
         auto rhs_iter = rhs.cbegin();
@@ -2442,6 +2444,6 @@ namespace dsa
 
         return result;
     }
-}
+} // namespace dsa
 
 #endif // !LIST_H

--- a/include/dsa/memory.h
+++ b/include/dsa/memory.h
@@ -40,12 +40,12 @@ namespace dsa
 
 #else // c++14 and newer
 
-    // use original implementation of std::make_unique when newer c++ version is used 
-    // and prevent clang-tidy warning 
+    // use original implementation of std::make_unique when newer c++ version is used
+    // and prevent clang-tidy warning
     // NOLINTNEXTLINE(misc-unused-using-decls)
     using std::make_unique;
 
 #endif
-}
+} // namespace dsa
 
 #endif // !MEMORY_H

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -28,7 +28,7 @@ namespace dsa
     auto operator==(const Queue<T>& lhs, const Queue<T>& rhs) -> bool;
 
     template<typename T>
-    auto operator<=>(const Queue<T>& lhs, const Queue<T>& rhs)->std::compare_three_way_result_t<T>;
+    auto operator<=>(const Queue<T>& lhs, const Queue<T>& rhs) -> std::compare_three_way_result_t<T>;
 
     /**
      * @brief Implements Queue class
@@ -218,12 +218,12 @@ namespace dsa
         /**
          * @brief Forward friend declaration to access internal container comparison operator
          */
-        friend auto operator==<T>(const Queue<T>& lhs, const Queue<T>& rhs) -> bool;
+        friend auto operator== <T>(const Queue<T>& lhs, const Queue<T>& rhs) -> bool;
 
         /**
          * @brief Forward friend declaration to access internal container comparison operator
          */
-        friend auto operator<=><T>(const Queue<T>& lhs, const Queue<T>& rhs)->std::compare_three_way_result_t<T>;
+        friend auto operator<=> <T>(const Queue<T>& lhs, const Queue<T>& rhs) -> std::compare_three_way_result_t<T>;
 
         Container container{};
     };
@@ -231,7 +231,8 @@ namespace dsa
     template<typename T>
     Queue<T>::Queue()
         : Queue(Container())
-    {}
+    {
+    }
 
     template<typename T>
     Queue<T>::Queue(const Container& cont)
@@ -245,7 +246,8 @@ namespace dsa
     template<typename T>
     Queue<T>::Queue(Container&& cont) noexcept
         : container{ std::move(cont) }
-    {}
+    {
+    }
 
     template<typename T>
     Queue<T>::Queue(const Queue<T>& other)
@@ -262,7 +264,8 @@ namespace dsa
     template<typename T>
     Queue<T>::Queue(Queue<T>&& other) noexcept
         : container{ std::move(other.container) }
-    {}
+    {
+    }
 
     template<typename T>
     auto Queue<T>::operator=(const Queue<T>& other) -> Queue<T>&
@@ -430,7 +433,7 @@ namespace dsa
     {
         lhs.swap(rhs);
     }
-}
+} // namespace dsa
 
 namespace dsa
 {
@@ -441,14 +444,11 @@ namespace dsa
      * @tparam Container type of underlying container used in class
      * @tparam Compare type of comparison used in class
      */
-    template<
-        typename T,
-        typename Container = dsa::Vector<T>,
-        typename Compare = std::less<typename Container::value_type>
-    > class PriorityQueue
+    template<typename T, typename Container = dsa::Vector<T>,
+        typename Compare = std::less<typename Container::value_type>>
+    class PriorityQueue
     {
     public:
-
 
         /**
          * @brief Alias for underlying container type used in class
@@ -653,8 +653,7 @@ namespace dsa
          * @param[in,out] other object to swap content with
          */
         void swap(PriorityQueue& other) noexcept(
-            std::is_nothrow_swappable_v<Container>&&
-            std::is_nothrow_swappable_v<Compare>);
+            std::is_nothrow_swappable_v<Container> && std::is_nothrow_swappable_v<Compare>);
 
     private:
 
@@ -666,12 +665,14 @@ namespace dsa
     template<typename T, typename Container, typename Compare>
     PriorityQueue<T, Container, Compare>::PriorityQueue()
         : PriorityQueue(Compare(), Container())
-    {}
+    {
+    }
 
     template<typename T, typename Container, typename Compare>
     PriorityQueue<T, Container, Compare>::PriorityQueue(const Compare& compare)
         : PriorityQueue(compare, Container())
-    {}
+    {
+    }
 
     template<typename T, typename Container, typename Compare>
     PriorityQueue<T, Container, Compare>::PriorityQueue(const Compare& compare, const Container& cont)
@@ -686,24 +687,27 @@ namespace dsa
 
     template<typename T, typename Container, typename Compare>
     PriorityQueue<T, Container, Compare>::PriorityQueue(const Compare& compare, Container&& cont) noexcept
-        : comp{ compare }, container{ std::move(cont) }
-    {}
+        : comp{ compare },
+          container{ std::move(cont) }
+    {
+    }
 
     template<typename T, typename Container, typename Compare>
     PriorityQueue<T, Container, Compare>::PriorityQueue(const PriorityQueue& other)
         : PriorityQueue(Compare(), other.container)
-    {}
+    {
+    }
 
     template<typename T, typename Container, typename Compare>
     PriorityQueue<T, Container, Compare>::PriorityQueue(PriorityQueue<T, Container, Compare>&& other) noexcept
         : PriorityQueue(Compare(), std::move(other.container))
-    {}
+    {
+    }
 
     template<typename T, typename Container, typename Compare>
     template<typename InputIt>
         requires std::input_iterator<InputIt>
-    PriorityQueue<T, Container, Compare>::PriorityQueue(
-        InputIt first, InputIt last, const Compare& compare)
+    PriorityQueue<T, Container, Compare>::PriorityQueue(InputIt first, InputIt last, const Compare& compare)
         : comp{ compare }
     {
         container.assign(first, last);
@@ -713,9 +717,10 @@ namespace dsa
     template<typename T, typename Container, typename Compare>
     template<typename InputIt>
         requires std::input_iterator<InputIt>
-    PriorityQueue<T, Container, Compare>::PriorityQueue(
-        InputIt first, InputIt last, const Compare& compare, const Container& cont)
-        : comp{ compare }, container{ std::move(cont) }
+    PriorityQueue<T, Container, Compare>::PriorityQueue(InputIt first, InputIt last, const Compare& compare,
+        const Container& cont)
+        : comp{ compare },
+          container{ std::move(cont) }
     {
         container.insert(container.end(), first, last);
         std::make_heap(container.begin(), container.end(), comp);
@@ -724,9 +729,10 @@ namespace dsa
     template<typename T, typename Container, typename Compare>
     template<typename InputIt>
         requires std::input_iterator<InputIt>
-    PriorityQueue<T, Container, Compare>::PriorityQueue(
-        InputIt first, InputIt last, const Compare& compare, Container&& cont)
-        : comp{ compare }, container{ std::move(cont) }
+    PriorityQueue<T, Container, Compare>::PriorityQueue(InputIt first, InputIt last, const Compare& compare,
+        Container&& cont)
+        : comp{ compare },
+          container{ std::move(cont) }
     {
         container.insert(container.end(), first, last);
         std::make_heap(container.begin(), container.end(), comp);
@@ -805,8 +811,7 @@ namespace dsa
 
     template<typename T, typename Container, typename Compare>
     void PriorityQueue<T, Container, Compare>::swap(PriorityQueue& other) noexcept(
-        std::is_nothrow_swappable_v<Container>&&
-        std::is_nothrow_swappable_v<Compare>)
+        std::is_nothrow_swappable_v<Container> && std::is_nothrow_swappable_v<Compare>)
     {
         std::swap(container, other.container);
         std::swap(comp, other.comp);
@@ -842,12 +847,11 @@ namespace dsa
      * @param[in] rhs container to swap content
      */
     template<typename T, typename Container, typename Compare>
-    void swap(PriorityQueue<T, Container, Compare>& lhs, PriorityQueue<T, Container, Compare>& rhs)
-        noexcept(noexcept(lhs.swap(rhs)))
+    void swap(PriorityQueue<T, Container, Compare>& lhs, PriorityQueue<T, Container, Compare>& rhs) noexcept(
+        noexcept(lhs.swap(rhs)))
     {
         lhs.swap(rhs);
     }
-}
-
+} // namespace dsa
 
 #endif // !QUEUE_H

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -28,7 +28,7 @@ namespace dsa
     auto operator==(const Stack<T>& lhs, const Stack<T>& rhs) -> bool;
 
     template<typename T>
-    auto operator<=>(const Stack<T>& lhs, const Stack<T>& rhs)->std::compare_three_way_result_t<T>;
+    auto operator<=>(const Stack<T>& lhs, const Stack<T>& rhs) -> std::compare_three_way_result_t<T>;
 
     /**
      * @brief Implements Stack class
@@ -203,12 +203,12 @@ namespace dsa
         /**
          * @brief Forward friend declaration to access internal container comparison operator
          */
-        friend auto operator==<T>(const Stack<T>& lhs, const Stack<T>& rhs) -> bool;
+        friend auto operator== <T>(const Stack<T>& lhs, const Stack<T>& rhs) -> bool;
 
         /**
          * @brief Forward friend declaration to access internal container comparison operator
          */
-        friend auto operator<=><T>(const Stack<T>& lhs, const Stack<T>& rhs)->std::compare_three_way_result_t<T>;
+        friend auto operator<=> <T>(const Stack<T>& lhs, const Stack<T>& rhs) -> std::compare_three_way_result_t<T>;
 
         Container container{};
     };
@@ -216,7 +216,8 @@ namespace dsa
     template<typename T>
     Stack<T>::Stack()
         : Stack(Container())
-    {}
+    {
+    }
 
     template<typename T>
     Stack<T>::Stack(const Container& cont)
@@ -230,7 +231,8 @@ namespace dsa
     template<typename T>
     Stack<T>::Stack(Container&& cont) noexcept
         : container{ std::move(cont) }
-    {}
+    {
+    }
 
     template<typename T>
     Stack<T>::Stack(const Stack<T>& other)
@@ -403,5 +405,5 @@ namespace dsa
     {
         lhs.swap(rhs);
     }
-}
+} // namespace dsa
 #endif // !STACK_H

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -188,7 +188,7 @@ namespace dsa
          */
         constexpr auto operator=(Vector<T>&& other) noexcept(
             std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value ||
-            std::allocator_traits<allocator_type>::is_always_equal::value)->Vector<T>&;
+            std::allocator_traits<allocator_type>::is_always_equal::value) -> Vector<T>&;
 
         /**
          * @brief Assign Vector object from \p init_list elements
@@ -258,7 +258,7 @@ namespace dsa
          * @param[in] pos index of element to return
          * @return reference to Vector element
          */
-        [[nodiscard]] constexpr auto operator[](size_type pos)->reference;
+        [[nodiscard]] constexpr auto operator[](size_type pos) -> reference;
 
         /**
          * @brief Returns a const_reference to Vector element at \p pos index.
@@ -267,7 +267,7 @@ namespace dsa
          * @param[in] pos index of element to return
          * @return const_reference to Vector element
          */
-        [[nodiscard]] constexpr auto operator[](size_type pos) const->const_reference;
+        [[nodiscard]] constexpr auto operator[](size_type pos) const -> const_reference;
 
         /**
          * @brief Returns reference to first Arary element
@@ -693,7 +693,8 @@ namespace dsa
     template<typename T>
     Vector<T>::Vector(size_type count)
         : Vector(count, T())
-    {}
+    {
+    }
 
     template<typename T>
     constexpr Vector<T>::Vector(size_type count, const T& value)
@@ -764,7 +765,7 @@ namespace dsa
     template<typename T>
     constexpr auto Vector<T>::operator=(Vector<T>&& other) noexcept(
         std::allocator_traits<allocator_type>::propagate_on_container_move_assignment::value ||
-        std::allocator_traits<allocator_type>::is_always_equal::value)-> Vector<T>&
+        std::allocator_traits<allocator_type>::is_always_equal::value) -> Vector<T>&
     {
         if (&other != this)
         {
@@ -1140,11 +1141,11 @@ namespace dsa
     constexpr auto Vector<T>::emplace_back(Args&&... args) -> reference
     {
         /*
-        * If an exception is thrown for any reason, this function has no effect
-        * strong exception guarantee by:
-        * - reallocate
-        * - if construction of new element fails, state of object does not change
-        */
+         * If an exception is thrown for any reason, this function has no effect
+         * strong exception guarantee by:
+         * - reallocate
+         * - if construction of new element fails, state of object does not change
+         */
 
         if (m_size >= m_capacity)
         {
@@ -1295,8 +1296,7 @@ namespace dsa
      * @retval false if containers are not equal
      */
     template<typename T>
-    auto operator==(const Vector<T>& lhs, const Vector<T>& rhs)
-        noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> bool
+    auto operator==(const Vector<T>& lhs, const Vector<T>& rhs) noexcept(noexcept(*lhs.begin() == *rhs.begin())) -> bool
     {
         if (lhs.size() != rhs.size())
         {
@@ -1334,8 +1334,8 @@ namespace dsa
      * @return three way comparison result type
      */
     template<typename T>
-    auto operator<=>(const Vector<T>& lhs, const Vector<T>& rhs)
-        noexcept(noexcept(*lhs.begin() == *rhs.begin()))->std::compare_three_way_result_t<T>
+    auto operator<=>(const Vector<T>& lhs, const Vector<T>& rhs) noexcept(noexcept(*lhs.begin() == *rhs.begin()))
+        -> std::compare_three_way_result_t<T>
     {
         auto lhs_iter = lhs.cbegin();
         auto rhs_iter = rhs.cbegin();
@@ -1477,10 +1477,10 @@ namespace dsa
     void Vector<T>::reallocate(size_type new_cap)
     {
         /*
-        * strong exception guarantee by:
-        * - throwing exception in case container is too large
-        * - using std::move_if_noexcept during reallocation
-        */
+         * strong exception guarantee by:
+         * - throwing exception in case container is too large
+         * - using std::move_if_noexcept during reallocation
+         */
 
         if (new_cap > max_size())
         {
@@ -1490,8 +1490,8 @@ namespace dsa
         pointer new_data = allocator_type().allocate(new_cap);
         for (size_t i = 0; i < m_size; i++)
         {
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            std::allocator_traits<allocator_type>::construct(m_allocator, new_data + i, std::move_if_noexcept(m_data[i]));
+            std::allocator_traits<allocator_type>::construct(m_allocator, new_data + i,
+                std::move_if_noexcept(m_data[i])); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         }
         clear_allocation();
         m_data = new_data;
@@ -1520,6 +1520,6 @@ namespace dsa
             m_capacity = 0;
         }
     }
-}
+} // namespace dsa
 
 #endif // !VECTOR_H

--- a/tests/array/array_binding_test.cpp
+++ b/tests/array/array_binding_test.cpp
@@ -80,7 +80,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Array8 b", array8_b, expected8[1]);
         tests::compare("Array8 c", array8_c, expected8[2]);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         // test get<I>()
@@ -114,7 +113,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Array8 a vs std", array8_a, std_a8);
         tests::compare("Array8 b vs std", array8_b, std_b8);
         tests::compare("Array8 c vs std", array8_c, std_c8);
-
 
         tests::print_stats();
     }

--- a/tests/array/array_operators_test.cpp
+++ b/tests/array/array_operators_test.cpp
@@ -93,8 +93,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Array4 <=> Array5 weak ordering", (Array1 <=> Array3) != std::weak_ordering::less, true);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<dsa::Array<int, 3>&>(),
-            std::declval<dsa::Array<int, 3>&>())));
+        static_assert(noexcept(swap(std::declval<dsa::Array<int, 3>&>(), std::declval<dsa::Array<int, 3>&>())));
         // swap throwing type
         static_assert(!noexcept(swap(std::declval<dsa::Array<tests::ThrowingType, 3>&>(),
             std::declval<dsa::Array<tests::ThrowingType, 3>&>())));
@@ -102,7 +101,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // operators
         static_assert(!noexcept(dsa::Array<tests::ThrowingType, 3>{} == dsa::Array<tests::ThrowingType, 3>{}));
         static_assert(!noexcept(dsa::Array<tests::ThrowingType, 3>{} <=> dsa::Array<tests::ThrowingType, 3>{}));
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -136,12 +134,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Array1 <=> Array2 vs std <=", (Array1 <=> Array2) <= 0, (std_Array1 <=> std_Array2) <= 0);
         tests::compare("Array1 <=> Array2 vs std >=", (Array1 <=> Array2) >= 0, (std_Array1 <=> std_Array2) >= 0);
 
-        tests::compare("Array1 <=> Array2 vs std <",
-            (Array1 <=> Array2) == std::weak_ordering::less, (std_Array1 <=> std_Array2) == std::weak_ordering::less);
-        tests::compare("Array1 <=> Array2 vs std <>",
-            (Array1 <=> Array2) != std::weak_ordering::equivalent, (std_Array1 <=> std_Array2) != std::weak_ordering::equivalent);
-        tests::compare("Array1 <=> Array2 vs std <=",
-            (Array1 <=> Array2) != std::weak_ordering::greater, (std_Array1 <=> std_Array2) != std::weak_ordering::greater);
+        tests::compare("Array1 <=> Array2 vs std <", (Array1 <=> Array2) == std::weak_ordering::less,
+            (std_Array1 <=> std_Array2) == std::weak_ordering::less);
+        tests::compare("Array1 <=> Array2 vs std <>", (Array1 <=> Array2) != std::weak_ordering::equivalent,
+            (std_Array1 <=> std_Array2) != std::weak_ordering::equivalent);
+        tests::compare("Array1 <=> Array2 vs std <=", (Array1 <=> Array2) != std::weak_ordering::greater,
+            (std_Array1 <=> std_Array2) != std::weak_ordering::greater);
 
         tests::compare("Array1 <=> Array3 vs std ==", (Array1 <=> Array3) == 0, (std_Array1 <=> std_Array3) == 0);
         tests::compare("Array1 <=> Array3 vs std <", (Array1 <=> Array3) < 0, (std_Array1 <=> std_Array3) < 0);
@@ -149,12 +147,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Array1 <=> Array3 vs std <=", (Array1 <=> Array3) <= 0, (std_Array1 <=> std_Array3) <= 0);
         tests::compare("Array1 <=> Array3 vs std >=", (Array1 <=> Array3) >= 0, (std_Array1 <=> std_Array3) >= 0);
 
-        tests::compare("Array1 <=> Array3 vs std >=",
-            (Array1 <=> Array3) != std::weak_ordering::less, (std_Array1 <=> std_Array3) != std::weak_ordering::less);
-        tests::compare("Array1 <=> Array3 vs std ==",
-            (Array1 <=> Array3) == std::weak_ordering::equivalent, (std_Array1 <=> std_Array3) == std::weak_ordering::equivalent);
-        tests::compare("Array1 <=> Array3 vs std <= ",
-            (Array1 <=> Array3) != std::weak_ordering::greater, (std_Array1 <=> std_Array3) != std::weak_ordering::greater);
+        tests::compare("Array1 <=> Array3 vs std >=", (Array1 <=> Array3) != std::weak_ordering::less,
+            (std_Array1 <=> std_Array3) != std::weak_ordering::less);
+        tests::compare("Array1 <=> Array3 vs std ==", (Array1 <=> Array3) == std::weak_ordering::equivalent,
+            (std_Array1 <=> std_Array3) == std::weak_ordering::equivalent);
+        tests::compare("Array1 <=> Array3 vs std <= ", (Array1 <=> Array3) != std::weak_ordering::greater,
+            (std_Array1 <=> std_Array3) != std::weak_ordering::greater);
 
         // test comparison categories
         static_assert(std::is_same_v<std::compare_three_way_result_t<std::array<int, 3>>, std::strong_ordering>,
@@ -172,7 +170,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
             (std_Array4 <=> std_Array5) == std::partial_ordering::unordered, true);
         tests::compare("(Array4 <=> Array5) == (std_Array4 <=> std_Array5)",
             (Array4 <=> Array5) == (std_Array4 <=> std_Array5), true);
-
 
         tests::print_stats();
     }

--- a/tests/array/array_ranges_test.cpp
+++ b/tests/array/array_ranges_test.cpp
@@ -76,7 +76,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         static_assert(std::ranges::view<array_t>);
         static_assert(!std::ranges::view<const_array_t>);
 
-
         // test constexpt access via iterators
         constexpr array_t array{ 1, 2, 3 };
         static_assert(*array.begin() == 1);
@@ -123,7 +122,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         static_assert(std::ranges::common_range<array_t>);
         static_assert(std::ranges::common_range<const_array_t>);
 
-        // test if iterators are indirectly readable 
+        // test if iterators are indirectly readable
         static_assert(std::indirectly_readable<array_t::iterator>);
         static_assert(std::indirectly_readable<array_t::const_iterator>);
 
@@ -182,8 +181,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Array3 sum", sum, 80);
         std::list<int> expected3;
         std::ranges::for_each(array3, [&](int item) { expected3.push_back(item); });
-        tests::compare("Array3 for_each() equal()",
-            std::ranges::equal(expected3, std::list{ 30, 10, 40 }), true);
+        tests::compare("Array3 for_each() equal()", std::ranges::equal(expected3, std::list{ 30, 10, 40 }), true);
 
         // test std::ranges::reverse_viev
         const dsa::Array<int, 3> array4{ 10, 20, 30 };
@@ -270,7 +268,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Array15", array15, expected15);
         tests::compare("Array16", array16, expected16);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::array<int, 3> std_array2{};
@@ -294,29 +291,28 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         std::array<int, 0> std_array10{};
         tests::compare("Array10 vs std empty()", array10.empty(), std_array10.empty());
-        tests::compare("Array10 vs std begin() == end()",
-            array10.begin() == array10.end(), std_array10.begin() == std_array10.end());
-        tests::compare("Array10 vs std distance == 0",
-            std::ranges::distance(array10) == 0, std::ranges::distance(array10) == 0);
+        tests::compare("Array10 vs std begin() == end()", array10.begin() == array10.end(),
+            std_array10.begin() == std_array10.end());
+        tests::compare("Array10 vs std distance == 0", std::ranges::distance(array10) == 0,
+            std::ranges::distance(array10) == 0);
 
         std::array<int, 3> std_array11{};
         std_array11.at(0) = 10;
         tests::compare("Array11 vs std empty()", array11.empty(), std_array11.empty());
         tests::compare("Array11 vs std front() == back()", array11.front(), std_array11.front());
         tests::compare("Array11 vs std front() == back()", array11.back(), std_array11.back());
-        tests::compare("Array11 vs std distance == 1",
-            std::ranges::distance(array11) == 1, std::ranges::distance(std_array11) == 1);
+        tests::compare("Array11 vs std distance == 1", std::ranges::distance(array11) == 1,
+            std::ranges::distance(std_array11) == 1);
 
         std::array<int, 5> std_array13{ 10, 20, 30, 40, 50 };
         std::ranges::fill(std_array13, 10);
         tests::compare("Array13", array13, std_array13);
 
         std::array<int, 3> std_array14{};
-        tests::compare("Array14 vs begin()",
-            std::ranges::begin(array14) == array14.begin(), std::ranges::begin(std_array14) == std_array14.begin());
-        tests::compare("Array14 vs end()",
-            std::ranges::end(array14) == array14.end(), std::ranges::end(std_array14) == std_array14.end());
-
+        tests::compare("Array14 vs begin()", std::ranges::begin(array14) == array14.begin(),
+            std::ranges::begin(std_array14) == std_array14.begin());
+        tests::compare("Array14 vs end()", std::ranges::end(array14) == array14.end(),
+            std::ranges::end(std_array14) == std_array14.end());
 
         tests::print_stats();
     }

--- a/tests/array/array_test.cpp
+++ b/tests/array/array_test.cpp
@@ -65,11 +65,11 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         // use lambda expression as workaround to prevent inlining call to const data()
         auto use_const_data = [](const auto& array)
-            {
-                const int* ptr = array.data();
-                (void)ptr;
-                return ptr;
-            };
+        {
+            const int* ptr = array.data();
+            (void)ptr;
+            return ptr;
+        };
         const dsa::Array<int, 3> const_array3{ 10, 20, 30 };
         const auto* ptr_cd3 = use_const_data(const_array3);
         static_assert(std::is_same_v<decltype(expected3.data()), const int*>, "data() must return const T*");
@@ -425,11 +425,11 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         // modyfing elements
         constexpr dsa::Array<int, 3> array20 = []
-            {
-                dsa::Array<int, 3> tmp = { 1, 2, 3 };
-                tmp[0] = 100;
-                return tmp;
-            }();
+        {
+            dsa::Array<int, 3> tmp = { 1, 2, 3 };
+            tmp[0] = 100;
+            return tmp;
+        }();
         static_assert(array20[0] == 100);
 
         // Test to_array
@@ -447,13 +447,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<std::string> expected22{ "A", "B", "C" };
         tests::compare("Array22", array22, expected22);
 
-        auto array23 = dsa::to_array<std::string>({ std::string{"A"}, std::string{"B"}, std::string{"C"} });
+        auto array23 = dsa::to_array<std::string>({ std::string{ "A" }, std::string{ "B" }, std::string{ "C" } });
         const std::initializer_list<std::string> expected23{ "A", "B", "C" };
         tests::compare("Array23", array23, expected23);
 
         // Intentional use of C-style arrays
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-        auto array24 = dsa::to_array<std::string>({ std::string{"A"}, std::string{"B"}, std::string{"C"} });
+        auto array24 = dsa::to_array<std::string>({ std::string{ "A" }, std::string{ "B" }, std::string{ "C" } });
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
         std::string array25[] = { "X", "Y", "Z" };
         array24 = dsa::to_array(std::move(array25));
@@ -461,7 +461,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<std::string> expected25{ "", "", "" };
         tests::compare("Array24", array24, expected24);
         tests::compare("Array25", dsa::to_array(array25), expected25);
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -587,18 +586,18 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         // Test empty array
         std::array<int, 0> std_array14{};
-        tests::compare("Array14 vs std begin() == cbegin()",
-            array14.begin() == array14.cbegin(), std_array14.begin() == std_array14.cbegin());
-        tests::compare("Array14 vs std begin() == end()",
-            array14.begin() == array14.end(), std_array14.begin() == std_array14.end());
-        tests::compare("Array14 vs std end() == cend()",
-            array14.end() == array14.cend(), std_array14.end() == std_array14.cend());
-        tests::compare("Array14 vs std rbegin() == crbegin()",
-            array14.rbegin() == array14.crbegin(), std_array14.rbegin() == std_array14.crbegin());
-        tests::compare("Array14 vs std rbegin() == rend()",
-            array14.rbegin() == array14.rend(), std_array14.rbegin() == std_array14.rend());
-        tests::compare("Array14 vs std rend() == crend()",
-            array14.rend() == array14.crend(), std_array14.rend() == std_array14.crend());
+        tests::compare("Array14 vs std begin() == cbegin()", array14.begin() == array14.cbegin(),
+            std_array14.begin() == std_array14.cbegin());
+        tests::compare("Array14 vs std begin() == end()", array14.begin() == array14.end(),
+            std_array14.begin() == std_array14.end());
+        tests::compare("Array14 vs std end() == cend()", array14.end() == array14.cend(),
+            std_array14.end() == std_array14.cend());
+        tests::compare("Array14 vs std rbegin() == crbegin()", array14.rbegin() == array14.crbegin(),
+            std_array14.rbegin() == std_array14.crbegin());
+        tests::compare("Array14 vs std rbegin() == rend()", array14.rbegin() == array14.rend(),
+            std_array14.rbegin() == std_array14.rend());
+        tests::compare("Array14 vs std rend() == crend()", array14.rend() == array14.crend(),
+            std_array14.rend() == std_array14.crend());
         tests::compare("Array14 vs std size()", array14.size(), std_array14.size());
         tests::compare("Array14 vs std max_size()", array14.max_size(), std_array14.max_size());
         tests::compare("Array14 vs std empty()", array14.empty(), std_array14.empty());
@@ -635,11 +634,11 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         // modyfing elements
         constexpr std::array<int, 3> std_array20 = []
-            {
-                std::array<int, 3> std_tmp = { 1, 2, 3 };
-                std_tmp[0] = 100;
-                return std_tmp;
-            }();
+        {
+            std::array<int, 3> std_tmp = { 1, 2, 3 };
+            std_tmp[0] = 100;
+            return std_tmp;
+        }();
         static_assert(std_array20[0] == 100);
 
         // Test to_array
@@ -649,9 +648,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto std_array22 = std::to_array(temp22);
         tests::compare("Array22 vs std", array22, std_array22);
 
-        auto std_array23 = std::to_array<std::string>({ std::string{"A"}, std::string{"B"}, std::string{"C"} });
+        auto std_array23 = std::to_array<std::string>({ std::string{ "A" }, std::string{ "B" }, std::string{ "C" } });
         tests::compare("Array23 vs std", array23, std_array23);
-
 
         tests::print_stats();
     }

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -33,12 +33,11 @@ namespace tests
         std::cerr << '\n';
     }
 
-    auto handle_exception(const std::optional<std::exception_ptr>& exception,
-        const std::source_location& location) -> int
+    auto handle_exception(const std::optional<std::exception_ptr>& exception, const std::source_location& location)
+        -> int
     {
-        std::cerr << '[' << location.file_name()
-            << '(' << location.line() << ':' << location.column() << ")] "
-            << '\'' << location.function_name() << '\'';
+        std::cerr << '[' << location.file_name() << '(' << location.line() << ':' << location.column() << ")] " << '\''
+                  << location.function_name() << '\'';
 
         if (exception.has_value())
         {
@@ -79,4 +78,4 @@ namespace tests
         }
     }
 
-}
+} // namespace tests

--- a/tests/common.h
+++ b/tests/common.h
@@ -38,9 +38,9 @@
 #include <string>
 #include <vector>
 
- /**
-  * @brief Namespace with test results
-  */
+/**
+ * @brief Namespace with test results
+ */
 namespace tests
 {
     constexpr size_t throwing_type_size_limit = 5;
@@ -75,8 +75,8 @@ namespace tests
          *
          * @param[in] other unused parameter
          */
-         // move constructors intentionally throw exception
-         // NOLINTNEXTLINE(cppcoreguidelines-noexcept-move-operations,performance-noexcept-move-constructor,bugprone-exception-escape)
+        // move constructors intentionally throw exception
+        // NOLINTNEXTLINE(cppcoreguidelines-noexcept-move-operations,performance-noexcept-move-constructor,bugprone-exception-escape)
         ThrowingType(ThrowingType&& /*other*/)
         {
             conditional_exception("ThrowingType size limit reached in move ctor");
@@ -96,7 +96,9 @@ namespace tests
         auto operator=(const ThrowingType& other) noexcept(false) -> ThrowingType&
         {
             // empty if statement silences clang-tidy warning for copy assignment operator in mock struct
-            if (this != &other) {}
+            if (this != &other)
+            {
+            }
             return *this;
         }
 
@@ -168,13 +170,13 @@ namespace tests
      */
     enum class ExceptionCode : std::int8_t
     {
-        BadAlloc = -1,          ///< Memory allocation error
-        OutOfRange = -2,        ///< Accesing wrong range
-        RuntimeError = -3,      ///< Exception generated during program execution
-        LengthError = -4,       ///< Maximum allowed size exceeded
-        Exception = -5,         ///< General exception, exception reason should be moved into separate catch block
-        Unknown = -6,           ///< Unhandled exception from (...) block
-        Nullopt = -7            ///< Optional exception is invalid
+        BadAlloc = -1,     ///< Memory allocation error
+        OutOfRange = -2,   ///< Accesing wrong range
+        RuntimeError = -3, ///< Exception generated during program execution
+        LengthError = -4,  ///< Maximum allowed size exceeded
+        Exception = -5,    ///< General exception, exception reason should be moved into separate catch block
+        Unknown = -6,      ///< Unhandled exception from (...) block
+        Nullopt = -7       ///< Optional exception is invalid
     };
 
     /**
@@ -183,8 +185,8 @@ namespace tests
      */
     enum class Status : std::int8_t
     {
-        OK = 0,                 ///< Function executed sucessfully
-        Error = -1              ///< Function returned error
+        OK = 0,    ///< Function executed sucessfully
+        Error = -1 ///< Function returned error
     };
 
     /**
@@ -224,11 +226,8 @@ namespace tests
      *
      * @see requires
      */
-    template <typename T>
-    concept has_front = requires(T type)
-    {
-        type.front();
-    };
+    template<typename T>
+    concept has_front = requires(T type) { type.front(); };
 
     /**
      * @brief Concept that checks if an object of type T allows calling public `pop()` method
@@ -237,11 +236,8 @@ namespace tests
      *
      * @see requires
      */
-    template <typename T>
-    concept has_pop = requires(T type)
-    {
-        type.pop();
-    };
+    template<typename T>
+    concept has_pop = requires(T type) { type.pop(); };
 
     /**
      * @brief Concept that checks if an object of type T allows calling public `pop_front()` method
@@ -250,11 +246,8 @@ namespace tests
      *
      * @see requires
      */
-    template <typename T>
-    concept has_pop_front = requires(T type)
-    {
-        type.pop_front();
-    };
+    template<typename T>
+    concept has_pop_front = requires(T type) { type.pop_front(); };
 
     /**
      * @brief Concept that checks if an object provide printable range for not-string-like types
@@ -263,11 +256,10 @@ namespace tests
      *
      * @see requires
      */
-    template <typename T>
-    concept has_printable_range = std::ranges::range<T> &&
-        !std::same_as<std::remove_cvref_t<T>, std::string> &&
-        !std::same_as<std::remove_cvref_t<T>, std::string_view> &&
-        !std::is_convertible_v<T, const char*>;
+    template<typename T>
+    concept has_printable_range =
+        std::ranges::range<T> && !std::same_as<std::remove_cvref_t<T>, std::string> &&
+        !std::same_as<std::remove_cvref_t<T>, std::string_view> && !std::is_convertible_v<T, const char*>;
 
     /**
      * @brief Concept that defines the requirements of a type that allows iteration over elements
@@ -277,7 +269,7 @@ namespace tests
      *
      * @tparam T type checked agains the concept
      */
-    template <typename T>
+    template<typename T>
     concept has_ranges = std::ranges::range<T>;
 
     /**
@@ -287,11 +279,8 @@ namespace tests
      *
      * @see requires
      */
-    template <typename T>
-    concept has_size = requires(T type)
-    {
-        type.size();
-    };
+    template<typename T>
+    concept has_size = requires(T type) { type.size(); };
 
     /**
      * @brief Concept that checks if an object of type T allows calling public `top()` method
@@ -300,11 +289,8 @@ namespace tests
      *
      * @see requires
      */
-    template <typename T>
-    concept has_top = requires(T type)
-    {
-        type.top();
-    };
+    template<typename T>
+    concept has_top = requires(T type) { type.top(); };
 
     /**
      * @brief Function print error message
@@ -716,8 +702,7 @@ namespace tests
      */
     inline auto print_stats() -> void
     {
-        std::cout << total_count() - failed_count() << "/" << total_count() << " PASS, "
-            << failed_count() << " FAIL\n";
+        std::cout << total_count() - failed_count() << "/" << total_count() << " PASS, " << failed_count() << " FAIL\n";
     }
 
     /**
@@ -731,8 +716,8 @@ namespace tests
      * @param[in] container_2 second input container
      */
     template<typename T, typename U>
-    auto print_containers(const std::string& name_1, const T& container_1,
-        const std::string& name_2, const U& container_2) -> void
+    auto print_containers(const std::string& name_1, const T& container_1, const std::string& name_2,
+        const U& container_2) -> void
     {
         const int size{ static_cast<int>(std::max(name_1.length(), name_2.length())) };
         std::cout << std::setw(size) << std::left << name_1 << ": " << container_1 << '\n';
@@ -817,6 +802,6 @@ namespace tests
     {
         return cmp(val1, val2);
     }
-}
+} // namespace tests
 
 #endif // !COMMON_H

--- a/tests/forward_list/forward_list_ctors_test.cpp
+++ b/tests/forward_list/forward_list_ctors_test.cpp
@@ -94,7 +94,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected11{ 10, 20, 30 };
         tests::compare("ForwardList11", list11, expected11);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::forward_list<int> std_list1;
@@ -143,7 +142,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::forward_list<int> std_temp11 = { 0, 10, 20, 30, 40, 50 };
         const std::forward_list<int> std_list11(std::next(std_temp11.begin(), 1), std::next(std_temp11.begin(), 4));
         tests::compare("ForwardList11 vs std", list11, std_list11);
-
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_get_test.cpp
+++ b/tests/forward_list/forward_list_get_test.cpp
@@ -40,7 +40,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const dsa::ForwardList<int> list2 = dsa::ForwardList<int>({ 20, 10, 0 });
         tests::compare("ForwardList2 front", list2.front(), 20);
 
-
         tests::print_stats();
     }
     catch (...)

--- a/tests/forward_list/forward_list_grow_test.cpp
+++ b/tests/forward_list/forward_list_grow_test.cpp
@@ -109,8 +109,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::ForwardList<int> list10{};
         const dsa::ForwardList<int> temp10{ 0, 10, 20, 30, 40, 50 };
         auto temp10_it = std::next(temp10.begin(), 3);
-        auto list10_it = list10.insert_after(
-            list10.before_begin(), std::next(temp10.begin(), 1), std::next(temp10.begin(), 4));
+        auto list10_it =
+            list10.insert_after(list10.before_begin(), std::next(temp10.begin(), 1), std::next(temp10.begin(), 4));
         const std::initializer_list<int> expected10{ 10, 20, 30 };
         tests::compare("ForwardList10", list10, expected10);
         tests::compare("ForwardList10 it", *list10_it, *temp10_it);
@@ -274,7 +274,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList26", list26, expected26);
         tests::compare("ForwardList26 it", list26_it == list26.begin(), true);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::forward_list<int> std_list5;
@@ -303,8 +302,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::forward_list<int> std_list10{};
         const std::forward_list<int> std_temp10{ 0, 10, 20, 30, 40, 50 };
         auto std_temp10_it = std::next(std_temp10.begin(), 3);
-        auto std_list10_it = std_list10.insert_after(
-            std_list10.before_begin(), std::next(std_temp10.begin(), 1), std::next(std_temp10.begin(), 4));
+        auto std_list10_it = std_list10.insert_after(std_list10.before_begin(), std::next(std_temp10.begin(), 1),
+            std::next(std_temp10.begin(), 4));
         tests::compare("ForwardList10 vs std", list10, std_list10);
         tests::compare("ForwardList10 it vs std", *list10_it, *std_list10_it);
         tests::compare("ForwardList10 temp it vs std", *temp10_it, *std_temp10_it);
@@ -312,8 +311,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::forward_list<int> std_list11{ 0, 10, 20 };
         const std::forward_list<int> std_temp11{ 30, 40, 50 };
         auto std_temp11_it = std::next(std_temp11.begin(), 2);
-        auto std_list11_it = std_list11.insert_after(
-            std::next(std_list11.begin(), 2), std_temp11.begin(), std_temp11.end());
+        auto std_list11_it =
+            std_list11.insert_after(std::next(std_list11.begin(), 2), std_temp11.begin(), std_temp11.end());
         tests::compare("ForwardList11 vs std", list11, std_list11);
         tests::compare("ForwardList11 it vs std", *list11_it, *std_list11_it);
         tests::compare("ForwardList11 temp it vs std", *temp11_it, *std_temp11_it);
@@ -323,7 +322,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_list16.push_front(std::move(std_ptr16));
         tests::compare("ForwardList17 vs std", *list16.front(), expected16);
         tests::compare("ptr16 == nullptr vs std", ptr16 == nullptr, std_ptr16 == nullptr);
-
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_itors_test.cpp
+++ b/tests/forward_list/forward_list_itors_test.cpp
@@ -348,7 +348,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::advance(iter18, 1);
         tests::compare("iter18 == nullptr", iter18 == nullptr, true);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::forward_list<int> std_list1{ 0, 10, 20 };
@@ -370,7 +369,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         const std::forward_list<int> std_list3{ 0, 10, 20 };
         // NOLINTNEXTLINE(modernize-loop-convert, modernize-use-auto)
-        for (std::forward_list<int>::const_iterator std_iter = std_list3.cbegin(); std_iter != std_list3.cend(); std_iter++)
+        for (std::forward_list<int>::const_iterator std_iter = std_list3.cbegin(); std_iter != std_list3.cend();
+            std_iter++)
         {
             std::cout << (*std_iter) << '\t';
         }
@@ -391,7 +391,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList5 iterator vs std", expectedval5, val);
         tests::compare("ForwardList5 vs std", list5, expected5);
 
-        std::forward_list<int>std_list6 = std::forward_list<int>(1, 50);
+        std::forward_list<int> std_list6 = std::forward_list<int>(1, 50);
         std_list6.push_front(40);
         std_list6.push_front(30);
         iterator = std_list6.insert_after(std_list6.cbegin(), 0, 5);
@@ -399,25 +399,24 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList6 iterator vs std", expectedval6, val);
         tests::compare("ForwardList6 vs std", list6, std_list6);
 
-        std::forward_list<int>std_list9 = std::forward_list<int>{ 10, 20, 30, 40, 50 };
+        std::forward_list<int> std_list9 = std::forward_list<int>{ 10, 20, 30, 40, 50 };
         // use classic iterator based algorithms, separate test was added to test std::ranges based algorithms
         // NOLINTNEXTLINE(modernize-use-ranges)
         std::fill(std_list9.begin(), std_list9.end(), 10);
         tests::compare("ForwardList9 vs std", list9, std_list9);
 
-        std::forward_list<int>std_list10 = std::forward_list<int>{ 10, 20, 30 };
+        std::forward_list<int> std_list10 = std::forward_list<int>{ 10, 20, 30 };
         auto std_iter10b = std_list10.begin();
         *std_iter10b = 1;
         auto std_citer10b = std_list10.cbegin();
         tests::compare("citer10b vs std", *citer10b, *std_citer10b);
 
-        const std::forward_list<int>std_list11 = std::forward_list<int>{ 10, 20, 30 };
+        const std::forward_list<int> std_list11 = std::forward_list<int>{ 10, 20, 30 };
         auto std_iter11b = std_list11.begin();
         tests::compare("iter11b vs std", *iter11b, *std_iter11b);
 
         auto std_citer11b = std_list11.cbegin();
         tests::compare("citer11b vs std", *citer11b, *std_citer11b);
-
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_merge_test.cpp
+++ b/tests/forward_list/forward_list_merge_test.cpp
@@ -45,7 +45,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::ForwardList<int> list3 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list4;
         list4.merge(list3);
-        const std::initializer_list<int> expected3 = { };
+        const std::initializer_list<int> expected3 = {};
         tests::compare("ForwardList3", list3, expected3);
         const std::initializer_list<int> expected4 = il_1;
         tests::compare("ForwardList4", list4, expected4);
@@ -276,7 +276,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList45 it 47_2", std::next(list45.begin(), 2) == addr45_2, true);
         tests::compare("ForwardList45 it 48_2", std::next(list45.begin(), 3) == addr46_2, true);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::forward_list<int> std_list1{ il_1 };
@@ -461,7 +460,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList45 it 45_1 vs std", std::next(std_list45.begin(), 1) == std_addr45_1, true);
         tests::compare("ForwardList45 it 45_2 vs std", std::next(std_list45.begin(), 2) == std_addr45_2, true);
         tests::compare("ForwardList45 it 46_2 vs std", std::next(std_list45.begin(), 3) == std_addr46_2, true);
-
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_operators_test.cpp
+++ b/tests/forward_list/forward_list_operators_test.cpp
@@ -123,9 +123,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // test noexcept
 
         // operators
-        static_assert(!noexcept(dsa::ForwardList<tests::ThrowingType>{1} == dsa::ForwardList<tests::ThrowingType>{1}));
-        static_assert(!noexcept(dsa::ForwardList<tests::ThrowingType>{1} <=> dsa::ForwardList<tests::ThrowingType>{1}));
-
+        static_assert(
+            !noexcept(dsa::ForwardList<tests::ThrowingType>{ 1 } == dsa::ForwardList<tests::ThrowingType>{ 1 }));
+        static_assert(
+            !noexcept(dsa::ForwardList<tests::ThrowingType>{ 1 } <=> dsa::ForwardList<tests::ThrowingType>{ 1 }));
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -159,12 +160,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("list1 <=> list2 vs std <=", (list1 <=> list2) <= 0, (std_list1 <=> std_list2) <= 0);
         tests::compare("list1 <=> list2 vs std >=", (list1 <=> list2) >= 0, (std_list1 <=> std_list2) >= 0);
 
-        tests::compare("list1 <=> list2 vs std <",
-            (list1 <=> list2) == std::weak_ordering::less, (std_list1 <=> std_list2) == std::weak_ordering::less);
-        tests::compare("list1 <=> list2 vs std <>",
-            (list1 <=> list2) != std::weak_ordering::equivalent, (std_list1 <=> std_list2) != std::weak_ordering::equivalent);
-        tests::compare("list1 <=> list2 vs std <=",
-            (list1 <=> list2) != std::weak_ordering::greater, (std_list1 <=> std_list2) != std::weak_ordering::greater);
+        tests::compare("list1 <=> list2 vs std <", (list1 <=> list2) == std::weak_ordering::less,
+            (std_list1 <=> std_list2) == std::weak_ordering::less);
+        tests::compare("list1 <=> list2 vs std <>", (list1 <=> list2) != std::weak_ordering::equivalent,
+            (std_list1 <=> std_list2) != std::weak_ordering::equivalent);
+        tests::compare("list1 <=> list2 vs std <=", (list1 <=> list2) != std::weak_ordering::greater,
+            (std_list1 <=> std_list2) != std::weak_ordering::greater);
 
         std::cout << "Compare operators for objects of different size\n\n";
 
@@ -200,12 +201,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("list1 <=> list3 vs std <=", (list1 <=> list3) <= 0, (std_list1 <=> std_list3) <= 0);
         tests::compare("list1 <=> list3 vs std >=", (list1 <=> list3) >= 0, (std_list1 <=> std_list3) >= 0);
 
-        tests::compare("list1 <=> list3 vs std >=",
-            (list1 <=> list3) != std::weak_ordering::less, (std_list1 <=> std_list3) != std::weak_ordering::less);
-        tests::compare("list1 <=> list3 vs std ==",
-            (list1 <=> list3) == std::weak_ordering::equivalent, (std_list1 <=> std_list3) == std::weak_ordering::equivalent);
-        tests::compare("list1 <=> list3 vs std <= ",
-            (list1 <=> list3) != std::weak_ordering::greater, (std_list1 <=> std_list3) != std::weak_ordering::greater);
+        tests::compare("list1 <=> list3 vs std >=", (list1 <=> list3) != std::weak_ordering::less,
+            (std_list1 <=> std_list3) != std::weak_ordering::less);
+        tests::compare("list1 <=> list3 vs std ==", (list1 <=> list3) == std::weak_ordering::equivalent,
+            (std_list1 <=> std_list3) == std::weak_ordering::equivalent);
+        tests::compare("list1 <=> list3 vs std <= ", (list1 <=> list3) != std::weak_ordering::greater,
+            (std_list1 <=> std_list3) != std::weak_ordering::greater);
 
         // test comparison categories
         static_assert(std::is_same_v<std::compare_three_way_result_t<std::forward_list<int>>, std::strong_ordering>,
@@ -221,15 +222,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         assert((list7 <=> list8) == (std_list7 <=> std_list8));
         tests::compare("std_list7 <=> std_list8 weak ordering",
             (std_list7 <=> std_list8) == std::partial_ordering::unordered, true);
-        tests::compare("(list7 <=> list8) == (std_list7 <=> std_list8)",
-            (list7 <=> list8) == (std_list7 <=> std_list8), true);
+        tests::compare("(list7 <=> list8) == (std_list7 <=> std_list8)", (list7 <=> list8) == (std_list7 <=> std_list8),
+            true);
 
         // test noexcept
 
         // operators
-        static_assert(!noexcept(std::forward_list<tests::ThrowingType>{1} == std::forward_list<tests::ThrowingType>{1}));
-        static_assert(!noexcept(std::forward_list<tests::ThrowingType>{1} <=> std::forward_list<tests::ThrowingType>{1}));
-
+        static_assert(
+            !noexcept(std::forward_list<tests::ThrowingType>{ 1 } == std::forward_list<tests::ThrowingType>{ 1 }));
+        static_assert(
+            !noexcept(std::forward_list<tests::ThrowingType>{ 1 } <=> std::forward_list<tests::ThrowingType>{ 1 }));
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_ranges_test.cpp
+++ b/tests/forward_list/forward_list_ranges_test.cpp
@@ -62,14 +62,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         static_assert(std::ranges::common_range<dsa::ForwardList<int>>);
         static_assert(std::ranges::common_range<const dsa::ForwardList<int>>);
 
-        // test if iterators are indirectly readable 
+        // test if iterators are indirectly readable
         static_assert(std::indirectly_readable<dsa::ForwardList<int>::iterator>);
         static_assert(std::indirectly_readable<dsa::ForwardList<int>::const_iterator>);
 
         // test if sentinel and iterators are comparable
         static_assert(std::sentinel_for<dsa::ForwardList<int>::iterator, dsa::ForwardList<int>::iterator>);
         static_assert(std::sentinel_for<dsa::ForwardList<int>::const_iterator, dsa::ForwardList<int>::const_iterator>);
-
 
         // test iterator traversal and dereference correctness
         dsa::ForwardList<int> list1{ 10, 20, 30 };
@@ -107,7 +106,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const int sum = std::accumulate(list4.begin(), list4.end(), 0);
         tests::compare("ForwardList4 sum", sum, 80);
         std::list<int> expected4;
-        std::ranges::for_each(list4, [&](int item) {expected4.push_back(item); });
+        std::ranges::for_each(list4, [&](int item) { expected4.push_back(item); });
         tests::compare("ForwardList4 for_each() equal()", std::ranges::equal(expected4, std::list{ 30, 10, 40 }), true);
 
         // test copy constructor and assignment, create deep copies
@@ -177,7 +176,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList15", list15, expected15);
         tests::compare("ForwardList16", list16, expected16);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::forward_list<int> std_list2;
@@ -201,17 +199,17 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         std::forward_list<int> std_list11;
         tests::compare("ForwardList11 vs std empty()", list11.empty(), std_list11.empty());
-        tests::compare("ForwardList11 vs std begin() == end()",
-            list11.begin() == list11.end(), std_list11.begin() == std_list11.end());
-        tests::compare("ForwardList11 vs std distance",
-            std::ranges::distance(list11), std::ranges::distance(std_list11));
+        tests::compare("ForwardList11 vs std begin() == end()", list11.begin() == list11.end(),
+            std_list11.begin() == std_list11.end());
+        tests::compare("ForwardList11 vs std distance", std::ranges::distance(list11),
+            std::ranges::distance(std_list11));
 
         std::forward_list<int> std_list12;
         std_list12.push_front(10);
         tests::compare("ForwardList12 vs std empty()", list12.empty(), std_list12.empty());
         tests::compare("ForwardList12 vs std begin() == end()", *list12.begin(), *std_list12.begin());
-        tests::compare("ForwardList12 vs std distance",
-            std::ranges::distance(list12), std::ranges::distance(std_list12));
+        tests::compare("ForwardList12 vs std distance", std::ranges::distance(list12),
+            std::ranges::distance(std_list12));
 
         std::forward_list<int> std_list13{ 10, 20, 30, 40, 50 };
         std::ranges::fill(std_list13, 10);
@@ -219,11 +217,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         // test std::ranges::begin and ::end
         dsa::ForwardList<int> std_list14;
-        tests::compare("ForwardList14 vs begin()",
-            std::ranges::begin(list14) == list14.begin(), std::ranges::begin(std_list14) == std_list14.begin());
-        tests::compare("ForwardList14 vs end()",
-            std::ranges::end(list14) == list14.end(), std::ranges::end(std_list14) == std_list14.end());
-
+        tests::compare("ForwardList14 vs begin()", std::ranges::begin(list14) == list14.begin(),
+            std::ranges::begin(std_list14) == std_list14.begin());
+        tests::compare("ForwardList14 vs end()", std::ranges::end(list14) == list14.end(),
+            std::ranges::end(std_list14) == std_list14.end());
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_resize_test.cpp
+++ b/tests/forward_list/forward_list_resize_test.cpp
@@ -70,7 +70,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const dsa::ForwardList<int> list9;
         tests::compare("max_size()", list9.max_size(), UINTMAX_MAX);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::forward_list<int> std_list1{ 1, 2, 3, 4, 5 };
@@ -104,7 +103,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::forward_list<int> std_list8;
         std_list8.resize(5, 10);
         tests::compare("ForwardList8 vs std", list8, std_list8);
-
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_reverse_test.cpp
+++ b/tests/forward_list/forward_list_reverse_test.cpp
@@ -41,7 +41,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected3{};
         tests::compare("ForwardList3", list3, expected3);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::forward_list<int> std_list1{ 0, 10, 20, 30, 40, 50 };
@@ -55,7 +54,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::forward_list<int> std_list3;
         std_list3.reverse();
         tests::compare("ForwardList3 vs std", list3, std_list3);
-
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_set_test.cpp
+++ b/tests/forward_list/forward_list_set_test.cpp
@@ -64,7 +64,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list7.assign(expected7);
         tests::compare("ForwardList7", list7, expected7);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::forward_list<int> std_list1{ 0, 10, 20 };
@@ -94,7 +93,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::forward_list<int> std_list7{ 0, 10, 20 };
         std_list7.assign(expected7);
         tests::compare("ForwardList7 vs std", list7, std_list7);
-
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_shrink_test.cpp
+++ b/tests/forward_list/forward_list_shrink_test.cpp
@@ -64,7 +64,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list6 = dsa::ForwardList<int>({ 0, 0, 0, 0, 0, 0 });
         auto cnt6 = list6.remove(0);
-        const std::initializer_list<int> expected6 = { };
+        const std::initializer_list<int> expected6 = {};
         tests::compare("ForwardList6", list6, expected6);
         tests::compare("ForwardList6 removed count", cnt6, std::size_t{ 6 });
 
@@ -76,7 +76,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list8 = dsa::ForwardList<int>({ 0, 0, 0, 0, 0, 0 });
         auto cnt8 = list8.remove_if([](int val) { return val == 0; });
-        const std::initializer_list<int> expected8 = { };
+        const std::initializer_list<int> expected8 = {};
         tests::compare("ForwardList8", list8, expected8);
         tests::compare("ForwardList8 removed count", cnt8, std::size_t{ 6 });
 
@@ -96,7 +96,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare(list11.empty(), false);
         list11.clear();
         tests::compare(list11.empty(), true);
-        const std::initializer_list<int> expected11 = { };
+        const std::initializer_list<int> expected11 = {};
         tests::compare("ForwardList11", list11, expected11);
 
         dsa::ForwardList<int> list12 = dsa::ForwardList<int>({ 10, 20, 30 });
@@ -104,7 +104,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list12.pop_front();
         list12.pop_front();
         list12.pop_front();
-        const std::initializer_list<int> expected12 = { };
+        const std::initializer_list<int> expected12 = {};
         tests::compare("ForwardList12", list12, expected12);
 
         dsa::ForwardList<int> list13;
@@ -119,7 +119,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list15 = dsa::ForwardList<int>({ 0, 0, 0, 0, 0, 0 });
         auto cnt15 = dsa::erase(list15, 0);
-        const std::initializer_list<int> expected15 = { };
+        const std::initializer_list<int> expected15 = {};
         tests::compare("ForwardList15", list15, expected15);
         tests::compare("ForwardList15 erase count", cnt15, std::size_t{ 6 });
 
@@ -131,7 +131,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list17 = dsa::ForwardList<int>({ 0, 0, 0, 0, 0, 0 });
         auto cnt17 = dsa::erase_if(list17, [](int val) { return val == 0; });
-        const std::initializer_list<int> expected17 = { };
+        const std::initializer_list<int> expected17 = {};
         tests::compare("ForwardList17", list17, expected17);
         tests::compare("ForwardList17 erase_if count", cnt17, std::size_t{ 6 });
 
@@ -191,7 +191,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list20h = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
         auto cnt20h = dsa::erase_if(list20h, [](int val) { return val > (-5); });
-        const std::initializer_list<int> expected20h = { };
+        const std::initializer_list<int> expected20h = {};
         tests::compare("ForwardList20h", list20h, expected20h);
         tests::compare("ForwardList20h erase_if count", cnt20h, std::size_t{ 6 });
 
@@ -203,13 +203,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list20j = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
         auto cnt20j = dsa::erase_if(list20j, [](int val) { return val >= (-5); });
-        const std::initializer_list<int> expected20j = { };
+        const std::initializer_list<int> expected20j = {};
         tests::compare("ForwardList20j", list20j, expected20j);
         tests::compare("ForwardList20j erase_if count", cnt20j, std::size_t{ 6 });
 
         dsa::ForwardList<int> list20k = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
         auto cnt20k = dsa::erase_if(list20k, [](int val) { return val < 100; });
-        const std::initializer_list<int> expected20k = { };
+        const std::initializer_list<int> expected20k = {};
         tests::compare("ForwardList20k", list20k, expected20k);
         tests::compare("ForwardList20k erase_if count", cnt20k, std::size_t{ 6 });
 
@@ -221,7 +221,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list20m = dsa::ForwardList<int>({ 0, 10, 2, 5, 7, 9 });
         auto cnt20m = dsa::erase_if(list20m, [](int val) { return val <= 100; });
-        const std::initializer_list<int> expected20m = { };
+        const std::initializer_list<int> expected20m = {};
         tests::compare("ForwardList20m", list20m, expected20m);
         tests::compare("ForwardList20m erase_if count", cnt20m, std::size_t{ 6 });
 
@@ -233,37 +233,37 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list21a{};
         auto cnt21a = list21a.remove_if([](int val) { return val == 0; });
-        const std::initializer_list<int> expected21a = { };
+        const std::initializer_list<int> expected21a = {};
         tests::compare("ForwardList21a", list21a, expected21a);
         tests::compare("ForwardList21a removed count", cnt21a, std::size_t{ 0 });
 
         dsa::ForwardList<int> list21b{};
         auto cnt21b = list21b.remove_if([](int val) { return val != 0; });
-        const std::initializer_list<int> expected21b = { };
+        const std::initializer_list<int> expected21b = {};
         tests::compare("ForwardList21b", list21b, expected21b);
         tests::compare("ForwardList21b removed count", cnt21b, std::size_t{ 0 });
 
         dsa::ForwardList<int> list21c{};
         auto cnt21c = list21c.remove_if([](int val) { return val < 0; });
-        const std::initializer_list<int> expected21c = { };
+        const std::initializer_list<int> expected21c = {};
         tests::compare("ForwardList21c", list21c, expected21c);
         tests::compare("ForwardList21c removed count", cnt21c, std::size_t{ 0 });
 
         dsa::ForwardList<int> list21d{};
         auto cnt21d = list21d.remove_if([](int val) { return val > 0; });
-        const std::initializer_list<int> expected21d = { };
+        const std::initializer_list<int> expected21d = {};
         tests::compare("ForwardList21d", list21d, expected21d);
         tests::compare("ForwardList21d removed count", cnt21d, std::size_t{ 0 });
 
         dsa::ForwardList<int> list21e{};
         auto cnt21e = list21e.remove_if([](int val) { return val <= 0; });
-        const std::initializer_list<int> expected21e = { };
+        const std::initializer_list<int> expected21e = {};
         tests::compare("ForwardList21e", list21e, expected21e);
         tests::compare("ForwardList21e removed count", cnt21e, std::size_t{ 0 });
 
         dsa::ForwardList<int> list21f{};
         auto cnt21f = list21f.remove_if([](int val) { return val >= 0; });
-        const std::initializer_list<int> expected21f = { };
+        const std::initializer_list<int> expected21f = {};
         tests::compare("ForwardList21f", list21f, expected21f);
         tests::compare("ForwardList21f removed count", cnt21f, std::size_t{ 0 });
 
@@ -272,7 +272,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("iter22 == nullptr", iter22 == nullptr, true);
         iter22 = list22.erase_after(list22.begin(), std::next(list22.end()));
         tests::compare("iter22 == nullptr", iter22 == nullptr, true);
-
 
         std::cout << "Compare operations results with std container\n\n";
 

--- a/tests/forward_list/forward_list_sort_test.cpp
+++ b/tests/forward_list/forward_list_sort_test.cpp
@@ -78,7 +78,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected9{ -10, 0 };
         tests::compare("ForwardList9", list9, expected9);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         // ascending
@@ -119,7 +118,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::forward_list<int> std_list9{ 0, -10 };
         std_list9.sort();
         tests::compare("ForwardList9", list9, std_list9);
-
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_splice_test.cpp
+++ b/tests/forward_list/forward_list_splice_test.cpp
@@ -88,8 +88,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list13 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list14 = dsa::ForwardList<int>(il_2);
-        list13.splice_after(list13.begin(),
-            list14, std::next(list14.begin(), static_cast<ptrdiff_t>(list14.size() - 2)));
+        list13.splice_after(list13.begin(), list14,
+            std::next(list14.begin(), static_cast<ptrdiff_t>(list14.size() - 2)));
         const std::initializer_list<int> expected13 = { 1, 50, 2, 3, 4, 5 };
         tests::compare("ForwardList13", list13, expected13);
         const std::initializer_list<int> expected14 = { 10, 20, 30, 40 };
@@ -113,18 +113,17 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list19 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list20 = dsa::ForwardList<int>(il_2);
-        list19.splice_after(std::next(list19.begin(), 3),
-            list20, std::next(list20.begin(), static_cast<ptrdiff_t>(list20.size() - 2)));
+        list19.splice_after(std::next(list19.begin(), 3), list20,
+            std::next(list20.begin(), static_cast<ptrdiff_t>(list20.size() - 2)));
         const std::initializer_list<int> expected19 = { 1, 2, 3, 4, 50, 5 };
         tests::compare("ForwardList19", list19, expected19);
         const std::initializer_list<int> expected20 = { 10, 20, 30, 40 };
         tests::compare("ForwardList20", list20, expected20);
 
-
         dsa::ForwardList<int> list21 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list22 = dsa::ForwardList<int>(il_2);
-        list21.splice_after(std::next(list21.begin(), static_cast<ptrdiff_t>(list21.size() - 1)),
-            list22, list22.begin());
+        list21.splice_after(std::next(list21.begin(), static_cast<ptrdiff_t>(list21.size() - 1)), list22,
+            list22.begin());
         const std::initializer_list<int> expected21 = { 1, 2, 3, 4, 5, 20 };
         tests::compare("ForwardList21", list21, expected21);
         const std::initializer_list<int> expected22 = { 10, 30, 40, 50 };
@@ -132,8 +131,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list23 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list24 = dsa::ForwardList<int>(il_2);
-        list23.splice_after(std::next(list23.begin(), static_cast<ptrdiff_t>(list23.size() - 1)),
-            list24, std::next(list24.begin(), 3));
+        list23.splice_after(std::next(list23.begin(), static_cast<ptrdiff_t>(list23.size() - 1)), list24,
+            std::next(list24.begin(), 3));
         const std::initializer_list<int> expected23 = { 1, 2, 3, 4, 5, 50 };
         tests::compare("ForwardList23", list23, expected23);
         const std::initializer_list<int> expected24 = { 10, 20, 30, 40 };
@@ -141,13 +140,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list25 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list26 = dsa::ForwardList<int>(il_2);
-        list25.splice_after(std::next(list25.begin(), static_cast<ptrdiff_t>(list25.size() - 1)),
-            list26, std::next(list26.begin(), static_cast<ptrdiff_t>(list26.size() - 2)));
+        list25.splice_after(std::next(list25.begin(), static_cast<ptrdiff_t>(list25.size() - 1)), list26,
+            std::next(list26.begin(), static_cast<ptrdiff_t>(list26.size() - 2)));
         const std::initializer_list<int> expected25 = { 1, 2, 3, 4, 5, 50 };
         tests::compare("ForwardList25", list25, expected25);
         const std::initializer_list<int> expected26 = { 10, 20, 30, 40 };
         tests::compare("ForwardList26", list26, expected26);
-
 
         std::cout << "Testing moving range of element from other list\n\n";
 
@@ -169,13 +167,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list31 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list32 = dsa::ForwardList<int>(il_2);
-        list31.splice_after(list31.begin(),
-            list32, list32.begin(), std::next(list32.begin(), static_cast<ptrdiff_t>(list32.size() - 1)));
+        list31.splice_after(list31.begin(), list32, list32.begin(),
+            std::next(list32.begin(), static_cast<ptrdiff_t>(list32.size() - 1)));
         const std::initializer_list<int> expected31 = { 1, 20, 30, 40, 2, 3, 4, 5 };
         tests::compare("ForwardList31", list31, expected31);
         const std::initializer_list<int> expected32 = { 10, 50 };
         tests::compare("ForwardList32", list32, expected32);
-
 
         dsa::ForwardList<int> list33 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list34 = dsa::ForwardList<int>(il_2);
@@ -187,8 +184,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list35 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list36 = dsa::ForwardList<int>(il_2);
-        list35.splice_after(std::next(list35.begin(), 2),
-            list36, std::next(list36.begin(), 1), std::next(list36.begin(), 3));
+        list35.splice_after(std::next(list35.begin(), 2), list36, std::next(list36.begin(), 1),
+            std::next(list36.begin(), 3));
         const std::initializer_list<int> expected35 = { 1, 2, 3, 30, 4, 5 };
         tests::compare("ForwardList35", list35, expected35);
         const std::initializer_list<int> expected36 = { 10, 20, 40, 50 };
@@ -196,18 +193,17 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list37 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list38 = dsa::ForwardList<int>(il_2);
-        list37.splice_after(std::next(list37.begin(), 2),
-            list38, list38.begin(), std::next(list38.begin(), static_cast<ptrdiff_t>(list38.size() - 1)));
+        list37.splice_after(std::next(list37.begin(), 2), list38, list38.begin(),
+            std::next(list38.begin(), static_cast<ptrdiff_t>(list38.size() - 1)));
         const std::initializer_list<int> expected37 = { 1, 2, 3, 20, 30, 40, 4, 5 };
         tests::compare("ForwardList37", list37, expected37);
         const std::initializer_list<int> expected38 = { 10, 50 };
         tests::compare("ForwardList38", list38, expected38);
 
-
         dsa::ForwardList<int> list39 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list40 = dsa::ForwardList<int>(il_2);
-        list39.splice_after(std::next(list39.begin(), static_cast<ptrdiff_t>(list39.size() - 1)),
-            list40, list40.begin(), std::next(list40.begin(), 1));
+        list39.splice_after(std::next(list39.begin(), static_cast<ptrdiff_t>(list39.size() - 1)), list40,
+            list40.begin(), std::next(list40.begin(), 1));
         const std::initializer_list<int> expected39 = { 1, 2, 3, 4, 5 };
         tests::compare("ForwardList39", list39, expected39);
         const std::initializer_list<int> expected40 = { 10, 20, 30, 40, 50 };
@@ -215,8 +211,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list41 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list42 = dsa::ForwardList<int>(il_2);
-        list41.splice_after(std::next(list41.begin(), static_cast<ptrdiff_t>(list41.size() - 1)),
-            list42, std::next(list42.begin(), 1), std::next(list42.begin(), 3));
+        list41.splice_after(std::next(list41.begin(), static_cast<ptrdiff_t>(list41.size() - 1)), list42,
+            std::next(list42.begin(), 1), std::next(list42.begin(), 3));
         const std::initializer_list<int> expected41 = { 1, 2, 3, 4, 5, 30 };
         tests::compare("ForwardList41", list41, expected41);
         const std::initializer_list<int> expected42 = { 10, 20, 40, 50 };
@@ -224,18 +220,17 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list43 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list44 = dsa::ForwardList<int>(il_2);
-        list43.splice_after(std::next(list43.begin(), static_cast<ptrdiff_t>(list43.size() - 1)),
-            list44, list44.begin(), std::next(list44.begin(), static_cast<ptrdiff_t>(list44.size() - 1)));
+        list43.splice_after(std::next(list43.begin(), static_cast<ptrdiff_t>(list43.size() - 1)), list44,
+            list44.begin(), std::next(list44.begin(), static_cast<ptrdiff_t>(list44.size() - 1)));
         const std::initializer_list<int> expected43 = { 1, 2, 3, 4, 5, 20, 30, 40 };
         tests::compare("ForwardList43", list43, expected43);
         const std::initializer_list<int> expected44 = { 10, 50 };
         tests::compare("ForwardList44", list44, expected44);
 
-
         dsa::ForwardList<int> list45 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list46 = dsa::ForwardList<int>(il_2);
-        list45.splice_after(list45.before_begin(),
-            list46, list46.begin(), std::next(list46.begin(), static_cast<ptrdiff_t>(list46.size() - 1)));
+        list45.splice_after(list45.before_begin(), list46, list46.begin(),
+            std::next(list46.begin(), static_cast<ptrdiff_t>(list46.size() - 1)));
         const std::initializer_list<int> expected45 = { 20, 30, 40, 1, 2, 3, 4, 5 };
         tests::compare("ForwardList45", list45, expected45);
         const std::initializer_list<int> expected46 = { 10, 50 };
@@ -243,8 +238,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list47 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list48 = dsa::ForwardList<int>(il_2);
-        list47.splice_after(std::next(list47.before_begin(), static_cast<ptrdiff_t>(list47.size() - 1)),
-            list48, list48.begin(), list48.end());
+        list47.splice_after(std::next(list47.before_begin(), static_cast<ptrdiff_t>(list47.size() - 1)), list48,
+            list48.begin(), list48.end());
         const std::initializer_list<int> expected47 = { 1, 2, 3, 4, 20, 30, 40, 50, 5 };
         tests::compare("ForwardList47", list47, expected47);
         const std::initializer_list<int> expected48 = { 10 };
@@ -252,13 +247,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list49 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list50 = dsa::ForwardList<int>(il_2);
-        list49.splice_after(std::next(list49.before_begin(), static_cast<ptrdiff_t>(list49.size())),
-            list50, list50.before_begin(), list50.end());
+        list49.splice_after(std::next(list49.before_begin(), static_cast<ptrdiff_t>(list49.size())), list50,
+            list50.before_begin(), list50.end());
         const std::initializer_list<int> expected49 = { 1, 2, 3, 4, 5, 10, 20, 30, 40, 50 };
         tests::compare("ForwardList49", list49, expected49);
         const std::initializer_list<int> expected50 = {};
         tests::compare("ForwardList50", list50, expected50);
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -389,7 +383,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list74.splice_after(list74.begin(), list74, list74.begin(), list74.end());
         const std::initializer_list<int> expected74 = { 1, 2, 3, 4, 5 };
         tests::compare("ForwardList74", list74, expected74);
-
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_swap_test.cpp
+++ b/tests/forward_list/forward_list_swap_test.cpp
@@ -41,7 +41,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::ForwardList<int> list3 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list4;
         list3.swap(list4);
-        const std::initializer_list<int> expected3 = { };
+        const std::initializer_list<int> expected3 = {};
         tests::compare("ForwardList3", list3, expected3);
         const std::initializer_list<int> expected4 = il_1;
         tests::compare("ForwardList4", list4, expected4);
@@ -57,18 +57,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::ForwardList<int> list7 = dsa::ForwardList<int>(il_1);
         dsa::ForwardList<int> list8;
         dsa::swap(list7, list8);
-        const std::initializer_list<int> expected7 = { };
+        const std::initializer_list<int> expected7 = {};
         tests::compare("ForwardList7", list7, expected7);
         const std::initializer_list<int> expected8 = il_1;
         tests::compare("ForwardList8", list8, expected8);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<dsa::ForwardList<int>&>(),
-            std::declval<dsa::ForwardList<int>&>())));
+        static_assert(noexcept(swap(std::declval<dsa::ForwardList<int>&>(), std::declval<dsa::ForwardList<int>&>())));
         // swap throwing type
         static_assert(noexcept(swap(std::declval<dsa::ForwardList<tests::ThrowingType>&>(),
             std::declval<dsa::ForwardList<tests::ThrowingType>&>())));
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -97,12 +95,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList8 vs std", list8, std_list8);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<std::forward_list<int>&>(),
-            std::declval<std::forward_list<int>&>())));
+        static_assert(noexcept(swap(std::declval<std::forward_list<int>&>(), std::declval<std::forward_list<int>&>())));
         // swap throwing type
         static_assert(noexcept(swap(std::declval<std::forward_list<tests::ThrowingType>&>(),
             std::declval<std::forward_list<tests::ThrowingType>&>())));
-
 
         tests::print_stats();
     }

--- a/tests/forward_list/forward_list_unique_test.cpp
+++ b/tests/forward_list/forward_list_unique_test.cpp
@@ -60,7 +60,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::ForwardList<int> list6 = dsa::ForwardList<int>();
         auto removed6 = list6.unique();
-        const std::initializer_list<int> expected6 = { };
+        const std::initializer_list<int> expected6 = {};
         tests::compare("ForwardList6", list6, expected6);
         tests::compare("ForwardList6 removed", removed6, size_t{ 0 });
 
@@ -71,10 +71,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("ForwardList7 removed", removed7, size_t{ 0 });
 
         // find unique values using predicate
-        auto predicate = [](const int& input_a, const int& input_b)
-            {
-                return std::abs(input_a - input_b) <= 5;
-            };
+        auto predicate = [](const int& input_a, const int& input_b) { return std::abs(input_a - input_b) <= 5; };
 
         dsa::ForwardList<int> list8 = dsa::ForwardList<int>({ 1, 5, 7, 15, 25 });
         auto removed8 = list8.unique(predicate);
@@ -87,7 +84,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected9 = { 1, 12, 3, 15, 1 };
         tests::compare("ForwardList9", list9, expected9);
         tests::compare("ForwardList9 removed", removed9, size_t{ 4 });
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -135,7 +131,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto std_removed9 = std_list9.unique(predicate);
         tests::compare("ForwardList9 vs std", list9, std_list9);
         tests::compare("ForwardList9 removed vs std", removed9, std_removed9);
-
 
         tests::print_stats();
     }

--- a/tests/list/list_ctors_test.cpp
+++ b/tests/list/list_ctors_test.cpp
@@ -94,7 +94,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected11{ 10, 20, 30 };
         tests::compare("List11", list11, expected11);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list1;
@@ -143,7 +142,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_temp11 = { 0, 10, 20, 30, 40, 50 };
         const std::list<int> std_list11(std::next(std_temp11.begin(), 1), std::next(std_temp11.begin(), 4));
         tests::compare("List11 vs std", list11, std_list11);
-
 
         tests::print_stats();
     }

--- a/tests/list/list_get_test.cpp
+++ b/tests/list/list_get_test.cpp
@@ -41,7 +41,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List2 front", list2.front(), 0);
         tests::compare("List2 back", list2.back(), 20);
 
-
         tests::print_stats();
     }
     catch (...)

--- a/tests/list/list_grow_test.cpp
+++ b/tests/list/list_grow_test.cpp
@@ -106,8 +106,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::List<int> list10{};
         const dsa::List<int> temp10{ 0, 10, 20, 30, 40, 50 };
         auto temp10_it = std::next(temp10.begin(), 1);
-        auto list10_it = list10.insert(
-            list10.begin(), std::next(temp10.begin(), 1), std::next(temp10.begin(), 4));
+        auto list10_it = list10.insert(list10.begin(), std::next(temp10.begin(), 1), std::next(temp10.begin(), 4));
         const std::initializer_list<int> expected10{ 10, 20, 30 };
         tests::compare("List10", list10, expected10);
         tests::compare("List10 it", *list10_it, *temp10_it);
@@ -428,7 +427,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List34", list34, expected34);
         tests::compare("List34 it", *list34_it, *(std::next(list34.begin(), 2)));
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list5{ 10, 20, 30 };
@@ -451,8 +449,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         std::list<int> std_list10{};
         const std::list<int> std_temp10{ 0, 10, 20, 30, 40, 50 };
-        auto std_list10_it = std_list10.insert(
-            std_list10.begin(), std::next(std_temp10.begin(), 1), std::next(std_temp10.begin(), 4));
+        auto std_list10_it =
+            std_list10.insert(std_list10.begin(), std::next(std_temp10.begin(), 1), std::next(std_temp10.begin(), 4));
         tests::compare("List10 vs std", list10, std_list10);
         tests::compare("List10 it vs std", *list10_it, *std_list10_it);
 
@@ -505,7 +503,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List18 front vs std", *list18.front(), *std_list18.front());
         tests::compare("List18 backvs std", *list18.back(), *std_list18.back());
         tests::compare("ptr18 == nullptr vs std", ptr18 == std_ptr18, true);
-
 
         tests::print_stats();
     }

--- a/tests/list/list_itors_test.cpp
+++ b/tests/list/list_itors_test.cpp
@@ -461,7 +461,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const dsa::List<int> reversed23{ 4, 3, 2, 1, 0 };
         tests::compare("list23 reverse iter", reversed23, temp23);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list1{ 0, 10, 20 };
@@ -504,7 +503,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List5 iterator vs std", expectedval5, val);
         tests::compare("List5 vs std", list5, expected5);
 
-        std::list<int>std_list6 = std::list<int>(1, 50);
+        std::list<int> std_list6 = std::list<int>(1, 50);
         std_list6.push_front(40);
         std_list6.push_front(30);
         std_iterator = std_list6.insert(std_list6.cbegin(), 0, 5);
@@ -512,25 +511,24 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List6 iterator vs std", expectedval6, val);
         tests::compare("List6 vs std", list6, std_list6);
 
-        std::list<int>std_list9 = std::list<int>{ 10, 20, 30, 40, 50 };
+        std::list<int> std_list9 = std::list<int>{ 10, 20, 30, 40, 50 };
         // use classic iterator based algorithms, separate test was added to test std::ranges based algorithms
         // NOLINTNEXTLINE(modernize-use-ranges)
         std::fill(std_list9.begin(), std_list9.end(), 10);
         tests::compare("List9 vs std", list9, std_list9);
 
-        std::list<int>std_list10 = std::list<int>{ 10, 20, 30 };
+        std::list<int> std_list10 = std::list<int>{ 10, 20, 30 };
         auto std_iter10b = std_list10.begin();
         *std_iter10b = 1;
         auto std_citer10b = std_list10.cbegin();
         tests::compare("citer10b vs std", *citer10b, *std_citer10b);
 
-        const std::list<int>std_list11 = std::list<int>{ 10, 20, 30 };
+        const std::list<int> std_list11 = std::list<int>{ 10, 20, 30 };
         auto std_iter11b = std_list11.begin();
         tests::compare("iter11b vs std", *iter11b, *std_iter11b);
 
         auto std_citer11b = std_list11.cbegin();
         tests::compare("citer11b vs std", *citer11b, *std_citer11b);
-
 
         tests::print_stats();
     }

--- a/tests/list/list_merge_test.cpp
+++ b/tests/list/list_merge_test.cpp
@@ -45,7 +45,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::List<int> list3 = dsa::List<int>(il_1);
         dsa::List<int> list4;
         list4.merge(list3);
-        const std::initializer_list<int> expected3 = { };
+        const std::initializer_list<int> expected3 = {};
         tests::compare("List3", list3, expected3);
         const std::initializer_list<int> expected4 = il_1;
         tests::compare("List4", list4, expected4);
@@ -268,7 +268,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List45 it 47_2", std::next(list45.begin(), 2) == addr45_2, true);
         tests::compare("List45 it 48_2", std::next(list45.begin(), 3) == addr46_2, true);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list1{ il_1 };
@@ -453,7 +452,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List45 it 45_1 vs std", std::next(std_list45.begin(), 1) == std_addr45_1, true);
         tests::compare("List45 it 45_2 vs std", std::next(std_list45.begin(), 2) == std_addr45_2, true);
         tests::compare("List45 it 46_2 vs std", std::next(std_list45.begin(), 3) == std_addr46_2, true);
-
 
         tests::print_stats();
     }

--- a/tests/list/list_operators_test.cpp
+++ b/tests/list/list_operators_test.cpp
@@ -123,9 +123,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // test noexcept
 
         // operators
-        static_assert(!noexcept(dsa::List<tests::ThrowingType>{1} == dsa::List<tests::ThrowingType>{1}));
-        static_assert(!noexcept(dsa::List<tests::ThrowingType>{1} <=> dsa::List<tests::ThrowingType>{1}));
-
+        static_assert(!noexcept(dsa::List<tests::ThrowingType>{ 1 } == dsa::List<tests::ThrowingType>{ 1 }));
+        static_assert(!noexcept(dsa::List<tests::ThrowingType>{ 1 } <=> dsa::List<tests::ThrowingType>{ 1 }));
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -159,12 +158,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("list1 <=> list2 vs std <=", (list1 <=> list2) <= 0, (std_list1 <=> std_list2) <= 0);
         tests::compare("list1 <=> list2 vs std >=", (list1 <=> list2) >= 0, (std_list1 <=> std_list2) >= 0);
 
-        tests::compare("list1 <=> list2 vs std <",
-            (list1 <=> list2) == std::weak_ordering::less, (std_list1 <=> std_list2) == std::weak_ordering::less);
-        tests::compare("list1 <=> list2 vs std <>",
-            (list1 <=> list2) != std::weak_ordering::equivalent, (std_list1 <=> std_list2) != std::weak_ordering::equivalent);
-        tests::compare("list1 <=> list2 vs std <=",
-            (list1 <=> list2) != std::weak_ordering::greater, (std_list1 <=> std_list2) != std::weak_ordering::greater);
+        tests::compare("list1 <=> list2 vs std <", (list1 <=> list2) == std::weak_ordering::less,
+            (std_list1 <=> std_list2) == std::weak_ordering::less);
+        tests::compare("list1 <=> list2 vs std <>", (list1 <=> list2) != std::weak_ordering::equivalent,
+            (std_list1 <=> std_list2) != std::weak_ordering::equivalent);
+        tests::compare("list1 <=> list2 vs std <=", (list1 <=> list2) != std::weak_ordering::greater,
+            (std_list1 <=> std_list2) != std::weak_ordering::greater);
 
         std::cout << "Compare operators for objects of different size\n\n";
 
@@ -200,12 +199,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("list1 <=> list3 vs std <=", (list1 <=> list3) <= 0, (std_list1 <=> std_list3) <= 0);
         tests::compare("list1 <=> list3 vs std >=", (list1 <=> list3) >= 0, (std_list1 <=> std_list3) >= 0);
 
-        tests::compare("list1 <=> list3 vs std >=",
-            (list1 <=> list3) != std::weak_ordering::less, (std_list1 <=> std_list3) != std::weak_ordering::less);
-        tests::compare("list1 <=> list3 vs std ==",
-            (list1 <=> list3) == std::weak_ordering::equivalent, (std_list1 <=> std_list3) == std::weak_ordering::equivalent);
-        tests::compare("list1 <=> list3 vs std <= ",
-            (list1 <=> list3) != std::weak_ordering::greater, (std_list1 <=> std_list3) != std::weak_ordering::greater);
+        tests::compare("list1 <=> list3 vs std >=", (list1 <=> list3) != std::weak_ordering::less,
+            (std_list1 <=> std_list3) != std::weak_ordering::less);
+        tests::compare("list1 <=> list3 vs std ==", (list1 <=> list3) == std::weak_ordering::equivalent,
+            (std_list1 <=> std_list3) == std::weak_ordering::equivalent);
+        tests::compare("list1 <=> list3 vs std <= ", (list1 <=> list3) != std::weak_ordering::greater,
+            (std_list1 <=> std_list3) != std::weak_ordering::greater);
 
         // test comparison categories
         static_assert(std::is_same_v<std::compare_three_way_result_t<std::list<int>>, std::strong_ordering>,
@@ -221,15 +220,14 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         assert((list7 <=> list8) == (std_list7 <=> std_list8));
         tests::compare("std_list7 <=> std_list8 weak ordering",
             (std_list7 <=> std_list8) == std::partial_ordering::unordered, true);
-        tests::compare("(list7 <=> list8) == (std_list7 <=> std_list8)",
-            (list7 <=> list8) == (std_list7 <=> std_list8), true);
+        tests::compare("(list7 <=> list8) == (std_list7 <=> std_list8)", (list7 <=> list8) == (std_list7 <=> std_list8),
+            true);
 
         // test noexcept
 
         // operators
-        static_assert(!noexcept(std::list<tests::ThrowingType>{1} == std::list<tests::ThrowingType>{1}));
-        static_assert(!noexcept(std::list<tests::ThrowingType>{1} <=> std::list<tests::ThrowingType>{1}));
-
+        static_assert(!noexcept(std::list<tests::ThrowingType>{ 1 } == std::list<tests::ThrowingType>{ 1 }));
+        static_assert(!noexcept(std::list<tests::ThrowingType>{ 1 } <=> std::list<tests::ThrowingType>{ 1 }));
 
         tests::print_stats();
     }

--- a/tests/list/list_ranges_test.cpp
+++ b/tests/list/list_ranges_test.cpp
@@ -63,14 +63,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         static_assert(std::ranges::common_range<dsa::List<int>>);
         static_assert(std::ranges::common_range<const dsa::List<int>>);
 
-        // test if iterators are indirectly readable 
+        // test if iterators are indirectly readable
         static_assert(std::indirectly_readable<dsa::List<int>::iterator>);
         static_assert(std::indirectly_readable<dsa::List<int>::const_iterator>);
 
         // test if sentinel and iterators are comparable
         static_assert(std::sentinel_for<dsa::List<int>::iterator, dsa::List<int>::iterator>);
         static_assert(std::sentinel_for<dsa::List<int>::const_iterator, dsa::List<int>::const_iterator>);
-
 
         // test iterator forward and backward traversal and dereference correctness
         dsa::List<int> list1{ 10, 20, 30 };
@@ -122,9 +121,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const int sum = std::accumulate(list4.begin(), list4.end(), 0);
         tests::compare("List4 sum", sum, 80);
         std::list<int> expected4;
-        std::ranges::for_each(list4, [&](int item) {expected4.push_back(item); });
-        tests::compare("List4 for_each() equal()",
-            std::ranges::equal(expected4, std::list{ 30, 10, 40 }), true);
+        std::ranges::for_each(list4, [&](int item) { expected4.push_back(item); });
+        tests::compare("List4 for_each() equal()", std::ranges::equal(expected4, std::list{ 30, 10, 40 }), true);
 
         // test std::ranges::reverse_viev
         dsa::List<int> list5{ 10, 20, 30 };
@@ -212,7 +210,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List17", list17, expected17);
         tests::compare("List18", list18, expected18);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list2;
@@ -238,29 +235,28 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         std::list<int> std_list12;
         tests::compare("List12 vs std empty()", list12.empty(), std_list12.empty());
-        tests::compare("List12 vs std begin() == end()",
-            list12.begin() == list12.end(), std_list12.begin() == std_list12.end());
-        tests::compare("List12 vs std distance == 0",
-            std::ranges::distance(list12) == 0, std::ranges::distance(list12) == 0);
+        tests::compare("List12 vs std begin() == end()", list12.begin() == list12.end(),
+            std_list12.begin() == std_list12.end());
+        tests::compare("List12 vs std distance == 0", std::ranges::distance(list12) == 0,
+            std::ranges::distance(list12) == 0);
 
         std::list<int> std_list13;
         std_list13.push_front(10);
         tests::compare("List13 vs std empty()", list13.empty(), std_list13.empty());
         tests::compare("List13 vs std front() == back()", list13.front(), std_list13.back());
         tests::compare("List13 vs std front() == back()", list13.back(), std_list13.back());
-        tests::compare("List13 vs std distance == 1",
-            std::ranges::distance(list13) == 1, std::ranges::distance(std_list13) == 1);
+        tests::compare("List13 vs std distance == 1", std::ranges::distance(list13) == 1,
+            std::ranges::distance(std_list13) == 1);
 
         std::list<int> std_list15{ 10, 20, 30, 40, 50 };
         std::ranges::fill(std_list15, 10);
         tests::compare("List15", list15, std_list15);
 
         std::list<int> std_list16;
-        tests::compare("List16 vs begin()",
-            std::ranges::begin(list16) == list16.begin(), std::ranges::begin(std_list16) == std_list16.begin());
-        tests::compare("List16 vs end()",
-            std::ranges::end(list16) == list16.end(), std::ranges::end(std_list16) == std_list16.end());
-
+        tests::compare("List16 vs begin()", std::ranges::begin(list16) == list16.begin(),
+            std::ranges::begin(std_list16) == std_list16.begin());
+        tests::compare("List16 vs end()", std::ranges::end(list16) == list16.end(),
+            std::ranges::end(std_list16) == std_list16.end());
 
         tests::print_stats();
     }

--- a/tests/list/list_resize_test.cpp
+++ b/tests/list/list_resize_test.cpp
@@ -72,7 +72,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list10 = dsa::List<int>({ 1, 2, 3, 4, 5 });
         list10.resize(0);
-        const std::initializer_list<int> expected10 = { };
+        const std::initializer_list<int> expected10 = {};
         tests::compare("List10", list10, expected10);
 
         std::cout << "Compare operations results with std container\n\n";
@@ -112,7 +112,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_list10{ 1, 2, 3, 4, 5 };
         std_list10.resize(0);
         tests::compare("List10 vs std", list10, std_list10);
-
 
         tests::print_stats();
     }

--- a/tests/list/list_reverse_test.cpp
+++ b/tests/list/list_reverse_test.cpp
@@ -51,7 +51,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected3{};
         tests::compare("List3", list3, expected3);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list1{ 0, 10, 20, 30, 40, 50 };
@@ -77,7 +76,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_list3;
         std_list3.reverse();
         tests::compare("List3 vs std", list3, std_list3);
-
 
         tests::print_stats();
     }

--- a/tests/list/list_set_test.cpp
+++ b/tests/list/list_set_test.cpp
@@ -64,7 +64,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list7.assign(expected7);
         tests::compare("List7", list7, expected7);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::list<int> std_list1{ 0, 10, 20 };
@@ -93,7 +92,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_list7{ 0, 10, 20 };
         std_list7.assign(expected7);
         tests::compare("List7 vs std", list7, std_list7);
-
 
         tests::print_stats();
     }

--- a/tests/list/list_shrink_test.cpp
+++ b/tests/list/list_shrink_test.cpp
@@ -83,7 +83,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list9 = dsa::List<int>({ 0, 0, 0, 0, 0, 0 });
         list9.remove(0);
-        const std::initializer_list<int> expected9 = { };
+        const std::initializer_list<int> expected9 = {};
         tests::compare("List9", list9, expected9);
 
         dsa::List<int> list10 = dsa::List<int>({ 0, 10, 0, 0, 40, 0 });
@@ -94,7 +94,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list11 = dsa::List<int>({ 0, 0, 0, 0, 0, 0 });
         auto cnt11 = list11.remove_if([](int val) { return val == 0; });
-        const std::initializer_list<int> expected11 = { };
+        const std::initializer_list<int> expected11 = {};
         tests::compare("List11", list11, expected11);
         tests::compare("List11 removed count", cnt11, std::size_t{ 6 });
 
@@ -114,7 +114,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare(list14.empty(), false);
         list14.clear();
         tests::compare(list14.empty(), true);
-        const std::initializer_list<int> expected14 = { };
+        const std::initializer_list<int> expected14 = {};
         tests::compare("List14", list14, expected14);
 
         dsa::List<int> list15 = dsa::List<int>({ 10, 20, 30 });
@@ -122,7 +122,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list15.pop_front();
         list15.pop_front();
         list15.pop_front();
-        const std::initializer_list<int> expected15 = { };
+        const std::initializer_list<int> expected15 = {};
         tests::compare("List15", list15, expected15);
 
         dsa::List<int> list16 = dsa::List<int>({ 10, 20, 30 });
@@ -130,7 +130,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list16.pop_back();
         list16.pop_back();
         list16.pop_back();
-        const std::initializer_list<int> expected16 = { };
+        const std::initializer_list<int> expected16 = {};
         tests::compare("List16", list16, expected16);
 
         dsa::List<int> list17 = dsa::List<int>({ 0, 10, 0, 0, 40, 0 });
@@ -141,7 +141,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list18 = dsa::List<int>({ 0, 0, 0, 0, 0, 0 });
         auto cnt18 = dsa::erase(list18, 0);
-        const std::initializer_list<int> expected18 = { };
+        const std::initializer_list<int> expected18 = {};
         tests::compare("List18", list18, expected18);
         tests::compare("List18 erase count", cnt18, std::size_t{ 6 });
 
@@ -153,7 +153,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list20 = dsa::List<int>({ 0, 0, 0, 0, 0, 0 });
         auto cnt20 = dsa::erase_if(list20, [](int val) { return val == 0; });
-        const std::initializer_list<int> expected20 = { };
+        const std::initializer_list<int> expected20 = {};
         tests::compare("List20", list20, expected20);
         tests::compare("List20 erase_if count", cnt20, std::size_t{ 6 });
 
@@ -207,7 +207,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list22h = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
         auto cnt22h = dsa::erase_if(list22h, [](int val) { return val > (-5); });
-        const std::initializer_list<int> expected22h = { };
+        const std::initializer_list<int> expected22h = {};
         tests::compare("List22h", list22h, expected22h);
         tests::compare("List22h erase_if count", cnt22h, std::size_t{ 6 });
 
@@ -219,13 +219,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list22j = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
         auto cnt22j = dsa::erase_if(list22j, [](int val) { return val >= (-5); });
-        const std::initializer_list<int> expected22j = { };
+        const std::initializer_list<int> expected22j = {};
         tests::compare("List22j", list22j, expected22j);
         tests::compare("List22j erase_if count", cnt22j, std::size_t{ 6 });
 
         dsa::List<int> list22k = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
         auto cnt22k = dsa::erase_if(list22k, [](int val) { return val < 100; });
-        const std::initializer_list<int> expected22k = { };
+        const std::initializer_list<int> expected22k = {};
         tests::compare("List22k", list22k, expected22k);
         tests::compare("List22k erase_if count", cnt22k, std::size_t{ 6 });
 
@@ -237,7 +237,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list22m = dsa::List<int>({ 0, 10, 2, 5, 7, 9 });
         auto cnt22m = dsa::erase_if(list22m, [](int val) { return val <= 100; });
-        const std::initializer_list<int> expected22m = { };
+        const std::initializer_list<int> expected22m = {};
         tests::compare("List22m", list22m, expected22m);
         tests::compare("List22m erase_if count", cnt22m, std::size_t{ 6 });
 
@@ -249,37 +249,37 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list23a{};
         auto cnt23a = list23a.remove_if([](int val) { return val == 0; });
-        const std::initializer_list<int> expected23a = { };
+        const std::initializer_list<int> expected23a = {};
         tests::compare("List23a", list23a, expected23a);
         tests::compare("List23a removed count", cnt23a, std::size_t{ 0 });
 
         dsa::List<int> list23b{};
         auto cnt23b = list23b.remove_if([](int val) { return val != 0; });
-        const std::initializer_list<int> expected23b = { };
+        const std::initializer_list<int> expected23b = {};
         tests::compare("List23b", list23b, expected23b);
         tests::compare("List23b removed count", cnt23b, std::size_t{ 0 });
 
         dsa::List<int> list23c{};
         auto cnt23c = list23c.remove_if([](int val) { return val < 0; });
-        const std::initializer_list<int> expected23c = { };
+        const std::initializer_list<int> expected23c = {};
         tests::compare("List23c", list23c, expected23c);
         tests::compare("List23c removed count", cnt23c, std::size_t{ 0 });
 
         dsa::List<int> list23d{};
         auto cnt23d = list23d.remove_if([](int val) { return val > 0; });
-        const std::initializer_list<int> expected23d = { };
+        const std::initializer_list<int> expected23d = {};
         tests::compare("List23d", list23d, expected23d);
         tests::compare("List23d removed count", cnt23d, std::size_t{ 0 });
 
         dsa::List<int> list23e{};
         auto cnt23e = list23e.remove_if([](int val) { return val <= 0; });
-        const std::initializer_list<int> expected23e = { };
+        const std::initializer_list<int> expected23e = {};
         tests::compare("List23e", list23e, expected23e);
         tests::compare("List23e removed count", cnt23e, std::size_t{ 0 });
 
         dsa::List<int> list23f{};
         auto cnt23f = list23f.remove_if([](int val) { return val >= 0; });
-        const std::initializer_list<int> expected23f = { };
+        const std::initializer_list<int> expected23f = {};
         tests::compare("List23f", list23f, expected23f);
         tests::compare("List23f removed count", cnt23f, std::size_t{ 0 });
 
@@ -288,7 +288,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("iter24 == nullptr", iter24 == nullptr, true);
         iter24 = list24.erase(list24.begin(), std::next(list24.end()));
         tests::compare("iter24 == nullptr", iter24 == nullptr, true);
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -390,7 +389,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto std_cnt22e = std::erase_if(std_list22e, [](int val) { return val <= 5; });
         tests::compare("List22e vs std", list22e, std_list22e);
         tests::compare("List22e erase_if count vs std", cnt22e, std_cnt22e);
-
 
         tests::print_stats();
     }

--- a/tests/list/list_sort_test.cpp
+++ b/tests/list/list_sort_test.cpp
@@ -78,7 +78,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected9{ -10, 0 };
         tests::compare("List9", list9, expected9);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         // ascending
@@ -119,7 +118,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::list<int> std_list9{ 0, -10 };
         std_list9.sort();
         tests::compare("List9", list9, std_list9);
-
 
         tests::print_stats();
     }

--- a/tests/list/list_splice_test.cpp
+++ b/tests/list/list_splice_test.cpp
@@ -58,7 +58,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected6 = {};
         tests::compare("List6", list6, expected6);
 
-
         std::cout << "Testing moving empty list\n\n";
 
         dsa::List<int> list7 = dsa::List<int>(il_1);
@@ -68,7 +67,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List7", list7, expected7);
         const std::initializer_list<int> expected8 = {};
         tests::compare("List8", list8, expected8);
-
 
         std::cout << "Testing moving one element from other list\n\n";
 
@@ -96,7 +94,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected14 = { 10, 20, 30, 50 };
         tests::compare("List14", list14, expected14);
 
-
         dsa::List<int> list15 = dsa::List<int>(il_1);
         dsa::List<int> list16 = dsa::List<int>(il_2);
         list15.splice(std::next(list15.begin(), 3), list16, list16.begin());
@@ -115,13 +112,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list19 = dsa::List<int>(il_1);
         dsa::List<int> list20 = dsa::List<int>(il_2);
-        list19.splice(std::next(list19.begin(), 3),
-            list20, std::next(list20.begin(), static_cast<ptrdiff_t>(list20.size() - 2)));
+        list19.splice(std::next(list19.begin(), 3), list20,
+            std::next(list20.begin(), static_cast<ptrdiff_t>(list20.size() - 2)));
         const std::initializer_list<int> expected19 = { 1, 2, 3, 40, 4, 5 };
         tests::compare("List19", list19, expected19);
         const std::initializer_list<int> expected20 = { 10, 20, 30, 50 };
         tests::compare("List20", list20, expected20);
-
 
         dsa::List<int> list21 = dsa::List<int>(il_1);
         dsa::List<int> list22 = dsa::List<int>(il_2);
@@ -133,7 +129,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list23 = dsa::List<int>(il_1);
         dsa::List<int> list24 = dsa::List<int>(il_2);
-        list23.splice(std::next(list23.begin(), static_cast<ptrdiff_t>(list23.size() - 1)), list24, std::next(list24.begin(), 3));
+        list23.splice(std::next(list23.begin(), static_cast<ptrdiff_t>(list23.size() - 1)), list24,
+            std::next(list24.begin(), 3));
         const std::initializer_list<int> expected23 = { 1, 2, 3, 4, 40, 5 };
         tests::compare("List23", list23, expected23);
         const std::initializer_list<int> expected24 = { 10, 20, 30, 50 };
@@ -141,13 +138,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list25 = dsa::List<int>(il_1);
         dsa::List<int> list26 = dsa::List<int>(il_2);
-        list25.splice(std::next(list25.begin(), static_cast<ptrdiff_t>(list25.size() - 1)),
-            list26, std::next(list26.begin(), static_cast<ptrdiff_t>(list26.size() - 2)));
+        list25.splice(std::next(list25.begin(), static_cast<ptrdiff_t>(list25.size() - 1)), list26,
+            std::next(list26.begin(), static_cast<ptrdiff_t>(list26.size() - 2)));
         const std::initializer_list<int> expected25 = { 1, 2, 3, 4, 40, 5 };
         tests::compare("List25", list25, expected25);
         const std::initializer_list<int> expected26 = { 10, 20, 30, 50 };
         tests::compare("List26", list26, expected26);
-
 
         std::cout << "Testing moving range of element from other list\n\n";
 
@@ -169,13 +165,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list31 = dsa::List<int>(il_1);
         dsa::List<int> list32 = dsa::List<int>(il_2);
-        list31.splice(list31.begin(),
-            list32, list32.begin(), std::next(list32.begin(), static_cast<ptrdiff_t>(list32.size() - 1)));
+        list31.splice(list31.begin(), list32, list32.begin(),
+            std::next(list32.begin(), static_cast<ptrdiff_t>(list32.size() - 1)));
         const std::initializer_list<int> expected31 = { 10, 20, 30, 40, 1, 2, 3, 4, 5 };
         tests::compare("List31", list31, expected31);
         const std::initializer_list<int> expected32 = { 50 };
         tests::compare("List32", list32, expected32);
-
 
         dsa::List<int> list33 = dsa::List<int>(il_1);
         dsa::List<int> list34 = dsa::List<int>(il_2);
@@ -195,18 +190,17 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list37 = dsa::List<int>(il_1);
         dsa::List<int> list38 = dsa::List<int>(il_2);
-        list37.splice(std::next(list37.begin(), 2),
-            list38, list38.begin(), std::next(list38.begin(), static_cast<ptrdiff_t>(list38.size() - 1)));
+        list37.splice(std::next(list37.begin(), 2), list38, list38.begin(),
+            std::next(list38.begin(), static_cast<ptrdiff_t>(list38.size() - 1)));
         const std::initializer_list<int> expected37 = { 1, 2, 10, 20, 30, 40, 3, 4, 5 };
         tests::compare("List37", list37, expected37);
         const std::initializer_list<int> expected38 = { 50 };
         tests::compare("List38", list38, expected38);
 
-
         dsa::List<int> list39 = dsa::List<int>(il_1);
         dsa::List<int> list40 = dsa::List<int>(il_2);
-        list39.splice(std::next(list39.begin(), static_cast<ptrdiff_t>(list39.size() - 1)),
-            list40, list40.begin(), std::next(list40.begin(), 1));
+        list39.splice(std::next(list39.begin(), static_cast<ptrdiff_t>(list39.size() - 1)), list40, list40.begin(),
+            std::next(list40.begin(), 1));
         const std::initializer_list<int> expected39 = { 1, 2, 3, 4, 10, 5 };
         tests::compare("List39", list39, expected39);
         const std::initializer_list<int> expected40 = { 20, 30, 40, 50 };
@@ -214,8 +208,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list41 = dsa::List<int>(il_1);
         dsa::List<int> list42 = dsa::List<int>(il_2);
-        list41.splice(std::next(list41.begin(), static_cast<ptrdiff_t>(list41.size() - 1)),
-            list42, std::next(list42.begin(), 1), std::next(list42.begin(), 3));
+        list41.splice(std::next(list41.begin(), static_cast<ptrdiff_t>(list41.size() - 1)), list42,
+            std::next(list42.begin(), 1), std::next(list42.begin(), 3));
         const std::initializer_list<int> expected41 = { 1, 2, 3, 4, 20, 30, 5 };
         tests::compare("List41", list41, expected41);
         const std::initializer_list<int> expected42 = { 10, 40, 50 };
@@ -223,8 +217,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list43 = dsa::List<int>(il_1);
         dsa::List<int> list44 = dsa::List<int>(il_2);
-        list43.splice(std::next(list43.begin(), static_cast<ptrdiff_t>(list43.size() - 1)),
-            list44, list44.begin(), std::next(list44.begin(), static_cast<ptrdiff_t>(list44.size() - 1)));
+        list43.splice(std::next(list43.begin(), static_cast<ptrdiff_t>(list43.size() - 1)), list44, list44.begin(),
+            std::next(list44.begin(), static_cast<ptrdiff_t>(list44.size() - 1)));
         const std::initializer_list<int> expected43 = { 1, 2, 3, 4, 10, 20, 30, 40, 5 };
         tests::compare("List43", list43, expected43);
         const std::initializer_list<int> expected44 = { 50 };
@@ -232,8 +226,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list45 = dsa::List<int>(il_1);
         dsa::List<int> list46 = dsa::List<int>(il_2);
-        list45.splice(std::next(list45.begin(), static_cast<ptrdiff_t>(list45.size())),
-            list46, list46.begin(), std::next(list46.begin(), static_cast<ptrdiff_t>(list46.size() - 1)));
+        list45.splice(std::next(list45.begin(), static_cast<ptrdiff_t>(list45.size())), list46, list46.begin(),
+            std::next(list46.begin(), static_cast<ptrdiff_t>(list46.size() - 1)));
         const std::initializer_list<int> expected45 = { 1, 2, 3, 4, 5, 10, 20, 30, 40 };
         tests::compare("List45", list45, expected45);
         const std::initializer_list<int> expected46 = { 50 };
@@ -241,8 +235,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list47 = dsa::List<int>(il_1);
         dsa::List<int> list48 = dsa::List<int>(il_2);
-        list47.splice(std::next(list47.begin(), static_cast<ptrdiff_t>(list47.size() - 1)),
-            list48, list48.begin(), std::next(list48.begin(), static_cast<ptrdiff_t>(list48.size())));
+        list47.splice(std::next(list47.begin(), static_cast<ptrdiff_t>(list47.size() - 1)), list48, list48.begin(),
+            std::next(list48.begin(), static_cast<ptrdiff_t>(list48.size())));
         const std::initializer_list<int> expected47 = { 1, 2, 3, 4, 10, 20, 30, 40, 50, 5 };
         tests::compare("List47", list47, expected47);
         const std::initializer_list<int> expected48 = {};
@@ -250,13 +244,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list49 = dsa::List<int>(il_1);
         dsa::List<int> list50 = dsa::List<int>(il_2);
-        list49.splice(std::next(list49.begin(), static_cast<ptrdiff_t>(list49.size())),
-            list50, list50.begin(), std::next(list50.begin(), static_cast<ptrdiff_t>(list50.size())));
+        list49.splice(std::next(list49.begin(), static_cast<ptrdiff_t>(list49.size())), list50, list50.begin(),
+            std::next(list50.begin(), static_cast<ptrdiff_t>(list50.size())));
         const std::initializer_list<int> expected49 = { 1, 2, 3, 4, 5, 10, 20, 30, 40, 50 };
         tests::compare("List49", list49, expected49);
         const std::initializer_list<int> expected50 = {};
         tests::compare("List50", list50, expected50);
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -330,7 +323,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List61", list61, il_1);
         tests::compare("List62", list62, il_2);
 
-
         std::cout << "Testing moving other list\n\n";
 
         dsa::List<int> list63 = dsa::List<int>(il_1);
@@ -379,7 +371,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         list71.splice(list71.begin(), list71, list71.begin());
         const std::initializer_list<int> expected71 = { 1, 2, 3, 4, 5 };
         tests::compare("List71", list71, expected71);
-
 
         tests::print_stats();
     }

--- a/tests/list/list_swap_test.cpp
+++ b/tests/list/list_swap_test.cpp
@@ -41,7 +41,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::List<int> list3 = dsa::List<int>(il_1);
         dsa::List<int> list4;
         list3.swap(list4);
-        const std::initializer_list<int> expected3 = { };
+        const std::initializer_list<int> expected3 = {};
         tests::compare("List3", list3, expected3);
         const std::initializer_list<int> expected4 = { 1, 2, 3, 4, 5 };
         tests::compare("List4", list4, expected4);
@@ -57,18 +57,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::List<int> list7 = dsa::List<int>(il_1);
         dsa::List<int> list8;
         dsa::swap(list7, list8);
-        const std::initializer_list<int> expected7 = { };
+        const std::initializer_list<int> expected7 = {};
         tests::compare("List7", list7, expected7);
         const std::initializer_list<int> expected8 = il_1;
         tests::compare("List8", list8, expected8);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<dsa::List<int>&>(),
-            std::declval<dsa::List<int>&>())));
+        static_assert(noexcept(swap(std::declval<dsa::List<int>&>(), std::declval<dsa::List<int>&>())));
         // swap throwing type
-        static_assert(noexcept(swap(std::declval<dsa::List<tests::ThrowingType>&>(),
-            std::declval<dsa::List<tests::ThrowingType>&>())));
-
+        static_assert(noexcept(
+            swap(std::declval<dsa::List<tests::ThrowingType>&>(), std::declval<dsa::List<tests::ThrowingType>&>())));
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -97,12 +95,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List8 vs std", list8, std_list8);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<std::list<int>&>(),
-            std::declval<std::list<int>&>())));
+        static_assert(noexcept(swap(std::declval<std::list<int>&>(), std::declval<std::list<int>&>())));
         // swap throwing type
-        static_assert(noexcept(swap(std::declval<std::list<tests::ThrowingType>&>(),
-            std::declval<std::list<tests::ThrowingType>&>())));
-
+        static_assert(noexcept(
+            swap(std::declval<std::list<tests::ThrowingType>&>(), std::declval<std::list<tests::ThrowingType>&>())));
 
         tests::print_stats();
     }

--- a/tests/list/list_unique_test.cpp
+++ b/tests/list/list_unique_test.cpp
@@ -60,7 +60,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::List<int> list6 = dsa::List<int>();
         auto removed6 = list6.unique();
-        const std::initializer_list<int> expected6 = { };
+        const std::initializer_list<int> expected6 = {};
         tests::compare("List6", list6, expected6);
         tests::compare("List6 removed", removed6, size_t{ 0 });
 
@@ -71,10 +71,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("List7 removed", removed7, size_t{ 0 });
 
         // find unique values using predicate
-        auto predicate = [](const int& input_a, const int& input_b)
-            {
-                return std::abs(input_a - input_b) <= 5;
-            };
+        auto predicate = [](const int& input_a, const int& input_b) { return std::abs(input_a - input_b) <= 5; };
 
         dsa::List<int> list8 = dsa::List<int>({ 1, 5, 7, 15, 25 });
         auto removed8 = list8.unique(predicate);
@@ -87,7 +84,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected9 = { 1, 12, 3, 15, 1 };
         tests::compare("List9", list9, expected9);
         tests::compare("List9 removed", removed9, size_t{ 4 });
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -135,7 +131,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto std_removed9 = std_list9.unique(predicate);
         tests::compare("List9 vs std", list9, std_list9);
         tests::compare("List9 removed vs std", removed9, std_removed9);
-
 
         tests::print_stats();
     }

--- a/tests/queue/priority_queue_ctors_test.cpp
+++ b/tests/queue/priority_queue_ctors_test.cpp
@@ -71,22 +71,21 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("PriorityQueue6", priority_queue6, expected);
 
         std::cout << "Iterator-pair constructor, template compare - greater\n";
-        const dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>>
-            priority_queue7(data.begin(), data.end(), std::greater<>());
+        const dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue7(data.begin(), data.end(),
+            std::greater<>());
         tests::compare("PriorityQueue7", priority_queue7, std::initializer_list<int>{ 0, 10, 20 });
 
         std::cout << "Iterator-pair copy constructor, template compare - greater\n";
         const dsa::Vector<int> temp_8({ -1, -2, -3 });
-        const dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>>
-            priority_queue8(data.begin(), data.end(), std::greater<>(), temp_8);
+        const dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue8(data.begin(), data.end(),
+            std::greater<>(), temp_8);
         tests::compare("PriorityQueue8", priority_queue8, std::initializer_list<int>{ -3, -2, -1, 0, 10, 20 });
 
         std::cout << "Iterator-pair move constructor, template compare - greater\n";
         dsa::Vector<int> temp_9({ -1, -2, -3 });
-        const dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>>
-            priority_queue9(data.begin(), data.end(), std::greater<>(), std::move(temp_9));
+        const dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue9(data.begin(), data.end(),
+            std::greater<>(), std::move(temp_9));
         tests::compare("PriorityQueue9", priority_queue9, std::initializer_list<int>{ -3, -2, -1, 0, 10, 20 });
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -121,20 +120,19 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::priority_queue<int> std_priority_queue6(data.begin(), data.end());
         tests::compare("PriorityQueue6 vs std", priority_queue6, std_priority_queue6);
 
-        const std::priority_queue<int, std::vector<int>, std::greater<>>
-            std_priority_queue7(data.begin(), data.end(), std::greater<>());
+        const std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue7(data.begin(), data.end(),
+            std::greater<>());
         tests::compare("PriorityQueue7 vs std", priority_queue7, std_priority_queue7);
 
         const std::vector<int> std_temp_8({ -1, -2, -3 });
-        const std::priority_queue<int, std::vector<int>, std::greater<>>
-            std_priority_queue8(data.begin(), data.end(), std::greater<>(), std_temp_8);
+        const std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue8(data.begin(), data.end(),
+            std::greater<>(), std_temp_8);
         tests::compare("PriorityQueue8 vs std", priority_queue8, std_priority_queue8);
 
         std::vector<int> std_temp_9({ -1, -2, -3 });
-        const std::priority_queue<int, std::vector<int>, std::greater<>>
-            std_priority_queue9(data.begin(), data.end(), std::greater<>(), std::move(std_temp_9));
+        const std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue9(data.begin(), data.end(),
+            std::greater<>(), std::move(std_temp_9));
         tests::compare("PriorityQueue9 vs std", priority_queue9, std_priority_queue9);
-
 
         tests::print_stats();
     }

--- a/tests/queue/priority_queue_swap_test.cpp
+++ b/tests/queue/priority_queue_swap_test.cpp
@@ -39,7 +39,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> il_1_asc{ 1, 2, 3, 4, 5 };
         const std::initializer_list<int> il_2_asc{ 10, 20, 30, 40, 50 };
 
-
         dsa::PriorityQueue<int> priority_queue1(il_1.begin(), il_1.end());
         dsa::PriorityQueue<int> priority_queue2(il_2.begin(), il_2.end());
         priority_queue1.swap(priority_queue2);
@@ -51,7 +50,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::PriorityQueue<int> priority_queue3 = dsa::PriorityQueue<int>(il_1.begin(), il_1.end());
         dsa::PriorityQueue<int> priority_queue4;
         priority_queue3.swap(priority_queue4);
-        const std::initializer_list<int> expected3 = { };
+        const std::initializer_list<int> expected3 = {};
         tests::compare("PriorityQueue3", priority_queue3, expected3);
         const std::initializer_list<int> expected4 = il_1_desc;
         tests::compare("PriorityQueue4", priority_queue4, expected4);
@@ -67,7 +66,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::PriorityQueue<int> priority_queue7 = dsa::PriorityQueue<int>(il_1.begin(), il_1.end());
         dsa::PriorityQueue<int> priority_queue8;
         dsa::swap(priority_queue7, priority_queue8);
-        const std::initializer_list<int> expected7 = { };
+        const std::initializer_list<int> expected7 = {};
         tests::compare("PriorityQueue7", priority_queue7, expected7);
         const std::initializer_list<int> expected8 = il_1_desc;
         tests::compare("PriorityQueue8", priority_queue8, expected8);
@@ -75,78 +74,88 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // descending order
 
         dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue9(il_1.begin(), il_1.end(), std::less<>());
-        dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue10(il_2.begin(), il_2.end(), std::less<>());
+        dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue10(il_2.begin(), il_2.end(),
+            std::less<>());
         priority_queue9.swap(priority_queue10);
         const std::initializer_list<int> expected9 = il_2_desc;
         tests::compare("PriorityQueue9", priority_queue9, expected9);
         const std::initializer_list<int> expected10 = il_1_desc;
         tests::compare("PriorityQueue10", priority_queue10, expected10);
 
-        dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue11(il_1.begin(), il_1.end(), std::less<>());
+        dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue11(il_1.begin(), il_1.end(),
+            std::less<>());
         dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue12;
         priority_queue11.swap(priority_queue12);
-        const std::initializer_list<int> expected11 = { };
+        const std::initializer_list<int> expected11 = {};
         tests::compare("PriorityQueue11", priority_queue11, expected11);
         const std::initializer_list<int> expected12 = il_1_desc;
         tests::compare("PriorityQueue12", priority_queue12, expected12);
 
-        dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue13(il_1.begin(), il_1.end(), std::less<>());
-        dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue14(il_2.begin(), il_2.end(), std::less<>());
+        dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue13(il_1.begin(), il_1.end(),
+            std::less<>());
+        dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue14(il_2.begin(), il_2.end(),
+            std::less<>());
         dsa::swap(priority_queue13, priority_queue14);
         const std::initializer_list<int> expected13 = il_2_desc;
         tests::compare("PriorityQueue13", priority_queue13, expected13);
         const std::initializer_list<int> expected14 = il_1_desc;
         tests::compare("PriorityQueue14", priority_queue14, expected14);
 
-        dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue15(il_1.begin(), il_1.end(), std::less<>());
+        dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue15(il_1.begin(), il_1.end(),
+            std::less<>());
         dsa::PriorityQueue<int, dsa::Vector<int>, std::less<>> priority_queue16;
         dsa::swap(priority_queue15, priority_queue16);
-        const std::initializer_list<int> expected15 = { };
+        const std::initializer_list<int> expected15 = {};
         tests::compare("PriorityQueue15", priority_queue15, expected15);
         const std::initializer_list<int> expected16 = il_1_desc;
         tests::compare("PriorityQueue16", priority_queue16, expected16);
 
         // ascending order
 
-        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue17(il_1.begin(), il_1.end(), std::greater<>());
-        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue18(il_2.begin(), il_2.end(), std::greater<>());
+        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue17(il_1.begin(), il_1.end(),
+            std::greater<>());
+        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue18(il_2.begin(), il_2.end(),
+            std::greater<>());
         priority_queue17.swap(priority_queue18);
         const std::initializer_list<int> expected17 = il_2_asc;
         tests::compare("PriorityQueue17", priority_queue17, expected17);
         const std::initializer_list<int> expected18 = il_1_asc;
         tests::compare("PriorityQueue18", priority_queue18, expected18);
 
-        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue19(il_1.begin(), il_1.end(), std::greater<>());
+        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue19(il_1.begin(), il_1.end(),
+            std::greater<>());
         dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue20;
         priority_queue19.swap(priority_queue20);
-        const std::initializer_list<int> expected19 = { };
+        const std::initializer_list<int> expected19 = {};
         tests::compare("PriorityQueue19", priority_queue19, expected19);
         const std::initializer_list<int> expected20 = il_1_asc;
         tests::compare("PriorityQueue20", priority_queue20, expected20);
 
-        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue21(il_1.begin(), il_1.end(), std::greater<>());
-        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue22(il_2.begin(), il_2.end(), std::greater<>());
+        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue21(il_1.begin(), il_1.end(),
+            std::greater<>());
+        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue22(il_2.begin(), il_2.end(),
+            std::greater<>());
         dsa::swap(priority_queue21, priority_queue22);
         const std::initializer_list<int> expected21 = il_2_asc;
         tests::compare("PriorityQueue21", priority_queue21, expected21);
         const std::initializer_list<int> expected22 = il_1_asc;
         tests::compare("PriorityQueue22", priority_queue22, expected22);
 
-        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue23(il_1.begin(), il_1.end(), std::greater<>());
+        dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue23(il_1.begin(), il_1.end(),
+            std::greater<>());
         dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue24;
         dsa::swap(priority_queue23, priority_queue24);
-        const std::initializer_list<int> expected23 = { };
+        const std::initializer_list<int> expected23 = {};
         tests::compare("PriorityQueue23", priority_queue23, expected23);
         const std::initializer_list<int> expected24 = il_1_asc;
         tests::compare("PriorityQueue24", priority_queue24, expected24);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<dsa::PriorityQueue<int>&>(),
-            std::declval<dsa::PriorityQueue<int>&>())));
+        static_assert(
+            noexcept(swap(std::declval<dsa::PriorityQueue<int>&>(), std::declval<dsa::PriorityQueue<int>&>())));
         // swap throwing type
         static_assert(noexcept(swap(std::declval<dsa::PriorityQueue<tests::ThrowingType>&>(),
             std::declval<dsa::PriorityQueue<tests::ThrowingType>&>())));
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -176,25 +185,31 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         // descending order
 
-        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue9(il_1.begin(), il_1.end(), std::less<>());
-        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue10(il_2.begin(), il_2.end(), std::less<>());
+        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue9(il_1.begin(), il_1.end(),
+            std::less<>());
+        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue10(il_2.begin(), il_2.end(),
+            std::less<>());
         std_priority_queue9.swap(std_priority_queue10);
         tests::compare("PriorityQueue9 vs std", priority_queue9, std_priority_queue9);
         tests::compare("PriorityQueue10 vs std", priority_queue10, std_priority_queue10);
 
-        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue11(il_1.begin(), il_1.end(), std::less<>());
+        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue11(il_1.begin(), il_1.end(),
+            std::less<>());
         std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue12;
         std_priority_queue11.swap(std_priority_queue12);
         tests::compare("PriorityQueue11 vs std", priority_queue11, std_priority_queue11);
         tests::compare("PriorityQueue12 vs std", priority_queue12, std_priority_queue12);
 
-        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue13(il_1.begin(), il_1.end(), std::less<>());
-        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue14(il_2.begin(), il_2.end(), std::less<>());
+        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue13(il_1.begin(), il_1.end(),
+            std::less<>());
+        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue14(il_2.begin(), il_2.end(),
+            std::less<>());
         std::swap(std_priority_queue13, std_priority_queue14);
         tests::compare("PriorityQueue13 vs std", priority_queue13, std_priority_queue13);
         tests::compare("PriorityQueue14 vs std", priority_queue14, std_priority_queue14);
 
-        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue15(il_1.begin(), il_1.end(), std::less<>());
+        std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue15(il_1.begin(), il_1.end(),
+            std::less<>());
         std::priority_queue<int, std::vector<int>, std::less<>> std_priority_queue16;
         std::swap(std_priority_queue15, std_priority_queue16);
         tests::compare("PriorityQueue15 vs std", priority_queue15, std_priority_queue15);
@@ -202,37 +217,42 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         // ascending order
 
-        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue17(il_1.begin(), il_1.end(), std::greater<>());
-        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue18(il_2.begin(), il_2.end(), std::greater<>());
+        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue17(il_1.begin(), il_1.end(),
+            std::greater<>());
+        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue18(il_2.begin(), il_2.end(),
+            std::greater<>());
         std_priority_queue17.swap(std_priority_queue18);
         tests::compare("PriorityQueue17 vs std", priority_queue17, std_priority_queue17);
         tests::compare("PriorityQueue18 vs std", priority_queue18, std_priority_queue18);
 
-        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue19(il_1.begin(), il_1.end(), std::greater<>());
+        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue19(il_1.begin(), il_1.end(),
+            std::greater<>());
         std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue20;
         std_priority_queue19.swap(std_priority_queue20);
         tests::compare("PriorityQueue19 vs std", priority_queue19, std_priority_queue19);
         tests::compare("PriorityQueue20 vs std", priority_queue20, std_priority_queue20);
 
-        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue21(il_1.begin(), il_1.end(), std::greater<>());
-        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue22(il_2.begin(), il_2.end(), std::greater<>());
+        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue21(il_1.begin(), il_1.end(),
+            std::greater<>());
+        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue22(il_2.begin(), il_2.end(),
+            std::greater<>());
         std::swap(std_priority_queue21, std_priority_queue22);
         tests::compare("PriorityQueue21 vs std", priority_queue21, std_priority_queue21);
         tests::compare("PriorityQueue22 vs std", priority_queue22, std_priority_queue22);
 
-        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue23(il_1.begin(), il_1.end(), std::greater<>());
+        std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue23(il_1.begin(), il_1.end(),
+            std::greater<>());
         std::priority_queue<int, std::vector<int>, std::greater<>> std_priority_queue24;
         std::swap(std_priority_queue23, std_priority_queue24);
         tests::compare("PriorityQueue23 vs std", priority_queue23, std_priority_queue23);
         tests::compare("PriorityQueue24 vs std", priority_queue24, std_priority_queue24);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<std::priority_queue<int>&>(),
-            std::declval<std::priority_queue<int>&>())));
+        static_assert(
+            noexcept(swap(std::declval<std::priority_queue<int>&>(), std::declval<std::priority_queue<int>&>())));
         // swap throwing type
         static_assert(noexcept(swap(std::declval<std::priority_queue<tests::ThrowingType>&>(),
             std::declval<std::priority_queue<tests::ThrowingType>&>())));
-
 
         tests::print_stats();
     }

--- a/tests/queue/priority_queue_test.cpp
+++ b/tests/queue/priority_queue_test.cpp
@@ -26,19 +26,19 @@ namespace
     // Avoid const or ref data members
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     auto odd_even_asc = [](int lhs, int rhs) -> bool
+    {
+        const bool lhs_is_odd = lhs % 2 != 0;
+        const bool rhs_is_odd = rhs % 2 != 0;
+
+        // odd before even
+        if (lhs_is_odd != rhs_is_odd)
         {
-            const bool lhs_is_odd = lhs % 2 != 0;
-            const bool rhs_is_odd = rhs % 2 != 0;
+            return rhs_is_odd;
+        }
 
-            // odd before even
-            if (lhs_is_odd != rhs_is_odd)
-            {
-                return rhs_is_odd;
-            }
-
-            // smalest first
-            return lhs > rhs;
-        };
+        // smalest first
+        return lhs > rhs;
+    };
 
     struct
     {
@@ -50,7 +50,7 @@ namespace
     // Avoid const or ref data members
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     struct_compare;
-}
+} // namespace
 
 int main() // NOLINT(modernize-use-trailing-return-type)
 {
@@ -124,17 +124,17 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::PriorityQueue<int> priority_queue6(il_1.begin(), il_1.end());
         dsa::PriorityQueue<int, dsa::Vector<int>, std::greater<>> priority_queue7(il_1.begin(), il_1.end());
 
-        const dsa::PriorityQueue<int, dsa::Vector<int>, decltype(odd_even_asc)> priority_queue8(il_1.begin(), il_1.end(), odd_even_asc);
+        const dsa::PriorityQueue<int, dsa::Vector<int>, decltype(odd_even_asc)> priority_queue8(il_1.begin(),
+            il_1.end(), odd_even_asc);
         const std::initializer_list<int> expected8{ 1, 3, 5, 2, 4 };
         tests::compare("PriorityQueue8", priority_queue8, expected8);
 
-        const dsa::PriorityQueue<int, dsa::Vector<int>, decltype(struct_compare)> priority_queue9(il_1.begin(), il_1.end(), struct_compare);
+        const dsa::PriorityQueue<int, dsa::Vector<int>, decltype(struct_compare)> priority_queue9(il_1.begin(),
+            il_1.end(), struct_compare);
         const std::initializer_list<int> expected9{ 1, 3, 5, 2, 4 };
         tests::compare("PriorityQueue9", priority_queue9, expected9);
 
-
         std::cout << "Compare operations results with std container\n\n";
-
 
         std::priority_queue<int> std_priority_queue1;
         std_priority_queue1.push(2);
@@ -180,12 +180,13 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         }
         tests::compare("PriorityQueue7 vs std", priority_queue7, std_priority_queue7);
 
-        const std::priority_queue<int, std::vector<int>, decltype(odd_even_asc)> std_priority_queue8(il_1.begin(), il_1.end(), odd_even_asc);
+        const std::priority_queue<int, std::vector<int>, decltype(odd_even_asc)> std_priority_queue8(il_1.begin(),
+            il_1.end(), odd_even_asc);
         tests::compare("PriorityQueue8 vs std", priority_queue8, std_priority_queue8);
 
-        const std::priority_queue<int, std::vector<int>, decltype(struct_compare)> std_priority_queue9(il_1.begin(), il_1.end(), struct_compare);
+        const std::priority_queue<int, std::vector<int>, decltype(struct_compare)> std_priority_queue9(il_1.begin(),
+            il_1.end(), struct_compare);
         tests::compare("PriorityQueue9 vs std", priority_queue9, std_priority_queue9);
-
 
         tests::print_stats();
     }

--- a/tests/queue/queue_ctors_test.cpp
+++ b/tests/queue/queue_ctors_test.cpp
@@ -63,7 +63,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Queue5", queue5, expected);
 
         std::cout << "Copy self assignment ctor\n";
-        dsa::Queue<int> queue6{ dsa::List<int>({0, 10, 20}) };
+        dsa::Queue<int> queue6{ dsa::List<int>({ 0, 10, 20 }) };
         auto* pointer6 = &queue6;
         queue6 = *pointer6;
         tests::compare("Queue6", queue6, expected);
@@ -81,7 +81,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Queue8", queue8, expected);
 
         std::cout << "Move self assignment ctor\n";
-        dsa::Queue<int> queue9{ dsa::List<int>({0, 10, 20}) };
+        dsa::Queue<int> queue9{ dsa::List<int>({ 0, 10, 20 }) };
         auto* pointer9 = &queue9;
         queue9 = std::move(*pointer9);
         tests::compare("Queue9", queue9, expected);
@@ -101,7 +101,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const dsa::Queue<int> queue12(std::move(temp12));
         const std::initializer_list<int> expected12{ 10, 20, 30 };
         tests::compare("Queue12", queue12, expected12);
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -153,7 +152,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::deque<int> std_temp12 = { 10, 20, 30 };
         const std::queue<int> std_queue12(std::move(std_temp12));
         tests::compare("Queue12 vs std", queue12, std_queue12);
-
 
         tests::print_stats();
     }

--- a/tests/queue/queue_get_test.cpp
+++ b/tests/queue/queue_get_test.cpp
@@ -26,9 +26,9 @@ int main() // NOLINT(modernize-use-trailing-return-type)
     {
         std::cout << "Start queue_get_test:\n";
 
-        const std::initializer_list<int> expected{ 0,10,20 };
+        const std::initializer_list<int> expected{ 0, 10, 20 };
 
-        dsa::Queue<int> queue1 = dsa::Queue<int>({ 0,10,20 });
+        dsa::Queue<int> queue1 = dsa::Queue<int>({ 0, 10, 20 });
         std::cout << "Queue1:\t";
         for (const auto& item : expected)
         {
@@ -43,28 +43,26 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::cout << '\n';
         tests::compare("Queue1", queue1, expected);
 
-        dsa::Queue<int> queue2 = dsa::Queue<int>({ 0,10,20 });
+        dsa::Queue<int> queue2 = dsa::Queue<int>({ 0, 10, 20 });
         tests::compare("Queue2 front", queue2.front(), 0);
         tests::compare("Queue2 back", queue2.back(), 20);
 
-        const dsa::Queue<int> queue3 = dsa::Queue<int>({ 0,10,20 });
+        const dsa::Queue<int> queue3 = dsa::Queue<int>({ 0, 10, 20 });
         tests::compare("Queue3 front", queue3.front(), 0);
         tests::compare("Queue3 back", queue3.back(), 20);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
-        const std::queue<int> std_queue1 = std::queue<int>({ 0,10,20 });
+        const std::queue<int> std_queue1 = std::queue<int>({ 0, 10, 20 });
         tests::compare("Queue1 vs std", queue1, std_queue1);
 
-        std::queue<int> std_queue2 = std::queue<int>({ 0,10,20 });
+        std::queue<int> std_queue2 = std::queue<int>({ 0, 10, 20 });
         tests::compare("Queue2 front vs std", queue2.front(), std_queue2.front());
         tests::compare("Queue2 back vs std", queue2.back(), std_queue2.back());
 
-        const std::queue<int> std_queue3 = std::queue<int>({ 0,10,20 });
+        const std::queue<int> std_queue3 = std::queue<int>({ 0, 10, 20 });
         tests::compare("Queue3 front vs std", queue3.front(), std_queue3.front());
         tests::compare("Queue3 back vs std", queue3.back(), std_queue3.back());
-
 
         tests::print_stats();
     }

--- a/tests/queue/queue_grow_test.cpp
+++ b/tests/queue/queue_grow_test.cpp
@@ -41,7 +41,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         queue2.emplace(40);
         tests::compare("Queue2", queue2, expected);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::queue<int> std_queue1 = std::queue<int>({ 10 });
@@ -56,7 +55,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_queue2.emplace(30);
         std_queue2.emplace(40);
         tests::compare("Queue2 vs std", queue2, std_queue2);
-
 
         tests::print_stats();
     }

--- a/tests/queue/queue_operators_test.cpp
+++ b/tests/queue/queue_operators_test.cpp
@@ -116,21 +116,22 @@ int main() // NOLINT(modernize-use-trailing-return-type)
             "Double queue should support strong ordering");
 
         // test partial ordering
-        const dsa::Queue<double> queue7{ dsa::List<double>{1.0, 2.0, 3.0} };
-        const dsa::Queue<double> queue8{ dsa::List<double>{1.0, 2.0, std::numeric_limits<double>::quiet_NaN()} };
+        const dsa::Queue<double> queue7{
+            dsa::List<double>{ 1.0, 2.0, 3.0 }
+        };
+        const dsa::Queue<double> queue8{
+            dsa::List<double>{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() }
+        };
         assert((queue7 <=> queue8) == std::partial_ordering::unordered);
         tests::compare("Queue7 <=> queue8 weak ordering", (queue7 <=> queue8) != std::weak_ordering::less, true);
 
         // test noexcept
 
         // operators
-        static_assert(!noexcept(
-            dsa::Queue<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)} ==
-            dsa::Queue<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)}));
-        static_assert(!noexcept(
-            dsa::Queue<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)} <=>
-            dsa::Queue<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)}));
-
+        static_assert(!noexcept(dsa::Queue<tests::ThrowingType>{ dsa::List<tests::ThrowingType>(1) } ==
+                                dsa::Queue<tests::ThrowingType>{ dsa::List<tests::ThrowingType>(1) }));
+        static_assert(!noexcept(dsa::Queue<tests::ThrowingType>{ dsa::List<tests::ThrowingType>(1) } <=>
+                                dsa::Queue<tests::ThrowingType>{ dsa::List<tests::ThrowingType>(1) }));
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -164,12 +165,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Queue1 <=> queue2 vs std <=", (queue1 <=> queue2) <= 0, (std_queue1 <=> std_queue2) <= 0);
         tests::compare("Queue1 <=> queue2 vs std >=", (queue1 <=> queue2) >= 0, (std_queue1 <=> std_queue2) >= 0);
 
-        tests::compare("Queue1 <=> queue2 vs std <",
-            (queue1 <=> queue2) == std::weak_ordering::less, (std_queue1 <=> std_queue2) == std::weak_ordering::less);
-        tests::compare("Queue1 <=> queue2 vs std <>",
-            (queue1 <=> queue2) != std::weak_ordering::equivalent, (std_queue1 <=> std_queue2) != std::weak_ordering::equivalent);
-        tests::compare("Queue1 <=> queue2 vs std <=",
-            (queue1 <=> queue2) != std::weak_ordering::greater, (std_queue1 <=> std_queue2) != std::weak_ordering::greater);
+        tests::compare("Queue1 <=> queue2 vs std <", (queue1 <=> queue2) == std::weak_ordering::less,
+            (std_queue1 <=> std_queue2) == std::weak_ordering::less);
+        tests::compare("Queue1 <=> queue2 vs std <>", (queue1 <=> queue2) != std::weak_ordering::equivalent,
+            (std_queue1 <=> std_queue2) != std::weak_ordering::equivalent);
+        tests::compare("Queue1 <=> queue2 vs std <=", (queue1 <=> queue2) != std::weak_ordering::greater,
+            (std_queue1 <=> std_queue2) != std::weak_ordering::greater);
 
         std::cout << "Compare operators for objects of different size\n\n";
 
@@ -205,12 +206,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Queue1 <=> queue3 vs std <=", (queue1 <=> queue3) <= 0, (std_queue1 <=> std_queue3) <= 0);
         tests::compare("Queue1 <=> queue3 vs std >=", (queue1 <=> queue3) >= 0, (std_queue1 <=> std_queue3) >= 0);
 
-        tests::compare("Queue1 <=> queue3 vs std >=",
-            (queue1 <=> queue3) != std::weak_ordering::less, (std_queue1 <=> std_queue3) != std::weak_ordering::less);
-        tests::compare("Queue1 <=> queue3 vs std ==",
-            (queue1 <=> queue3) == std::weak_ordering::equivalent, (std_queue1 <=> std_queue3) == std::weak_ordering::equivalent);
-        tests::compare("Queue1 <=> queue3 vs std <= ",
-            (queue1 <=> queue3) != std::weak_ordering::greater, (std_queue1 <=> std_queue3) != std::weak_ordering::greater);
+        tests::compare("Queue1 <=> queue3 vs std >=", (queue1 <=> queue3) != std::weak_ordering::less,
+            (std_queue1 <=> std_queue3) != std::weak_ordering::less);
+        tests::compare("Queue1 <=> queue3 vs std ==", (queue1 <=> queue3) == std::weak_ordering::equivalent,
+            (std_queue1 <=> std_queue3) == std::weak_ordering::equivalent);
+        tests::compare("Queue1 <=> queue3 vs std <= ", (queue1 <=> queue3) != std::weak_ordering::greater,
+            (std_queue1 <=> std_queue3) != std::weak_ordering::greater);
 
         // test comparison categories
         static_assert(std::is_same_v<std::compare_three_way_result_t<std::queue<int>>, std::strong_ordering>,
@@ -220,8 +221,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
             "Double queue should support strong ordering");
 
         // test partial ordering
-        const std::queue<double> std_queue7{ std::deque<double>{1.0, 2.0, 3.0} };
-        const std::queue<double> std_queue8{ std::deque<double>{1.0, 2.0, std::numeric_limits<double>::quiet_NaN()} };
+        const std::queue<double> std_queue7{
+            std::deque<double>{ 1.0, 2.0, 3.0 }
+        };
+        const std::queue<double> std_queue8{
+            std::deque<double>{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() }
+        };
         assert((std_queue7 <=> std_queue8) == std::partial_ordering::unordered);
         assert((queue7 <=> queue8) == (std_queue7 <=> std_queue8));
         tests::compare("std_queue7 <=> std_queue8 weak ordering",
@@ -232,13 +237,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // test noexcept
 
         // operators
-        static_assert(!noexcept(
-            std::queue<tests::ThrowingType>{std::deque<tests::ThrowingType>(1)} ==
-            std::queue<tests::ThrowingType>{std::deque<tests::ThrowingType>(1)}));
-        static_assert(!noexcept(
-            std::queue<tests::ThrowingType>{std::deque < tests::ThrowingType>(1)} <=>
-            std::queue<tests::ThrowingType>{std::deque < tests::ThrowingType>(1)}));
-
+        static_assert(!noexcept(std::queue<tests::ThrowingType>{ std::deque<tests::ThrowingType>(1) } ==
+                                std::queue<tests::ThrowingType>{ std::deque<tests::ThrowingType>(1) }));
+        static_assert(!noexcept(std::queue<tests::ThrowingType>{ std::deque<tests::ThrowingType>(1) } <=>
+                                std::queue<tests::ThrowingType>{ std::deque<tests::ThrowingType>(1) }));
 
         tests::print_stats();
     }

--- a/tests/queue/queue_set_test.cpp
+++ b/tests/queue/queue_set_test.cpp
@@ -27,22 +27,21 @@ int main() // NOLINT(modernize-use-trailing-return-type)
     {
         std::cout << "Start queue_set_test:\n";
 
-        const std::initializer_list<int> expected{ 50,10,20 };
+        const std::initializer_list<int> expected{ 50, 10, 20 };
 
-        dsa::Queue<int> queue1 = dsa::Queue<int>({ 0,10,20 });
+        dsa::Queue<int> queue1 = dsa::Queue<int>({ 0, 10, 20 });
         queue1.front() = 50;
         tests::compare("Queue1", queue1, expected);
 
-        dsa::Queue<int> queue2 = dsa::Queue<int>({ 0,10,20 });
-        dsa::Queue<int> queue3 = dsa::Queue<int>({ 50,10,20 });
+        dsa::Queue<int> queue2 = dsa::Queue<int>({ 0, 10, 20 });
+        dsa::Queue<int> queue3 = dsa::Queue<int>({ 50, 10, 20 });
         queue2.swap(queue3);
         tests::compare("Queue2", queue2, dsa::Queue(dsa::List<int>{ 50, 10, 20 }));
-        tests::compare("Queue3", queue3, dsa::Queue(dsa::List<int>{  0, 10, 20 }));
+        tests::compare("Queue3", queue3, dsa::Queue(dsa::List<int>{ 0, 10, 20 }));
 
-        dsa::Queue<int> queue4 = dsa::Queue<int>({ 50,10,20 });
+        dsa::Queue<int> queue4 = dsa::Queue<int>({ 50, 10, 20 });
         queue4.swap(queue4);
         tests::compare("Queue4", queue4, expected);
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -71,7 +70,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_queue4.push(20);
         std_queue4.swap(std_queue4);
         tests::compare("Queue4 vs std", queue4, std_queue4);
-
 
         tests::print_stats();
     }

--- a/tests/queue/queue_shrink_test.cpp
+++ b/tests/queue/queue_shrink_test.cpp
@@ -27,20 +27,20 @@ int main() // NOLINT(modernize-use-trailing-return-type)
     {
         std::cout << "Start queue_shrink_test:\n";
 
-        dsa::Queue<int> queue1 = dsa::Queue<int>({ 0,10,20,30,40,50 });
+        dsa::Queue<int> queue1 = dsa::Queue<int>({ 0, 10, 20, 30, 40, 50 });
         queue1.pop();
         queue1.pop();
-        const std::initializer_list<int> expected1 = { 20,30,40,50 };
+        const std::initializer_list<int> expected1 = { 20, 30, 40, 50 };
         tests::compare("Queue1", queue1, expected1);
 
-        dsa::Queue<int> queue2 = dsa::Queue<int>({ 0,10,20 });
+        dsa::Queue<int> queue2 = dsa::Queue<int>({ 0, 10, 20 });
         queue2.pop();
         queue2.pop();
         queue2.pop();
-        const std::initializer_list<int> expected2 = std::initializer_list<int>{ };
+        const std::initializer_list<int> expected2 = std::initializer_list<int>{};
         tests::compare("Queue2", queue2, expected2);
 
-        const dsa::Queue<int> queue3 = dsa::Queue<int>({ 0,10,20 });
+        const dsa::Queue<int> queue3 = dsa::Queue<int>({ 0, 10, 20 });
         tests::compare("Queue3.size()", queue3.size(), static_cast<size_t>(3));
 
         dsa::Queue<int> queue4 = dsa::Queue<int>();
@@ -50,21 +50,20 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const dsa::Queue<int> queue5;
         tests::compare("Queue5.empty()", queue5.empty(), true);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
-        std::queue<int> std_queue1 = std::queue<int>({ 0,10,20,30,40,50 });
+        std::queue<int> std_queue1 = std::queue<int>({ 0, 10, 20, 30, 40, 50 });
         std_queue1.pop();
         std_queue1.pop();
         tests::compare("Queue1 vs std", queue1, std_queue1);
 
-        std::queue<int> std_queue2 = std::queue<int>({ 0,10,20 });
+        std::queue<int> std_queue2 = std::queue<int>({ 0, 10, 20 });
         std_queue2.pop();
         std_queue2.pop();
         std_queue2.pop();
         tests::compare("Queue2 vs std", queue2, std_queue2);
 
-        const std::queue<int> std_queue3 = std::queue<int>({ 0,10,20 });
+        const std::queue<int> std_queue3 = std::queue<int>({ 0, 10, 20 });
         tests::compare("Queue3.size() vs std", queue3.size(), std_queue3.size());
 
         const std::queue<int> std_queue4 = std::queue<int>();
@@ -73,7 +72,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         const std::queue<int> std_queue5;
         tests::compare("Queue5.empty() vs std", queue5.empty(), std_queue5.empty());
-
 
         tests::print_stats();
     }

--- a/tests/queue/queue_swap_test.cpp
+++ b/tests/queue/queue_swap_test.cpp
@@ -41,7 +41,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::Queue<int> queue3 = dsa::Queue<int>(il_1);
         dsa::Queue<int> queue4;
         queue3.swap(queue4);
-        const std::initializer_list<int> expected3 = { };
+        const std::initializer_list<int> expected3 = {};
         tests::compare("Queue3", queue3, expected3);
         const std::initializer_list<int> expected4 = { 1, 2, 3, 4, 5 };
         tests::compare("Queue4", queue4, expected4);
@@ -57,18 +57,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::Queue<int> queue7 = dsa::Queue<int>(il_1);
         dsa::Queue<int> queue8;
         dsa::swap(queue7, queue8);
-        const std::initializer_list<int> expected7 = { };
+        const std::initializer_list<int> expected7 = {};
         tests::compare("Queue7", queue7, expected7);
         const std::initializer_list<int> expected8 = il_1;
         tests::compare("Queue8", queue8, expected8);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<dsa::Queue<int>&>(),
-            std::declval<dsa::Queue<int>&>())));
+        static_assert(noexcept(swap(std::declval<dsa::Queue<int>&>(), std::declval<dsa::Queue<int>&>())));
         // swap throwing type
-        static_assert(noexcept(swap(std::declval<dsa::Queue<tests::ThrowingType>&>(),
-            std::declval<dsa::Queue<tests::ThrowingType>&>())));
-
+        static_assert(noexcept(
+            swap(std::declval<dsa::Queue<tests::ThrowingType>&>(), std::declval<dsa::Queue<tests::ThrowingType>&>())));
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -97,12 +95,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Queue8 vs std", queue8, std_queue8);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<std::queue<int>&>(),
-            std::declval<std::queue<int>&>())));
+        static_assert(noexcept(swap(std::declval<std::queue<int>&>(), std::declval<std::queue<int>&>())));
         // swap throwing type
-        static_assert(noexcept(swap(std::declval<std::queue<tests::ThrowingType>&>(),
-            std::declval<std::queue<tests::ThrowingType>&>())));
-
+        static_assert(noexcept(
+            swap(std::declval<std::queue<tests::ThrowingType>&>(), std::declval<std::queue<tests::ThrowingType>&>())));
 
         tests::print_stats();
     }

--- a/tests/stack/stack_ctors_test.cpp
+++ b/tests/stack/stack_ctors_test.cpp
@@ -29,7 +29,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
     {
         std::cout << "Start stack_ctors_test:\n";
 
-        const std::initializer_list<int> expected{ 20,10,0 };
+        const std::initializer_list<int> expected{ 20, 10, 0 };
 
         std::cout << "Default ctor\n";
         dsa::Stack<int> stack1;
@@ -48,7 +48,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const dsa::Stack<int> stack3({ 0, 10, 20 });
         tests::compare("Stack3", stack3, expected);
 
-
         std::cout << "Copy ctor\n";
         const dsa::Stack<int> stack4{ stack1 };
         tests::compare("Stack4", stack4, expected);
@@ -64,7 +63,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Stack5", stack5, expected);
 
         std::cout << "Copy self assignment ctor\n";
-        dsa::Stack<int> stack6{ dsa::List<int>({0, 10, 20}) };
+        dsa::Stack<int> stack6{ dsa::List<int>({ 0, 10, 20 }) };
         auto* pointer6 = &stack6;
         stack6 = *pointer6;
         tests::compare("Stack6", stack6, expected);
@@ -81,7 +80,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Stack8", stack8, expected);
 
         std::cout << "Move self assignment ctor\n";
-        dsa::Stack<int> stack9{ dsa::List<int>({0, 10, 20}) };
+        dsa::Stack<int> stack9{ dsa::List<int>({ 0, 10, 20 }) };
         auto* pointer9 = &stack9;
         stack9 = std::move(*pointer9);
         tests::compare("Stack9", stack9, expected);
@@ -101,7 +100,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const dsa::Stack<int> stack12(std::move(temp12));
         const std::initializer_list<int> expected12{ 30, 20, 10 };
         tests::compare("Stack12", stack12, expected12);
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -153,7 +151,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::deque<int> std_temp12 = { 10, 20, 30 };
         const std::stack<int> std_stack12(std::move(std_temp12));
         tests::compare("Stack12 vs std", stack12, std_stack12);
-
 
         tests::print_stats();
     }

--- a/tests/stack/stack_get_test.cpp
+++ b/tests/stack/stack_get_test.cpp
@@ -26,7 +26,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
     {
         std::cout << "Start stack_get_test:\n";
 
-        const std::initializer_list<int> expected{ 0,10,20 };
+        const std::initializer_list<int> expected{ 0, 10, 20 };
 
         dsa::Stack<int> stack1 = dsa::Stack<int>({ 20, 10, 0 });
         tests::compare("Stack1 top", stack1.top(), *expected.begin());
@@ -36,7 +36,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         const dsa::Stack<int> stack3 = dsa::Stack<int>({ 20, 10, 0 });
         tests::compare("Stack3 top", stack3.top(), *expected.begin());
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -48,7 +47,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         const std::stack<int> std_stack3 = std::stack<int>({ 20, 10, 0 });
         tests::compare("Stack3 top vs std", stack3.top(), std_stack3.top());
-
 
         tests::print_stats();
     }

--- a/tests/stack/stack_grow_test.cpp
+++ b/tests/stack/stack_grow_test.cpp
@@ -41,7 +41,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         stack2.emplace(10);
         tests::compare("Stack2", stack2, expected);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::stack<int> std_stack1 = std::stack<int>({ 40 });
@@ -56,7 +55,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_stack2.emplace(20);
         std_stack2.emplace(10);
         tests::compare("Stack2 vs std", stack2, std_stack2);
-
 
         tests::print_stats();
     }

--- a/tests/stack/stack_operators_test.cpp
+++ b/tests/stack/stack_operators_test.cpp
@@ -116,21 +116,22 @@ int main() // NOLINT(modernize-use-trailing-return-type)
             "Double stack should support strong ordering");
 
         // test partial ordering
-        const dsa::Stack<double> stack7{ dsa::List<double>{1.0, 2.0, 3.0} };
-        const dsa::Stack<double> stack8{ dsa::List<double>{1.0, 2.0, std::numeric_limits<double>::quiet_NaN()} };
+        const dsa::Stack<double> stack7{
+            dsa::List<double>{ 1.0, 2.0, 3.0 }
+        };
+        const dsa::Stack<double> stack8{
+            dsa::List<double>{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() }
+        };
         assert((stack7 <=> stack8) == std::partial_ordering::unordered);
         tests::compare("Stack7 <=> stack8 weak ordering", (stack7 <=> stack8) != std::weak_ordering::less, true);
 
         // test noexcept
 
         // operators
-        static_assert(!noexcept(
-            dsa::Stack<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)} ==
-            dsa::Stack<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)}));
-        static_assert(!noexcept(
-            dsa::Stack<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)} <=>
-            dsa::Stack<tests::ThrowingType>{dsa::List<tests::ThrowingType>(1)}));
-
+        static_assert(!noexcept(dsa::Stack<tests::ThrowingType>{ dsa::List<tests::ThrowingType>(1) } ==
+                                dsa::Stack<tests::ThrowingType>{ dsa::List<tests::ThrowingType>(1) }));
+        static_assert(!noexcept(dsa::Stack<tests::ThrowingType>{ dsa::List<tests::ThrowingType>(1) } <=>
+                                dsa::Stack<tests::ThrowingType>{ dsa::List<tests::ThrowingType>(1) }));
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -164,12 +165,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Stack1 <=> stack2 vs std <=", (stack1 <=> stack2) <= 0, (std_stack1 <=> std_stack2) <= 0);
         tests::compare("Stack1 <=> stack2 vs std >=", (stack1 <=> stack2) >= 0, (std_stack1 <=> std_stack2) >= 0);
 
-        tests::compare("Stack1 <=> stack2 vs std <",
-            (stack1 <=> stack2) == std::weak_ordering::less, (std_stack1 <=> std_stack2) == std::weak_ordering::less);
-        tests::compare("Stack1 <=> stack2 vs std <>",
-            (stack1 <=> stack2) != std::weak_ordering::equivalent, (std_stack1 <=> std_stack2) != std::weak_ordering::equivalent);
-        tests::compare("Stack1 <=> stack2 vs std <=",
-            (stack1 <=> stack2) != std::weak_ordering::greater, (std_stack1 <=> std_stack2) != std::weak_ordering::greater);
+        tests::compare("Stack1 <=> stack2 vs std <", (stack1 <=> stack2) == std::weak_ordering::less,
+            (std_stack1 <=> std_stack2) == std::weak_ordering::less);
+        tests::compare("Stack1 <=> stack2 vs std <>", (stack1 <=> stack2) != std::weak_ordering::equivalent,
+            (std_stack1 <=> std_stack2) != std::weak_ordering::equivalent);
+        tests::compare("Stack1 <=> stack2 vs std <=", (stack1 <=> stack2) != std::weak_ordering::greater,
+            (std_stack1 <=> std_stack2) != std::weak_ordering::greater);
 
         std::cout << "Compare operators for objects of different size\n\n";
 
@@ -205,12 +206,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Stack1 <=> stack3 vs std <=", (stack1 <=> stack3) <= 0, (std_stack1 <=> std_stack3) <= 0);
         tests::compare("Stack1 <=> stack3 vs std >=", (stack1 <=> stack3) >= 0, (std_stack1 <=> std_stack3) >= 0);
 
-        tests::compare("Stack1 <=> stack3 vs std >=",
-            (stack1 <=> stack3) != std::weak_ordering::less, (std_stack1 <=> std_stack3) != std::weak_ordering::less);
-        tests::compare("Stack1 <=> stack3 vs std ==",
-            (stack1 <=> stack3) == std::weak_ordering::equivalent, (std_stack1 <=> std_stack3) == std::weak_ordering::equivalent);
-        tests::compare("Stack1 <=> stack3 vs std <= ",
-            (stack1 <=> stack3) != std::weak_ordering::greater, (std_stack1 <=> std_stack3) != std::weak_ordering::greater);
+        tests::compare("Stack1 <=> stack3 vs std >=", (stack1 <=> stack3) != std::weak_ordering::less,
+            (std_stack1 <=> std_stack3) != std::weak_ordering::less);
+        tests::compare("Stack1 <=> stack3 vs std ==", (stack1 <=> stack3) == std::weak_ordering::equivalent,
+            (std_stack1 <=> std_stack3) == std::weak_ordering::equivalent);
+        tests::compare("Stack1 <=> stack3 vs std <= ", (stack1 <=> stack3) != std::weak_ordering::greater,
+            (std_stack1 <=> std_stack3) != std::weak_ordering::greater);
 
         // test comparison categories
         static_assert(std::is_same_v<std::compare_three_way_result_t<std::stack<int>>, std::strong_ordering>,
@@ -220,8 +221,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
             "Double stack should support strong ordering");
 
         // test partial ordering
-        const std::stack<double> std_stack7{ std::deque<double>{1.0, 2.0, 3.0} };
-        const std::stack<double> std_stack8{ std::deque<double>{1.0, 2.0, std::numeric_limits<double>::quiet_NaN()} };
+        const std::stack<double> std_stack7{
+            std::deque<double>{ 1.0, 2.0, 3.0 }
+        };
+        const std::stack<double> std_stack8{
+            std::deque<double>{ 1.0, 2.0, std::numeric_limits<double>::quiet_NaN() }
+        };
         assert((std_stack7 <=> std_stack8) == std::partial_ordering::unordered);
         assert((stack7 <=> stack8) == (std_stack7 <=> std_stack8));
         tests::compare("std_stack7 <=> std_stack8 weak ordering",
@@ -232,13 +237,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // test noexcept
 
         // operators
-        static_assert(!noexcept(
-            std::stack<tests::ThrowingType>{std::deque<tests::ThrowingType>(1)} ==
-            std::stack<tests::ThrowingType>{std::deque<tests::ThrowingType>(1)}));
-        static_assert(!noexcept(
-            std::stack<tests::ThrowingType>{std::deque < tests::ThrowingType>(1)} <=>
-            std::stack<tests::ThrowingType>{std::deque < tests::ThrowingType>(1)}));
-
+        static_assert(!noexcept(std::stack<tests::ThrowingType>{ std::deque<tests::ThrowingType>(1) } ==
+                                std::stack<tests::ThrowingType>{ std::deque<tests::ThrowingType>(1) }));
+        static_assert(!noexcept(std::stack<tests::ThrowingType>{ std::deque<tests::ThrowingType>(1) } <=>
+                                std::stack<tests::ThrowingType>{ std::deque<tests::ThrowingType>(1) }));
 
         tests::print_stats();
     }

--- a/tests/stack/stack_set_test.cpp
+++ b/tests/stack/stack_set_test.cpp
@@ -27,22 +27,21 @@ int main() // NOLINT(modernize-use-trailing-return-type)
     {
         std::cout << "Start stack_set_test:\n";
 
-        const std::initializer_list<int> expected{ 50,10,0 };
+        const std::initializer_list<int> expected{ 50, 10, 0 };
 
-        dsa::Stack<int> stack1 = dsa::Stack<int>({ 0,10,20 });
+        dsa::Stack<int> stack1 = dsa::Stack<int>({ 0, 10, 20 });
         stack1.top() = 50;
         tests::compare("Stack1", stack1, expected);
 
-        dsa::Stack<int> stack2 = dsa::Stack<int>({ 0,10,20 });
-        dsa::Stack<int> stack3 = dsa::Stack<int>({ 0,10,50 });
+        dsa::Stack<int> stack2 = dsa::Stack<int>({ 0, 10, 20 });
+        dsa::Stack<int> stack3 = dsa::Stack<int>({ 0, 10, 50 });
         stack2.swap(stack3);
         tests::compare("Stack2", stack2, dsa::Stack(dsa::List<int>{ 0, 10, 50 }));
         tests::compare("Stack3", stack3, dsa::Stack(dsa::List<int>{ 0, 10, 20 }));
 
-        dsa::Stack<int> stack4 = dsa::Stack<int>({ 0,10,50 });
+        dsa::Stack<int> stack4 = dsa::Stack<int>({ 0, 10, 50 });
         stack4.swap(stack4);
         tests::compare("Stack4", stack4, expected);
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -71,7 +70,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std_stack4.push(50);
         std_stack4.swap(std_stack4);
         tests::compare("Stack4 vs std", stack4, std_stack4);
-
 
         tests::print_stats();
     }

--- a/tests/stack/stack_shrink_test.cpp
+++ b/tests/stack/stack_shrink_test.cpp
@@ -27,20 +27,20 @@ int main() // NOLINT(modernize-use-trailing-return-type)
     {
         std::cout << "Start stack_shrink_test:\n";
 
-        dsa::Stack<int> stack1 = dsa::Stack<int>({ 0,10,20,30,40,50 });
+        dsa::Stack<int> stack1 = dsa::Stack<int>({ 0, 10, 20, 30, 40, 50 });
         stack1.pop();
         stack1.pop();
-        const std::initializer_list<int> expected1 = { 30,20,10,0 };
+        const std::initializer_list<int> expected1 = { 30, 20, 10, 0 };
         tests::compare("Stack1", stack1, expected1);
 
-        dsa::Stack<int> stack2 = dsa::Stack<int>({ 0,10,20 });
+        dsa::Stack<int> stack2 = dsa::Stack<int>({ 0, 10, 20 });
         stack2.pop();
         stack2.pop();
         stack2.pop();
-        const std::initializer_list<int> expected2 = std::initializer_list<int>{ };
+        const std::initializer_list<int> expected2 = std::initializer_list<int>{};
         tests::compare("Stack2", stack2, expected2);
 
-        const dsa::Stack<int> stack3 = dsa::Stack<int>({ 0,10,20 });
+        const dsa::Stack<int> stack3 = dsa::Stack<int>({ 0, 10, 20 });
         tests::compare("Stack3.size()", stack3.size(), static_cast<size_t>(3));
 
         dsa::Stack<int> stack4 = dsa::Stack<int>();
@@ -50,21 +50,20 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const dsa::Stack<int> stack5;
         tests::compare("Stack5.size()", stack5.size(), static_cast<size_t>(0));
 
-
         std::cout << "Compare operations results with std container\n\n";
 
-        std::stack<int> std_stack1 = std::stack<int>({ 0,10,20,30,40,50 });
+        std::stack<int> std_stack1 = std::stack<int>({ 0, 10, 20, 30, 40, 50 });
         std_stack1.pop();
         std_stack1.pop();
         tests::compare("Stack1 vs std", stack1, std_stack1);
 
-        std::stack<int> std_stack2 = std::stack<int>({ 0,10,20 });
+        std::stack<int> std_stack2 = std::stack<int>({ 0, 10, 20 });
         std_stack2.pop();
         std_stack2.pop();
         std_stack2.pop();
         tests::compare("Stack2 vs std", stack2, std_stack2);
 
-        const std::stack<int> std_stack3 = std::stack<int>({ 0,10,20 });
+        const std::stack<int> std_stack3 = std::stack<int>({ 0, 10, 20 });
         tests::compare("Stack3.size() vs std", stack3.size(), std_stack3.size());
 
         const std::stack<int> std_stack4 = std::stack<int>();
@@ -73,7 +72,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         const std::stack<int> std_stack5;
         tests::compare("Stack5.empty() vs std", stack5.empty(), std_stack5.empty());
-
 
         tests::print_stats();
     }

--- a/tests/stack/stack_swap_test.cpp
+++ b/tests/stack/stack_swap_test.cpp
@@ -41,7 +41,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::Stack<int> stack3 = dsa::Stack<int>(il_1);
         dsa::Stack<int> stack4;
         stack3.swap(stack4);
-        const std::initializer_list<int> expected3 = { };
+        const std::initializer_list<int> expected3 = {};
         tests::compare("Stack3", stack3, expected3);
         const std::initializer_list<int> expected4 = { 5, 4, 3, 2, 1 };
         tests::compare("Stack4", stack4, expected4);
@@ -57,18 +57,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::Stack<int> stack7 = dsa::Stack<int>(il_1);
         dsa::Stack<int> stack8;
         dsa::swap(stack7, stack8);
-        const std::initializer_list<int> expected7 = { };
+        const std::initializer_list<int> expected7 = {};
         tests::compare("Stack7", stack7, expected7);
         const std::initializer_list<int> expected8 = { 5, 4, 3, 2, 1 };
         tests::compare("Stack8", stack8, expected8);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<dsa::Stack<int>&>(),
-            std::declval<dsa::Stack<int>&>())));
+        static_assert(noexcept(swap(std::declval<dsa::Stack<int>&>(), std::declval<dsa::Stack<int>&>())));
         // swap throwing type
-        static_assert(noexcept(swap(std::declval<dsa::Stack<tests::ThrowingType>&>(),
-            std::declval<dsa::Stack<tests::ThrowingType>&>())));
-
+        static_assert(noexcept(
+            swap(std::declval<dsa::Stack<tests::ThrowingType>&>(), std::declval<dsa::Stack<tests::ThrowingType>&>())));
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -97,12 +95,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Stack8 vs std", stack8, std_stack8);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<std::stack<int>&>(),
-            std::declval<std::stack<int>&>())));
+        static_assert(noexcept(swap(std::declval<std::stack<int>&>(), std::declval<std::stack<int>&>())));
         // swap throwing type
-        static_assert(noexcept(swap(std::declval<std::stack<tests::ThrowingType>&>(),
-            std::declval<std::stack<tests::ThrowingType>&>())));
-
+        static_assert(noexcept(
+            swap(std::declval<std::stack<tests::ThrowingType>&>(), std::declval<std::stack<tests::ThrowingType>&>())));
 
         tests::print_stats();
     }

--- a/tests/vector/vector_ctors_test.cpp
+++ b/tests/vector/vector_ctors_test.cpp
@@ -96,7 +96,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected12{ 10, 20, 30 };
         tests::compare("Vector12", vector12, expected12);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::vector<int> std_vector1;

--- a/tests/vector/vector_grow_test.cpp
+++ b/tests/vector/vector_grow_test.cpp
@@ -141,7 +141,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected15 = { 0, 10, 20, 30, 40 };
         tests::compare("Vector15", vector15, expected15);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::vector<int> std_vector5{ 10, 20, 30 };
@@ -155,7 +154,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::vector<int> std_vector7{ 40 };
         std_vector7.insert(std_vector7.begin(), { 10, 20, 30 });
         tests::compare("Vector7 vs std", vector7, std_vector7);
-
 
         tests::print_stats();
     }

--- a/tests/vector/vector_itors_test.cpp
+++ b/tests/vector/vector_itors_test.cpp
@@ -291,7 +291,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("vector19 rbegin() == rend()", vector19.rbegin() == vector19.rend(), true);
         tests::compare("vector19 rend() == crend()", vector19.rend() == vector19.crend(), true);
         tests::compare("vector19 size()", vector19.size(), static_cast<std::size_t>(0));
-        tests::compare("vector19 max_size()", vector19.max_size(), std::numeric_limits<std::size_t>::max() / sizeof(int));
+        tests::compare("vector19 max_size()", vector19.max_size(),
+            std::numeric_limits<std::size_t>::max() / sizeof(int));
         tests::compare("vector19 empty()", vector19.empty(), true);
 
         // test element access
@@ -337,11 +338,11 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         // use lambda expression as workaround to prevent inlining call to const data()
         auto use_const_data = [](const auto& vector)
-            {
-                const int* ptr = vector.data();
-                (void)ptr;
-                return ptr;
-            };
+        {
+            const int* ptr = vector.data();
+            (void)ptr;
+            return ptr;
+        };
         const dsa::Vector<int> vector23{ 10, 20, 30 };
         const auto* ptr_vector23 = use_const_data(vector23);
         static_assert(std::is_same_v<decltype(vector23.data()), const int*>, "data() must return const T*");
@@ -357,7 +358,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         {
             std::cout << "vector24 out of range exception handled correctly\n\n";
         }
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -380,7 +380,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         const std::vector<int> std_vector3{ 0, 10, 20 };
         // NOLINTNEXTLINE(modernize-loop-convert, modernize-use-auto)
-        for (std::vector<int>::const_iterator std_iter = std_vector3.cbegin(); std_iter != std_vector3.cend(); std_iter++)
+        for (std::vector<int>::const_iterator std_iter = std_vector3.cbegin(); std_iter != std_vector3.cend();
+            std_iter++)
         {
             std::cout << (*std_iter) << '\t';
         }
@@ -401,7 +402,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector5 iterator vs std", expectedval5, val);
         tests::compare("Vector5 vs std", vector5, expected5);
 
-        std::vector<int>std_vector6 = std::vector<int>(1, 30);
+        std::vector<int> std_vector6 = std::vector<int>(1, 30);
         std_vector6.push_back(40);
         std_vector6.push_back(50);
         std_iterator = std_vector6.insert(std_vector6.cbegin(), 0, 5);
@@ -409,19 +410,19 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector6 iterator vs std", expectedval6, val);
         tests::compare("Vector6 vs std", vector6, std_vector6);
 
-        std::vector<int>std_vector9 = std::vector<int>{ 10, 20, 30, 40, 50 };
+        std::vector<int> std_vector9 = std::vector<int>{ 10, 20, 30, 40, 50 };
         // use classic iterator based algorithms, separate test was added to test std::ranges based algorithms
         // NOLINTNEXTLINE(modernize-use-ranges)
         std::fill(std_vector9.begin(), std_vector9.end(), 10);
         tests::compare("Vector9 vs std", vector9, std_vector9);
 
-        std::vector<int>std_vector10 = std::vector<int>{ 10, 20, 30 };
+        std::vector<int> std_vector10 = std::vector<int>{ 10, 20, 30 };
         auto std_iter10b = std_vector10.begin();
         *std_iter10b = 1;
         auto std_citer10b = std_vector10.cbegin();
         tests::compare("citer10b vs std", *citer10b, *std_citer10b);
 
-        const std::vector<int>std_vector11 = std::vector<int>{ 10, 20, 30 };
+        const std::vector<int> std_vector11 = std::vector<int>{ 10, 20, 30 };
         auto std_iter11b = std_vector11.begin();
         tests::compare("iter11b vs std", *iter11b, *std_iter11b);
 
@@ -441,7 +442,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::advance(iter16, -1);
         std::advance(std_iter16, -1);
         tests::compare("vector16 vs std end()--", *iter16, *std_iter16);
-        tests::compare("vector16 vs std end()-- == back()", *iter16 == vector16.back(), *std_iter16 == std_vector16.back());
+        tests::compare("vector16 vs std end()-- == back()", *iter16 == vector16.back(),
+            *std_iter16 == std_vector16.back());
         tests::compare("vector16 vs std iter", vector16, std_vector16);
 
         // test const iterator traversal
@@ -474,18 +476,18 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         // test empty vector
         std::vector<int> std_vector19{};
-        tests::compare("vector19 vs std begin() == cbegin()",
-            vector19.begin() == vector19.cbegin(), std_vector19.begin() == std_vector19.cbegin());
-        tests::compare("vector19 vs std begin() == end()",
-            vector19.begin() == vector19.end(), std_vector19.begin() == std_vector19.end());
-        tests::compare("vector19 vs std end() == cend()",
-            vector19.end() == vector19.cend(), std_vector19.end() == std_vector19.cend());
-        tests::compare("vector19 vs std rbegin() == crbegin()",
-            vector19.rbegin() == vector19.crbegin(), std_vector19.rbegin() == std_vector19.crbegin());
-        tests::compare("vector19 vs std rbegin() == rend()",
-            vector19.rbegin() == vector19.rend(), std_vector19.rbegin() == std_vector19.rend());
-        tests::compare("vector19 vs std rend() == crend()",
-            vector19.rend() == vector19.crend(), std_vector19.rend() == std_vector19.crend());
+        tests::compare("vector19 vs std begin() == cbegin()", vector19.begin() == vector19.cbegin(),
+            std_vector19.begin() == std_vector19.cbegin());
+        tests::compare("vector19 vs std begin() == end()", vector19.begin() == vector19.end(),
+            std_vector19.begin() == std_vector19.end());
+        tests::compare("vector19 vs std end() == cend()", vector19.end() == vector19.cend(),
+            std_vector19.end() == std_vector19.cend());
+        tests::compare("vector19 vs std rbegin() == crbegin()", vector19.rbegin() == vector19.crbegin(),
+            std_vector19.rbegin() == std_vector19.crbegin());
+        tests::compare("vector19 vs std rbegin() == rend()", vector19.rbegin() == vector19.rend(),
+            std_vector19.rbegin() == std_vector19.rend());
+        tests::compare("vector19 vs std rend() == crend()", vector19.rend() == vector19.crend(),
+            std_vector19.rend() == std_vector19.crend());
 
         // test element access
         std::vector<int> std_vector20{ 10, 20, 30 };
@@ -503,7 +505,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("vector22 vs std at(1) ", vector22.at(1), std_vector22.at(1));
         tests::compare("vector22 vs std back()", vector22.back(), std_vector22.back());
         tests::compare("vector22() vs std", vector22, std_vector22);
-
 
         tests::print_stats();
     }

--- a/tests/vector/vector_operators_test.cpp
+++ b/tests/vector/vector_operators_test.cpp
@@ -68,7 +68,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector1 <=> vector2 <>", (vector1 <=> vector2) != std::weak_ordering::equivalent, true);
         tests::compare("Vector1 <=> vector2 <=", (vector1 <=> vector2) != std::weak_ordering::greater, true);
 
-
         std::cout << "Compare operators for objects of different size\n\n";
 
         tests::compare("Vector1 == vector3", vector1 == vector3, false);
@@ -106,7 +105,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector1 <=> vector3 ==", (vector1 <=> vector3) == std::weak_ordering::equivalent, false);
         tests::compare("Vector1 <=> vector3 <=", (vector1 <=> vector3) != std::weak_ordering::greater, true);
 
-
         // test comparison categories
         static_assert(std::is_same_v<std::compare_three_way_result_t<dsa::Vector<int>>, std::strong_ordering>,
             "Int vector should support strong ordering");
@@ -123,9 +121,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // test noexcept
 
         // operators
-        static_assert(!noexcept(dsa::Vector<tests::ThrowingType>{1} == dsa::Vector<tests::ThrowingType>{1}));
-        static_assert(!noexcept(dsa::Vector<tests::ThrowingType>{1} <=> dsa::Vector<tests::ThrowingType>{1}));
-
+        static_assert(!noexcept(dsa::Vector<tests::ThrowingType>{ 1 } == dsa::Vector<tests::ThrowingType>{ 1 }));
+        static_assert(!noexcept(dsa::Vector<tests::ThrowingType>{ 1 } <=> dsa::Vector<tests::ThrowingType>{ 1 }));
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -159,13 +156,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector1 <=> vector2 vs std <=", (vector1 <=> vector2) <= 0, (std_vector1 <=> std_vector2) <= 0);
         tests::compare("Vector1 <=> vector2 vs std >=", (vector1 <=> vector2) >= 0, (std_vector1 <=> std_vector2) >= 0);
 
-        tests::compare("Vector1 <=> vector2 vs std <",
-            (vector1 <=> vector2) == std::weak_ordering::less, (std_vector1 <=> std_vector2) == std::weak_ordering::less);
-        tests::compare("Vector1 <=> vector2 vs std <>",
-            (vector1 <=> vector2) != std::weak_ordering::equivalent, (std_vector1 <=> std_vector2) != std::weak_ordering::equivalent);
-        tests::compare("Vector1 <=> vector2 vs std <=",
-            (vector1 <=> vector2) != std::weak_ordering::greater, (std_vector1 <=> std_vector2) != std::weak_ordering::greater);
-
+        tests::compare("Vector1 <=> vector2 vs std <", (vector1 <=> vector2) == std::weak_ordering::less,
+            (std_vector1 <=> std_vector2) == std::weak_ordering::less);
+        tests::compare("Vector1 <=> vector2 vs std <>", (vector1 <=> vector2) != std::weak_ordering::equivalent,
+            (std_vector1 <=> std_vector2) != std::weak_ordering::equivalent);
+        tests::compare("Vector1 <=> vector2 vs std <=", (vector1 <=> vector2) != std::weak_ordering::greater,
+            (std_vector1 <=> std_vector2) != std::weak_ordering::greater);
 
         std::cout << "Compare operators for objects of different size\n\n";
 
@@ -201,12 +197,12 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector1 <=> vector3 vs std <=", (vector1 <=> vector3) <= 0, (std_vector1 <=> std_vector3) <= 0);
         tests::compare("Vector1 <=> vector3 vs std >=", (vector1 <=> vector3) >= 0, (std_vector1 <=> std_vector3) >= 0);
 
-        tests::compare("Vector1 <=> vector3 vs std >=",
-            (vector1 <=> vector3) != std::weak_ordering::less, (std_vector1 <=> std_vector3) != std::weak_ordering::less);
-        tests::compare("Vector1 <=> vector3 vs std ==",
-            (vector1 <=> vector3) == std::weak_ordering::equivalent, (std_vector1 <=> std_vector3) == std::weak_ordering::equivalent);
-        tests::compare("Vector1 <=> vector3 vs std <= ",
-            (vector1 <=> vector3) != std::weak_ordering::greater, (std_vector1 <=> std_vector3) != std::weak_ordering::greater);
+        tests::compare("Vector1 <=> vector3 vs std >=", (vector1 <=> vector3) != std::weak_ordering::less,
+            (std_vector1 <=> std_vector3) != std::weak_ordering::less);
+        tests::compare("Vector1 <=> vector3 vs std ==", (vector1 <=> vector3) == std::weak_ordering::equivalent,
+            (std_vector1 <=> std_vector3) == std::weak_ordering::equivalent);
+        tests::compare("Vector1 <=> vector3 vs std <= ", (vector1 <=> vector3) != std::weak_ordering::greater,
+            (std_vector1 <=> std_vector3) != std::weak_ordering::greater);
 
         // test comparison categories
         static_assert(std::is_same_v<std::compare_three_way_result_t<std::vector<int>>, std::strong_ordering>,
@@ -228,9 +224,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // test noexcept
 
         // operators
-        static_assert(!noexcept(std::vector<tests::ThrowingType>{1} == std::vector<tests::ThrowingType>{1}));
-        static_assert(!noexcept(std::vector<tests::ThrowingType>{1} <=> std::vector<tests::ThrowingType>{1}));
-
+        static_assert(!noexcept(std::vector<tests::ThrowingType>{ 1 } == std::vector<tests::ThrowingType>{ 1 }));
+        static_assert(!noexcept(std::vector<tests::ThrowingType>{ 1 } <=> std::vector<tests::ThrowingType>{ 1 }));
 
         tests::print_stats();
     }

--- a/tests/vector/vector_ranges_test.cpp
+++ b/tests/vector/vector_ranges_test.cpp
@@ -122,7 +122,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         static_assert(std::ranges::common_range<vector_t>);
         static_assert(std::ranges::common_range<const_vector_t>);
 
-        // test if iterators are indirectly readable 
+        // test if iterators are indirectly readable
         static_assert(std::indirectly_readable<vector_t::iterator>);
         static_assert(std::indirectly_readable<vector_t::const_iterator>);
 
@@ -180,9 +180,8 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const int sum = std::accumulate(vector3.begin(), vector3.end(), 0);
         tests::compare("Vector3 sum", sum, 80);
         std::list<int> expected3;
-        std::ranges::for_each(vector3, [&](int item) {expected3.push_back(item); });
-        tests::compare("Vector3 for_each() equal()",
-            std::ranges::equal(expected3, std::list{ 30, 10, 40 }), true);
+        std::ranges::for_each(vector3, [&](int item) { expected3.push_back(item); });
+        tests::compare("Vector3 for_each() equal()", std::ranges::equal(expected3, std::list{ 30, 10, 40 }), true);
 
         // test std::ranges::reverse_viev
         const dsa::Vector<int> vector4{ 10, 20, 30 };
@@ -259,7 +258,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::Vector<int> vector15 = dsa::Vector<int>({ 0, 0, 0, 0, 0, 0 });
         auto it15 = std::ranges::remove(vector15, 0);
         vector15.erase(it15.begin(), vector15.end());
-        const std::initializer_list<int> expected15 = { };
+        const std::initializer_list<int> expected15 = {};
         tests::compare("vector15", vector15, expected15);
 
         // test std::ranges::begin and ::end
@@ -320,7 +319,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector22[2]", *std::next(vector22.begin(), 2), 30);
         tests::compare("Vector22[3]", *std::next(vector22.begin(), 3), 40);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::vector<int> std_vector2{};
@@ -344,18 +342,17 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         std::vector<int> std_vector10{};
         tests::compare("Vector10 vs std empty()", vector10.empty(), std_vector10.empty());
-        tests::compare("Vector10 vs std begin() == end()",
-            vector10.begin() == vector10.end(), std_vector10.begin() == std_vector10.end());
-        tests::compare("Vector10 vs std distance",
-            std::ranges::distance(vector10), std::ranges::distance(vector10));
+        tests::compare("Vector10 vs std begin() == end()", vector10.begin() == vector10.end(),
+            std_vector10.begin() == std_vector10.end());
+        tests::compare("Vector10 vs std distance", std::ranges::distance(vector10), std::ranges::distance(vector10));
 
         std::vector<int> std_vector11(3);
         std_vector11.at(0) = 10;
         tests::compare("Vector11 vs std empty()", vector11.empty(), std_vector11.empty());
         tests::compare("Vector11 vs std front() == back()", vector11.front(), std_vector11.front());
         tests::compare("Vector11 vs std front() == back()", vector11.back(), std_vector11.back());
-        tests::compare("Vector11 vs std distance",
-            std::ranges::distance(vector11), std::ranges::distance(std_vector11));
+        tests::compare("Vector11 vs std distance", std::ranges::distance(vector11),
+            std::ranges::distance(std_vector11));
 
         std::vector<int> std_vector12{ 40, 30, 20, 10 };
         std::ranges::sort(std_vector12);
@@ -376,10 +373,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("vector15 vs std", vector15, std_vector15);
 
         std::vector<int> std_vector16{};
-        tests::compare("Vector16 vs std begin()",
-            std::ranges::begin(vector16) == vector16.begin(), std::ranges::begin(std_vector16) == std_vector16.begin());
-        tests::compare("Vector16 vs std end()",
-            std::ranges::end(vector16) == vector16.end(), std::ranges::end(std_vector16) == std_vector16.end());
+        tests::compare("Vector16 vs std begin()", std::ranges::begin(vector16) == vector16.begin(),
+            std::ranges::begin(std_vector16) == std_vector16.begin());
+        tests::compare("Vector16 vs std end()", std::ranges::end(vector16) == vector16.end(),
+            std::ranges::end(std_vector16) == std_vector16.end());
 
         std::vector<int> std_vector17{ 10, 20, 30, 40, 50 };
         auto std_vector17_begin{ std::ranges::begin(std_vector17) };
@@ -395,7 +392,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::advance(std_it21, 1);
         *std_it21 = 30;
         tests::compare("Vector21 vs std", vector21, std_vector21);
-
 
         tests::print_stats();
     }

--- a/tests/vector/vector_resize_test.cpp
+++ b/tests/vector/vector_resize_test.cpp
@@ -75,14 +75,15 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::Vector<int> vector10 = dsa::Vector<int>({ 1, 2, 3, 4, 5 });
         vector10.resize(0);
-        const std::initializer_list<int> expected10 = { };
+        const std::initializer_list<int> expected10 = {};
         tests::compare("Vector10", vector10, expected10);
 
         // test empty vector
         const dsa::Vector<int> vector11;
         tests::compare("vector11 empty()", vector11.empty(), true);
         tests::compare("vector11 size()", vector11.size(), static_cast<std::size_t>(0));
-        tests::compare("vector11 max_size()", vector11.max_size(), std::numeric_limits<std::size_t>::max() / sizeof(int));
+        tests::compare("vector11 max_size()", vector11.max_size(),
+            std::numeric_limits<std::size_t>::max() / sizeof(int));
 
         // test throwing 'length_error' exception from resize
         try
@@ -105,7 +106,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         {
             std::cout << "vector13 length error exception handled correctly for reserve\n\n";
         }
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -152,7 +152,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("vector11 vs std empty()", vector11.empty(), std_vector11.empty());
         tests::compare("vector11 vs std size()", vector11.size(), std_vector11.size());
         tests::compare("vector11 vs std max_size()", vector11.max_size(), std_vector11_max_size);
-
 
         tests::print_stats();
     }

--- a/tests/vector/vector_set_test.cpp
+++ b/tests/vector/vector_set_test.cpp
@@ -52,7 +52,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected5 = { 1, 2, 3 };
         tests::compare("vector5", vector5, expected5);
 
-
         std::cout << "Compare operations results with std container\n\n";
 
         std::vector<int> std_vector1 = std::vector<int>({ 0, 10, 20 });
@@ -74,7 +73,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         std::vector<int> std_vector5 = std::vector<int>({ 0, 10, 20 });
         std_vector5.assign(temp5.begin() + 1, temp5.begin() + 4);
         tests::compare("vector5 vs std", vector5, std_vector5);
-
 
         tests::print_stats();
     }

--- a/tests/vector/vector_shrink_test.cpp
+++ b/tests/vector/vector_shrink_test.cpp
@@ -71,7 +71,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         // NOLINTNEXTLINE(modernize-use-ranges)
         auto* it6 = std::remove(vector6.begin(), vector6.end(), 0);
         vector6.erase(it6, vector6.end());
-        const std::initializer_list<int> expected6 = { };
+        const std::initializer_list<int> expected6 = {};
         tests::compare("Vector6", vector6, expected6);
 
         dsa::Vector<int> vector7 = dsa::Vector<int>({ 0 });
@@ -79,14 +79,14 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         vector7.clear();
         tests::compare(vector7.empty(), true);
         vector7.clear();
-        const std::initializer_list<int> expected7 = { };
+        const std::initializer_list<int> expected7 = {};
         tests::compare("Vector7", vector7, expected7);
 
         dsa::Vector<int> vector8 = dsa::Vector<int>({ 10, 20, 30 });
         vector8.erase(vector8.cbegin());
         vector8.erase(vector8.begin());
         vector8.erase(vector8.begin());
-        const std::initializer_list<int> expected8 = { };
+        const std::initializer_list<int> expected8 = {};
         tests::compare("Vector8", vector8, expected8);
         tests::compare("Vector8 size()", vector8.size(), static_cast<std::size_t>(0));
 
@@ -101,7 +101,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         vector10.pop_back();
         vector10.pop_back();
         vector10.pop_back();
-        const std::initializer_list<int> expected10 = { };
+        const std::initializer_list<int> expected10 = {};
         tests::compare("Vector10", vector10, expected10);
         tests::compare("Vector10 size()", vector10.size(), static_cast<std::size_t>(0));
 
@@ -124,7 +124,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::Vector<int> vector13 = dsa::Vector<int>({ 0, 0, 0, 0, 0, 0 });
         auto cnt13 = dsa::erase(vector13, 0);
-        const std::initializer_list<int> expected13 = { };
+        const std::initializer_list<int> expected13 = {};
         tests::compare("Vector13", vector13, expected13);
         tests::compare("Vector13 erase count", cnt13, std::size_t{ 6 });
 
@@ -136,7 +136,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
 
         dsa::Vector<int> vector15 = dsa::Vector<int>({ 0, 0, 0, 0, 0, 0 });
         auto cnt15 = dsa::erase_if(vector15, [](int val) { return val == 0; });
-        const std::initializer_list<int> expected15 = { };
+        const std::initializer_list<int> expected15 = {};
         tests::compare("Vector15", vector15, expected15);
         tests::compare("Vector15 erase_if count", cnt15, std::size_t{ 6 });
 
@@ -151,7 +151,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         const std::initializer_list<int> expected17 = { 10, 7, 9 };
         tests::compare("Vector17", vector17, expected17);
         tests::compare("Vector17 erase_if count", cnt17, std::size_t{ 3 });
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -211,7 +210,6 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         auto std_cnt17 = std::erase_if(std_vector17, [](int val) { return val <= 5; });
         tests::compare("Vector17 vs std", vector17, std_vector17);
         tests::compare("Vector17 vs std erase_if count", cnt17, std_cnt17);
-
 
         tests::print_stats();
     }

--- a/tests/vector/vector_swap_test.cpp
+++ b/tests/vector/vector_swap_test.cpp
@@ -41,7 +41,7 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::Vector<int> vector3 = dsa::Vector<int>(il_1);
         dsa::Vector<int> vector4;
         vector3.swap(vector4);
-        const std::initializer_list<int> expected3 = { };
+        const std::initializer_list<int> expected3 = {};
         tests::compare("Vector3", vector3, expected3);
         const std::initializer_list<int> expected4 = { 1, 2, 3, 4, 5 };
         tests::compare("Vector4", vector4, expected4);
@@ -62,18 +62,16 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         dsa::Vector<int> vector8 = dsa::Vector<int>(il_1);
         dsa::Vector<int> vector9;
         dsa::swap(vector8, vector9);
-        const std::initializer_list<int> expected8 = { };
+        const std::initializer_list<int> expected8 = {};
         tests::compare("Vector8", vector8, expected8);
         const std::initializer_list<int> expected9 = il_1;
         tests::compare("Vector9", vector9, expected9);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<dsa::Vector<int>&>(),
-            std::declval<dsa::Vector<int>&>())));
+        static_assert(noexcept(swap(std::declval<dsa::Vector<int>&>(), std::declval<dsa::Vector<int>&>())));
         // swap throwing type
         static_assert(noexcept(swap(std::declval<dsa::Vector<tests::ThrowingType>&>(),
             std::declval<dsa::Vector<tests::ThrowingType>&>())));
-
 
         std::cout << "Compare operations results with std container\n\n";
 
@@ -108,12 +106,10 @@ int main() // NOLINT(modernize-use-trailing-return-type)
         tests::compare("Vector9 vs std", vector9, std_vector9);
 
         // swap safe type
-        static_assert(noexcept(swap(std::declval<std::vector<int>&>(),
-            std::declval<std::vector<int>&>())));
+        static_assert(noexcept(swap(std::declval<std::vector<int>&>(), std::declval<std::vector<int>&>())));
         // swap throwing type
         static_assert(noexcept(swap(std::declval<std::vector<tests::ThrowingType>&>(),
             std::declval<std::vector<tests::ThrowingType>&>())));
-
 
         tests::print_stats();
     }


### PR DESCRIPTION
Add `clang-format` check to CI pipeline using GitHub Actions to improve code consistency and prevent formatting-related noise in reviews.

Closes #28

## Checklist:

- [x] use a project-wide `.clang-format` configuration file
- [x] consistency of formatting rules was checked in `clang-format` v19.1.7 (Ubuntu) and v22.1.3 (Windows)
- [x] add a GitHub Actions workflow step that runs clang-format on the codebase
- [x] CI checks only changed files (`git diff`)
- [x] CI passes when all checked files are properly formatted
- [x] CI fails when code is not formatted according to clang-format
- [x] add CMake targets to verify and format files in codebase
- [x] add documentation to `README.md` on how to run clang-format locally before pushing changes