### PR TITLE
Update Doxygen version used for documentation generation in GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -32,10 +32,10 @@ jobs:
       run: lsb_release -a
 
     # Install dependencies
-    - name: Install Doxygen 1.14
-      uses: ssciwr/doxygen-install@v1
+    - name: Install Doxygen
+      uses: ssciwr/doxygen-install@v2
       with:
-        version: "1.14.0"
+        version: "1.17.0"
 
     - name: Install Graphviz
       run: |

--- a/Doxyfile
+++ b/Doxyfile
@@ -2861,7 +2861,7 @@ INCLUDED_BY_GRAPH      = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALL_GRAPH             = NO
+CALL_GRAPH             = YES
 
 # If the CALLER_GRAPH tag is set to YES then Doxygen will generate a caller
 # dependency graph for every global function or class method.
@@ -2873,7 +2873,7 @@ CALL_GRAPH             = NO
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALLER_GRAPH           = NO
+CALLER_GRAPH           = YES
 
 # If the GRAPHICAL_HIERARCHY tag is set to YES then Doxygen will graphical
 # hierarchy of all classes instead of a textual one.
@@ -2917,7 +2917,7 @@ DIR_GRAPH_MAX_DEPTH    = 1
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 
 # If DOT_IMAGE_FORMAT is set to svg or svg:svg or svg:svg:core, then this option
 # can be set to YES to enable generation of interactive SVG images that allow

--- a/Doxyfile
+++ b/Doxyfile
@@ -1492,7 +1492,7 @@ HTML_STYLESHEET        =
 # documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_STYLESHEET  = docs/custom_doxygen.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note

--- a/Doxyfile
+++ b/Doxyfile
@@ -2667,7 +2667,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: NO.
 
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations Doxygen is allowed
 # to run in parallel. When set to 0 Doxygen will base this on the number of

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,4 +1,4 @@
-# Doxyfile 1.14.0
+# Doxyfile 1.17.0
 
 # This file describes the settings to be used by the documentation system
 # Doxygen (www.doxygen.org) for a project.
@@ -81,7 +81,7 @@ OUTPUT_DIRECTORY       = docs
 # and will distribute the generated files over these directories. Enabling this
 # option can be useful when feeding Doxygen a huge amount of source files, where
 # putting all generated files in the same directory would otherwise cause
-# performance problems for the file system. Adapt CREATE_SUBDIRS_LEVEL to
+# performance problems for the file system. Adjust CREATE_SUBDIRS_LEVEL to
 # control the number of sub-directories.
 # The default value is: NO.
 
@@ -361,6 +361,20 @@ EXTENSION_MAPPING      =
 
 MARKDOWN_SUPPORT       = YES
 
+# If the MARKDOWN_STRICT tag is enabled then Doxygen treats text in comments as
+# Markdown formatted also in cases where Doxygen's native markup format
+# conflicts with that of Markdown. This is only relevant in cases where
+# backticks are used. Doxygen's native markup style allows a single quote to end
+# a text fragment started with a backtick and then treat it as a piece of quoted
+# text, whereas in Markdown such text fragment is treated as verbatim and only
+# ends when a second matching backtick is found. Also, Doxygen's native markup
+# format requires double quotes to be escaped when they appear in a backtick
+# section, whereas this is not needed for Markdown.
+# The default value is: YES.
+# This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
+
+MARKDOWN_STRICT        = YES
+
 # When the TOC_INCLUDE_HEADINGS tag is set to a non-zero value, all headings up
 # to that level are automatically included in the table of contents, even if
 # they do not have an id attribute.
@@ -392,8 +406,8 @@ AUTOLINK_SUPPORT       = YES
 
 # This tag specifies a list of words that, when matching the start of a word in
 # the documentation, will suppress auto links generation, if it is enabled via
-# AUTOLINK_SUPPORT. This list does not affect links explicitly created using \#
-# or the \link or commands.
+# AUTOLINK_SUPPORT. This list does not affect links explicitly created using #
+# or the \link or \ref commands.
 # This tag requires that the tag AUTOLINK_SUPPORT is set to YES.
 
 AUTOLINK_IGNORE_WORDS  =
@@ -510,7 +524,7 @@ LOOKUP_CACHE_SIZE      = 0
 # which effectively disables parallel processing. Please report any issues you
 # encounter. Generating dot graphs in parallel is controlled by the
 # DOT_NUM_THREADS setting.
-# Minimum value: 0, maximum value: 32, default value: 1.
+# Minimum value: 0, maximum value: 512, default value: 1.
 
 NUM_PROC_THREADS       = 1
 
@@ -779,6 +793,27 @@ GENERATE_BUGLIST       = YES
 
 GENERATE_DEPRECATEDLIST= YES
 
+# The GENERATE_REQUIREMENTS tag can be used to enable (YES) or disable (NO) the
+# requirements page. When enabled, this page is automatically created when at
+# least one comment block with a \requirement command appears in the input.
+# The default value is: YES.
+
+GENERATE_REQUIREMENTS  = YES
+
+# The REQ_TRACEABILITY_INFO tag controls if traceability information is shown on
+# the requirements page (only relevant when using \requirement comment blocks).
+# The setting NO will disable the traceability information altogether. The
+# setting UNSATISFIED_ONLY will show a list of requirements that are missing a
+# satisfies relation (through the command: \satisfies). Similarly the setting
+# UNVERIFIED_ONLY will show a list of requirements that are missing a verifies
+# relation (through the command: \verifies). Setting the tag to YES (the
+# default) will show both lists if applicable.
+# Possible values are: YES, NO, UNSATISFIED_ONLY and UNVERIFIED_ONLY.
+# The default value is: YES.
+# This tag requires that the tag GENERATE_REQUIREMENTS is set to YES.
+
+REQ_TRACEABILITY_INFO  = YES
+
 # The ENABLED_SECTIONS tag can be used to enable conditional documentation
 # sections, marked by \if <section_label> ... \endif and \cond <section_label>
 # ... \endcond blocks.
@@ -991,7 +1026,9 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = include/ README.md docs/COVERAGE.md
+INPUT                  = include/ \
+                         README.md \
+                         docs/COVERAGE.md
 
 # This tag can be used to specify the character encoding of the source files
 # that Doxygen parses. Internally Doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1628,8 +1665,8 @@ DOCSET_PUBLISHER_NAME  = Publisher
 # a.o. the download links, offline (the HTML help workshop was already many
 # years in maintenance mode). You can download the HTML help workshop from the
 # web archives at Installation executable (see:
-# http://web.archive.org/web/20160201063255/http://download.microsoft.com/downlo
-# ad/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe).
+# http://web.archive.org/web/20160201063255/https://download.microsoft.com/downl
+# oad/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe).
 #
 # The HTML Help Workshop contains a compiler that can convert all HTML output
 # generated by Doxygen into a single compiled HTML file (.chm). Compiled HTML
@@ -1908,7 +1945,7 @@ USE_MATHJAX            = NO
 # regards to the different settings, so it is possible that also other MathJax
 # settings have to be changed when switching between the different MathJax
 # versions.
-# Possible values are: MathJax_2 and MathJax_3.
+# Possible values are: MathJax_2, MathJax_3 and MathJax_4.
 # The default value is: MathJax_2.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
@@ -1917,9 +1954,10 @@ MATHJAX_VERSION        = MathJax_2
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. For more details about the output format see MathJax
 # version 2 (see:
-# http://docs.mathjax.org/en/v2.7-latest/output.html) and MathJax version 3
+# https://docs.mathjax.org/en/v2.7/output.html), MathJax version 3 (see:
+# https://docs.mathjax.org/en/v3.2/output/index.html) and MathJax version 4
 # (see:
-# http://docs.mathjax.org/en/latest/web/components/output.html).
+# https://docs.mathjax.org/en/v4.0/output/index.htm).
 # Possible values are: HTML-CSS (which is slower, but has the best
 # compatibility. This is the name for Mathjax version 2, for MathJax version 3
 # this will be translated into chtml), NativeMML (i.e. MathML. Only supported
@@ -1932,36 +1970,50 @@ MATHJAX_VERSION        = MathJax_2
 MATHJAX_FORMAT         = HTML-CSS
 
 # When MathJax is enabled you need to specify the location relative to the HTML
-# output directory using the MATHJAX_RELPATH option. The destination directory
-# should contain the MathJax.js script. For instance, if the mathjax directory
-# is located at the same level as the HTML output directory, then
-# MATHJAX_RELPATH should be ../mathjax. The default value points to the MathJax
-# Content Delivery Network so you can quickly see the result without installing
-# MathJax. However, it is strongly recommended to install a local copy of
-# MathJax from https://www.mathjax.org before deployment. The default value is:
+# output directory using the MATHJAX_RELPATH option. For Mathjax version 2 the
+# destination directory should contain the MathJax.js script. For instance, if
+# the mathjax directory is located at the same level as the HTML output
+# directory, then MATHJAX_RELPATH should be ../mathjax. For Mathjax versions 3
+# and 4 the destination directory should contain the tex-<format>.js script
+# (where <format> is either chtml or svg). The default value points to the
+# MathJax Content Delivery Network so you can quickly see the result without
+# installing MathJax. However, it is strongly recommended to install a local
+# copy of MathJax from https://www.mathjax.org before deployment. The default
+# value is:
 # - in case of MathJax version 2: https://cdn.jsdelivr.net/npm/mathjax@2
 # - in case of MathJax version 3: https://cdn.jsdelivr.net/npm/mathjax@3
+# - in case of MathJax version 4: https://cdn.jsdelivr.net/npm/mathjax@4
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
 MATHJAX_RELPATH        =
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example
-# for MathJax version 2 (see
-# https://docs.mathjax.org/en/v2.7-latest/tex.html#tex-and-latex-extensions):
+# for MathJax version 2 (see https://docs.mathjax.org/en/v2.7/tex.html):
 # MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
 # For example for MathJax version 3 (see
-# http://docs.mathjax.org/en/latest/input/tex/extensions/index.html):
+# https://docs.mathjax.org/en/v3.2/input/tex/extensions/):
 # MATHJAX_EXTENSIONS = ams
+# For example for MathJax version 4 (see
+# https://docs.mathjax.org/en/v4.0/input/tex/extensions/):
+# MATHJAX_EXTENSIONS = units
+# Note that for Mathjax version 4 quite a few extensions are already
+# automatically loaded. To disable a package in Mathjax version 4 one can use
+# the package name prepended with a minus sign (- like MATHJAX_EXTENSIONS +=
+# -textmacros)
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
 MATHJAX_EXTENSIONS     =
 
 # The MATHJAX_CODEFILE tag can be used to specify a file with JavaScript pieces
-# of code that will be used on startup of the MathJax code. See the MathJax site
-# (see:
-# http://docs.mathjax.org/en/v2.7-latest/output.html) for more details. For an
-# example see the documentation.
+# of code that will be used on startup of the MathJax code. See the Mathjax site
+# for more details:
+# - MathJax version 2 (see:
+# https://docs.mathjax.org/en/v2.7/)
+# - MathJax version 3 (see:
+# https://docs.mathjax.org/en/v3.2/)
+# - MathJax version 4 (see:
+# https://docs.mathjax.org/en/v4.0/) For an example see the documentation.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
 MATHJAX_CODEFILE       =
@@ -2622,10 +2674,23 @@ HAVE_DOT               = NO
 # processors available in the system. You can set it explicitly to a value
 # larger than 0 to get control over the balance between CPU load and processing
 # speed.
-# Minimum value: 0, maximum value: 32, default value: 0.
+# Minimum value: 0, maximum value: 512, default value: 0.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_NUM_THREADS        = 0
+
+# The DOT_BATCH_SIZE specifies the number of dot graphs Doxygen is allowed to
+# compile in a single invocation of dot. When set to 1 Doxygen will invoke dot
+# for each graph separately, which can cause significant process creation
+# overhead especially on systems with many CPU cores. Together with
+# DOT_NUM_THREADS this setting can be used to optimise the dot processing speed
+# for a particular system. Doxygen will try to give each thread a balanced batch
+# of work. If the total number of graphs to process exceeds DOT_NUM_THREADS *
+# DOT_BATCH_SIZE then additional batches will be created for dot to process.
+# Minimum value: 1, maximum value: 1000, default value: 50.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+DOT_BATCH_SIZE         = 50
 
 # DOT_COMMON_ATTR is common attributes for nodes, edges and labels of
 # subgraphs. When you want a differently looking font in the dot files that
@@ -2918,6 +2983,58 @@ PLANTUML_INCLUDE_PATH  =
 
 PLANTUMLFILE_DIRS      =
 
+# When using Mermaid diagrams with CLI rendering, the MERMAID_PATH tag should be
+# used to specify the directory where the mmdc (Mermaid CLI) executable can be
+# found. If left blank, CLI-based rendering is disabled. For HTML output,
+# client-side rendering via JavaScript is used by default and does not require
+# mmdc. For LaTeX/PDF output, mmdc is required to pre-generate images. Doxygen
+# will generate a warning when CLI rendering is needed but mmdc is not
+# available.
+
+MERMAID_PATH           =
+
+# When using Mermaid diagrams, the MERMAID_CONFIG_FILE tag can be used to
+# specify a JSON configuration file for the Mermaid CLI tool (mmdc). This file
+# can contain theme settings and other Mermaid configuration options.
+
+MERMAID_CONFIG_FILE    =
+
+# The MERMAID_RENDER_MODE tag selects how Mermaid diagrams are rendered.
+# Possible values are: AUTO (use client-side rendering for HTML and mmdc for
+# LaTeX/PDF and other formats. If MERMAID_PATH is not set, non-HTML diagrams
+# will produce a warning), CLI (use the mmdc tool to pre-generate images
+# (requires Node.js and mermaid-js/mermaid-cli). Works for all output formats)
+# and CLIENT_SIDE (embed mermaid.js in HTML output for client-side rendering.
+# Does not require mmdc but only works for HTML output).
+# The default value is: AUTO.
+
+MERMAID_RENDER_MODE    = AUTO
+
+# The MERMAID_JS_URL tag specifies the URL to load mermaid.js from when using
+# client-side rendering (MERMAID_RENDER_MODE is CLIENT_SIDE or AUTO). The
+# default points to the latest Mermaid v11 release on the jsDelivr CDN.
+#
+# The default CDN URL requires internet access when viewing the generated
+# documentation. For offline use, download mermaid.esm.min.mjs and set this to a
+# relative path, or use MERMAID_RENDER_MODE=CLI to pre-generate images instead.
+# Examples:
+# - Latest v11 (default):
+# 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs'
+# - Pinned version:
+# 'https://cdn.jsdelivr.net/npm/mermaid@11.3.0/dist/mermaid.esm.min.mjs'
+# - Local copy: './mermaid.esm.min.mjs' (user must place file in HTML output
+# directory)
+# The default value is:
+# https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs.
+
+MERMAID_JS_URL         = https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs
+
+# The MERMAIDFILE_DIRS tag can be used to specify one or more directories that
+# contain Mermaid files that are included in the documentation (see the
+# \mermaidfile command).
+
+MERMAIDFILE_DIRS       =
+
 # The DOT_GRAPH_MAX_NODES tag can be used to set the maximum number of nodes
 # that will be shown in the graph. If the number of nodes in a graph becomes
 # larger than this value, Doxygen will truncate the graph, which is visualized
@@ -2941,15 +3058,6 @@ DOT_GRAPH_MAX_NODES    = 50
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 MAX_DOT_GRAPH_DEPTH    = 0
-
-# Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
-# files in one run (i.e. multiple -o and -T options on the command line). This
-# makes dot run faster, but since only newer versions of dot (>1.8.10) support
-# this, this feature is disabled by default.
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_MULTI_TARGETS      = NO
 
 # If the GENERATE_LEGEND tag is set to YES Doxygen will generate a legend page
 # explaining the meaning of the various boxes and arrows in the dot generated

--- a/docs/custom_doxygen.css
+++ b/docs/custom_doxygen.css
@@ -1,0 +1,10 @@
+
+/*
+	All SVG graphs were embedded as iframes and drawn with white background
+	in light and dark mode.
+	Condition apply transparent background to all iframes with SVG source.
+*/
+
+iframe[src*=".svg"] {
+	background-color: transparent;
+}

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -458,7 +458,7 @@ namespace dsa
          * @param[in] other ForwardList object of type T
          * @return ForwardList& reference to ForwardList object
          */
-        auto operator=(const ForwardList<T>& other) -> ForwardList&;
+        auto operator=(const ForwardList<T>& other) -> ForwardList<T>&;
 
         /**
          * @brief Construct a new ForwardList object using move constructor
@@ -475,7 +475,7 @@ namespace dsa
          * @param[in,out] other ForwardList object of type T
          * @return ForwardList& reference to ForwardList object
          */
-        auto operator=(ForwardList<T>&& other) noexcept -> ForwardList&;
+        auto operator=(ForwardList<T>&& other) noexcept -> ForwardList<T>&;
 
         /**
          * @brief Destroy the ForwardList object
@@ -1276,67 +1276,67 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::front() -> ForwardList<T>::reference
+    auto ForwardList<T>::front() -> reference
     {
         return *begin();
     }
 
     template<typename T>
-    auto ForwardList<T>::front() const -> ForwardList<T>::const_reference
+    auto ForwardList<T>::front() const -> const_reference
     {
         return *cbegin();
     }
 
     template<typename T>
-    auto ForwardList<T>::before_begin() noexcept -> ForwardList<T>::iterator
+    auto ForwardList<T>::before_begin() noexcept -> iterator
     {
         return iterator(m_head);
     }
 
     template<typename T>
-    auto ForwardList<T>::before_begin() const noexcept -> ForwardList<T>::const_iterator
+    auto ForwardList<T>::before_begin() const noexcept -> const_iterator
     {
         return const_iterator(m_head);
     }
 
     template<typename T>
-    auto ForwardList<T>::cbefore_begin() const noexcept -> ForwardList<T>::const_iterator
+    auto ForwardList<T>::cbefore_begin() const noexcept -> const_iterator
     {
         return before_begin();
     }
 
     template<typename T>
-    auto ForwardList<T>::begin() noexcept -> ForwardList<T>::iterator
+    auto ForwardList<T>::begin() noexcept -> iterator
     {
         return iterator(m_head->m_next);
     }
 
     template<typename T>
-    auto ForwardList<T>::begin() const noexcept -> ForwardList<T>::const_iterator
+    auto ForwardList<T>::begin() const noexcept -> const_iterator
     {
         return const_iterator(m_head->m_next);
     }
 
     template<typename T>
-    auto ForwardList<T>::cbegin() const noexcept -> ForwardList<T>::const_iterator
+    auto ForwardList<T>::cbegin() const noexcept -> const_iterator
     {
         return begin();
     }
 
     template<typename T>
-    auto ForwardList<T>::end() noexcept -> ForwardList<T>::iterator
+    auto ForwardList<T>::end() noexcept -> iterator
     {
         return iterator(nullptr);
     }
 
     template<typename T>
-    auto ForwardList<T>::end() const noexcept -> ForwardList<T>::const_iterator
+    auto ForwardList<T>::end() const noexcept -> const_iterator
     {
         return const_iterator(nullptr);
     }
 
     template<typename T>
-    auto ForwardList<T>::cend() const noexcept -> ForwardList<T>::const_iterator
+    auto ForwardList<T>::cend() const noexcept -> const_iterator
     {
         return end();
     }
@@ -1369,13 +1369,13 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::insert_after(const const_iterator& pos, const_reference value) -> ForwardList<T>::iterator
+    auto ForwardList<T>::insert_after(const const_iterator& pos, const_reference value) -> iterator
     {
         return insert_after(pos, 1, value);
     }
 
     template<typename T>
-    auto ForwardList<T>::insert_after(const const_iterator& pos, T&& value) -> ForwardList<T>::iterator
+    auto ForwardList<T>::insert_after(const const_iterator& pos, T&& value) -> iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1389,8 +1389,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::insert_after(const const_iterator& pos, size_type count, const_reference value)
-        -> ForwardList<T>::iterator
+    auto ForwardList<T>::insert_after(const const_iterator& pos, size_type count, const_reference value) -> iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1409,8 +1408,7 @@ namespace dsa
     template<typename T>
     template<typename InputIt>
         requires std::input_iterator<InputIt>
-    auto ForwardList<T>::insert_after(const const_iterator& pos, InputIt first, InputIt last)
-        -> ForwardList<T>::iterator
+    auto ForwardList<T>::insert_after(const const_iterator& pos, InputIt first, InputIt last) -> iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1428,8 +1426,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::insert_after(const const_iterator& pos, std::initializer_list<T> init_list)
-        -> ForwardList<T>::iterator
+    auto ForwardList<T>::insert_after(const const_iterator& pos, std::initializer_list<T> init_list) -> iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1459,7 +1456,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::erase_after(const const_iterator& pos) -> ForwardList<T>::iterator
+    auto ForwardList<T>::erase_after(const const_iterator& pos) -> iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1473,8 +1470,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto ForwardList<T>::erase_after(const const_iterator& first, const const_iterator& last)
-        -> ForwardList<T>::iterator
+    auto ForwardList<T>::erase_after(const const_iterator& first, const const_iterator& last) -> iterator
     {
         if (!if_valid_iterator(first) || !if_valid_iterator(last))
         {

--- a/include/dsa/forward_list.h
+++ b/include/dsa/forward_list.h
@@ -33,6 +33,8 @@ namespace dsa
      *        as internal base
      *
      * @tparam T type of data stored in ForwardList Node
+     *
+     * @todo Add support for custom allocator type in template parameters
      */
     template<typename T>
     class ForwardList

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -505,7 +505,7 @@ namespace dsa
          * @param[in] other List object of type T
          * @return List&
          */
-        auto operator=(const List<T>& other) -> List&;
+        auto operator=(const List<T>& other) -> List<T>&;
 
         /**
          * @brief Construct a new List object using move constructor
@@ -523,7 +523,7 @@ namespace dsa
          * @return List&
          */
         auto operator=(List<T>&& other) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value)
-            -> List&;
+            -> List<T>&;
 
         /**
          * @brief Assign elements from initializer list to List object
@@ -531,7 +531,7 @@ namespace dsa
          * @param[in] ilist initializer list to copy elements from
          * @return List&
          */
-        auto operator=(std::initializer_list<value_type> ilist) -> List&;
+        auto operator=(std::initializer_list<value_type> ilist) -> List<T>&;
 
         /**
          * @brief Destroy the List object
@@ -1319,7 +1319,7 @@ namespace dsa
 
     template<typename T>
     auto List<T>::operator=(List<T>&& other) noexcept(std::allocator_traits<allocator_type>::is_always_equal::value)
-        -> List&
+        -> List<T>&
     {
         if (&other != this)
         {
@@ -1339,7 +1339,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::operator=(std::initializer_list<value_type> ilist) -> List&
+    auto List<T>::operator=(std::initializer_list<value_type> ilist) -> List<T>&
     {
         clear();
 
@@ -1401,61 +1401,61 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::front() -> List<T>::reference
+    auto List<T>::front() -> reference
     {
         return *begin();
     }
 
     template<typename T>
-    auto List<T>::front() const -> List<T>::const_reference
+    auto List<T>::front() const -> const_reference
     {
         return *cbegin();
     }
 
     template<typename T>
-    auto List<T>::back() -> List<T>::reference
+    auto List<T>::back() -> reference
     {
         return *(--end());
     }
 
     template<typename T>
-    auto List<T>::back() const -> List<T>::const_reference
+    auto List<T>::back() const -> const_reference
     {
         return *(--cend());
     }
 
     template<typename T>
-    auto List<T>::begin() noexcept -> List<T>::iterator
+    auto List<T>::begin() noexcept -> iterator
     {
         return iterator(m_head);
     }
 
     template<typename T>
-    auto List<T>::begin() const noexcept -> List<T>::const_iterator
+    auto List<T>::begin() const noexcept -> const_iterator
     {
         return const_iterator(m_head);
     }
 
     template<typename T>
-    auto List<T>::cbegin() const noexcept -> List<T>::const_iterator
+    auto List<T>::cbegin() const noexcept -> const_iterator
     {
         return begin();
     }
 
     template<typename T>
-    auto List<T>::end() noexcept -> List<T>::iterator
+    auto List<T>::end() noexcept -> iterator
     {
         return iterator(m_tail);
     }
 
     template<typename T>
-    auto List<T>::end() const noexcept -> List<T>::const_iterator
+    auto List<T>::end() const noexcept -> const_iterator
     {
         return const_iterator(m_tail);
     }
 
     template<typename T>
-    auto List<T>::cend() const noexcept -> List<T>::const_iterator
+    auto List<T>::cend() const noexcept -> const_iterator
     {
         return end();
     }
@@ -1531,13 +1531,13 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::insert(const const_iterator& pos, const_reference value) -> List<T>::iterator
+    auto List<T>::insert(const const_iterator& pos, const_reference value) -> iterator
     {
         return insert(pos, 1, value);
     }
 
     template<typename T>
-    auto List<T>::insert(const const_iterator& pos, T&& value) -> List<T>::iterator
+    auto List<T>::insert(const const_iterator& pos, T&& value) -> iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1551,7 +1551,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::insert(const const_iterator& pos, size_type count, const_reference value) -> List<T>::iterator
+    auto List<T>::insert(const const_iterator& pos, size_type count, const_reference value) -> iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1570,7 +1570,7 @@ namespace dsa
     template<typename T>
     template<typename InputIt>
         requires std::input_iterator<InputIt>
-    auto List<T>::insert(const const_iterator& pos, InputIt first, InputIt last) -> List<T>::iterator
+    auto List<T>::insert(const const_iterator& pos, InputIt first, InputIt last) -> iterator
     {
         iterator iter{};
         while (first != last)
@@ -1588,7 +1588,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::insert(const const_iterator& pos, std::initializer_list<T> ilist) -> List<T>::iterator
+    auto List<T>::insert(const const_iterator& pos, std::initializer_list<T> ilist) -> iterator
     {
         return insert(pos, ilist.begin(), ilist.end());
     }
@@ -1625,7 +1625,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::erase(const_iterator pos) -> List<T>::iterator
+    auto List<T>::erase(const_iterator pos) -> iterator
     {
         if (!if_valid_iterator(pos))
         {
@@ -1636,7 +1636,7 @@ namespace dsa
     }
 
     template<typename T>
-    auto List<T>::erase(const_iterator first, const_iterator last) -> List<T>::iterator
+    auto List<T>::erase(const_iterator first, const_iterator last) -> iterator
     {
         if (!if_valid_iterator(first) || !if_valid_iterator(last))
         {

--- a/include/dsa/list.h
+++ b/include/dsa/list.h
@@ -33,6 +33,8 @@ namespace dsa
      *        elements as internal base
      *
      * @tparam T type of data stored in List Node
+     *
+     * @todo Add support for custom allocator type in template parameters
      */
     template<typename T>
     class List

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -56,6 +56,8 @@ namespace dsa
      * @brief Implements Queue class
      *
      * @tparam T type of data stored in Queue
+     *
+     * @todo Add support for custom container type in template parameters
      */
     template<typename T>
     class Queue

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -24,9 +24,31 @@ namespace dsa
     template<typename T>
     class Queue;
 
+    /**
+     * @brief The relational operator compares two Queue objects
+     *
+     * @tparam T type of data stored in Queue
+     * @param[in] lhs input container
+     * @param[in] rhs input container
+     * @retval true if containers are equal
+     * @retval false if containers are not equal
+     */
     template<typename T>
     auto operator==(const Queue<T>& lhs, const Queue<T>& rhs) -> bool;
 
+    /**
+     * @brief The relational operator compares two Queue objects
+     *
+     * Depending on type T, function returns one of following objects:
+     * std::strong_ordering::less / equal / greater
+     * std::weak_ordering::less / equivalent / greater
+     * std::partial_ordering::less / equivalent / greater / unordered
+     * It is best to compare results with 0 to determine if lhs is <, >, or == to rhs
+     *
+     * @param[in] lhs input container
+     * @param[in] rhs input container
+     * @return three way comparison result type
+     */
     template<typename T>
     auto operator<=>(const Queue<T>& lhs, const Queue<T>& rhs) -> std::compare_three_way_result_t<T>;
 
@@ -117,7 +139,7 @@ namespace dsa
          * @param[in] other Queue object of type T
          * @return Queue& reference to Queue object
          */
-        auto operator=(const Queue<T>& other) -> Queue&;
+        auto operator=(const Queue<T>& other) -> Queue<T>&;
 
         /**
          * @brief Assign Queue object using move assignment
@@ -126,7 +148,7 @@ namespace dsa
          * @param[in,out] other Queue object of type T
          * @return Queue& reference to Queue object
          */
-        auto operator=(Queue<T>&& other) noexcept -> Queue&;
+        auto operator=(Queue<T>&& other) noexcept -> Queue<T>&;
 
         /**
          * @brief Destroy the Queue object
@@ -215,14 +237,8 @@ namespace dsa
 
     private:
 
-        /**
-         * @brief Forward friend declaration to access internal container comparison operator
-         */
         friend auto operator== <T>(const Queue<T>& lhs, const Queue<T>& rhs) -> bool;
 
-        /**
-         * @brief Forward friend declaration to access internal container comparison operator
-         */
         friend auto operator<=> <T>(const Queue<T>& lhs, const Queue<T>& rhs) -> std::compare_three_way_result_t<T>;
 
         Container container{};
@@ -298,25 +314,25 @@ namespace dsa
     }
 
     template<typename T>
-    auto Queue<T>::front() -> Queue<T>::reference
+    auto Queue<T>::front() -> reference
     {
         return container.front();
     }
 
     template<typename T>
-    auto Queue<T>::front() const -> Queue<T>::const_reference
+    auto Queue<T>::front() const -> const_reference
     {
         return container.front();
     }
 
     template<typename T>
-    auto Queue<T>::back() -> Queue<T>::reference
+    auto Queue<T>::back() -> reference
     {
         return container.back();
     }
 
     template<typename T>
-    auto Queue<T>::back() const -> Queue<T>::const_reference
+    auto Queue<T>::back() const -> const_reference
     {
         return container.back();
     }
@@ -387,34 +403,12 @@ namespace dsa
         return out;
     }
 
-    /**
-     * @brief The relational operator compares two Queue objects
-     *
-     * @tparam T type of data stored in Queue
-     * @param[in] lhs input container
-     * @param[in] rhs input container
-     * @retval true if containers are equal
-     * @retval false if containers are not equal
-     */
     template<typename T>
     auto operator==(const Queue<T>& lhs, const Queue<T>& rhs) -> bool
     {
         return lhs.container == rhs.container;
     }
 
-    /**
-     * @brief The relational operator compares two Queue objects
-     *
-     * Depending on type T, function returns one of following objects:
-     * std::strong_ordering::less / equal / greater
-     * std::weak_ordering::less / equivalent / greater
-     * std::partial_ordering::less / equivalent / greater / unordered
-     * It is best to compare results with 0 to determine if lhs is <, >, or == to rhs
-     *
-     * @param[in] lhs input container
-     * @param[in] rhs input container
-     * @return three way comparison result type
-     */
     template<typename T>
     auto operator<=>(const Queue<T>& lhs, const Queue<T>& rhs) -> std::compare_three_way_result_t<T>
     {

--- a/include/dsa/queue.h
+++ b/include/dsa/queue.h
@@ -495,14 +495,15 @@ namespace dsa
         /**
          * @brief Construct a new PriorityQueue object from base Container using copy constructor
          *
-         * @param[in] cont object of type Container
+         * @param[in] compare comparison function object
          */
         explicit PriorityQueue(const Compare& compare);
 
         /**
          * @brief Construct a new PriorityQueue object from base Container using move constructor
          *
-         * @param[in,out] cont PriorityQueue object of type Container
+         * @param[in] compare comparison function object
+         * @param[in] cont container to be used as source for initialization od underlying container
          */
         PriorityQueue(const Compare& compare, const Container& cont);
 
@@ -510,7 +511,8 @@ namespace dsa
          * @brief Construct a new PriorityQueue object from base Container using move constructor
          * @details Content of other object will be taken by constructed object
          *
-         * @param[in,out] cont PriorityQueue object of type Container
+         * @param[in] compare comparison function object
+         * @param[in, out] cont container to be used as source for initialization od underlying container
          */
         PriorityQueue(const Compare& compare, Container&& cont) noexcept;
 
@@ -816,7 +818,7 @@ namespace dsa
      *
      * @tparam T type of initializer list elements
      * @param[in,out] out reference to output stream
-     * @param[in] PriorityQueue PriorityQueue to print
+     * @param[in] priorityQueue PriorityQueue to print
      * @return std::ostream& reference to std::ostream
      */
     template<typename T, typename Container, typename Compare>

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -24,9 +24,31 @@ namespace dsa
     template<typename T>
     class Stack;
 
+    /**
+     * @brief The relational operator compares two Stack objects
+     *
+     * @tparam T type of data stored in Stack
+     * @param[in] lhs input container
+     * @param[in] rhs input container
+     * @retval true if containers are equal
+     * @retval false if containers are not equal
+     */
     template<typename T>
     auto operator==(const Stack<T>& lhs, const Stack<T>& rhs) -> bool;
 
+    /**
+     * @brief The relational operator compares two Stack objects
+     *
+     * Depending on type T, function returns one of following objects:
+     * std::strong_ordering::less / equal / greater
+     * std::weak_ordering::less / equivalent / greater
+     * std::partial_ordering::less / equivalent / greater / unordered
+     * It is best to compare results with 0 to determine if lhs is <, >, or == to rhs
+     *
+     * @param[in] lhs input container
+     * @param[in] rhs input container
+     * @return three way comparison result type
+     */
     template<typename T>
     auto operator<=>(const Stack<T>& lhs, const Stack<T>& rhs) -> std::compare_three_way_result_t<T>;
 
@@ -116,7 +138,7 @@ namespace dsa
          * @param[in] other Stack object of type T
          * @return Stack& reference to Stack object
          */
-        auto operator=(const Stack<T>& other) -> Stack&;
+        auto operator=(const Stack<T>& other) -> Stack<T>&;
 
         /**
          * @brief Assign Stack object using move assignment
@@ -125,7 +147,7 @@ namespace dsa
          * @param[in,out] other Stack object of type T
          * @return Stack& reference to Stack object
          */
-        auto operator=(Stack<T>&& other) noexcept -> Stack&;
+        auto operator=(Stack<T>&& other) noexcept -> Stack<T>&;
 
         /**
          * @brief Destroy the Stack object
@@ -283,13 +305,13 @@ namespace dsa
     }
 
     template<typename T>
-    auto Stack<T>::top() -> Stack<T>::reference
+    auto Stack<T>::top() -> reference
     {
         return container.back();
     }
 
     template<typename T>
-    auto Stack<T>::top() const -> Stack<T>::const_reference
+    auto Stack<T>::top() const -> const_reference
     {
         return container.back();
     }
@@ -359,34 +381,12 @@ namespace dsa
         return out;
     }
 
-    /**
-     * @brief The relational operator compares two Stack objects
-     *
-     * @tparam T type of data stored in Stack
-     * @param[in] lhs input container
-     * @param[in] rhs input container
-     * @retval true if containers are equal
-     * @retval false if containers are not equal
-     */
     template<typename T>
     auto operator==(const Stack<T>& lhs, const Stack<T>& rhs) -> bool
     {
         return lhs.container == rhs.container;
     }
 
-    /**
-     * @brief The relational operator compares two Stack objects
-     *
-     * Depending on type T, function returns one of following objects:
-     * std::strong_ordering::less / equal / greater
-     * std::weak_ordering::less / equivalent / greater
-     * std::partial_ordering::less / equivalent / greater / unordered
-     * It is best to compare results with 0 to determine if lhs is <, >, or == to rhs
-     *
-     * @param[in] lhs input container
-     * @param[in] rhs input container
-     * @return three way comparison result type
-     */
     template<typename T>
     auto operator<=>(const Stack<T>& lhs, const Stack<T>& rhs) -> std::compare_three_way_result_t<T>
     {

--- a/include/dsa/stack.h
+++ b/include/dsa/stack.h
@@ -56,6 +56,8 @@ namespace dsa
      * @brief Implements Stack class
      *
      * @tparam T type of data stored in Stack
+     *
+     * @todo Add support for custom container type in template parameters
      */
     template<typename T>
     class Stack

--- a/include/dsa/vector.h
+++ b/include/dsa/vector.h
@@ -34,6 +34,8 @@ namespace dsa
      *       `dsa::Vector<bool>` behaves like a regular container,
      *       without bit-packing. This design choice prioritizes correctness
      *       and predictable semantics over memory optimization.
+     *
+     * @todo Add support for custom allocator type in template parameters
      */
     template<typename T>
     class Vector


### PR DESCRIPTION
Current `Doxygen` version to 1.17 in GitHub Actions and fix reported documentation warnings.

Closes #47 

## Checklist

- [x] update `doxygen` workflow to install the latest stable `Doxygen` release
- [x] verify that documentation generation works correctly after the upgrade
- [x] check for warning, deprecated configuration options or formatting changes
- [x] verify compatibility with installed `graphviz` version